### PR TITLE
Remove target, bump min.

### DIFF
--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -6,8 +6,7 @@ model {
     buildToolsVersion = "23.0.0"
 
     defaultConfig.with {
-      minSdkVersion.apiLevel = 3
-      targetSdkVersion.apiLevel = 23
+      minSdkVersion.apiLevel = 4
     }
   }
   android.ndk {


### PR DESCRIPTION
Specifying a target SDK on a project is usually not a good idea (can cause problems with manifest merging). Without a target, the minimum effectively becomes the target SDK and targetting API 3 implicitly adds the READ_PHONE_STATE permission.
