### PR TITLE
Fix UTF-8 encoding of inputs and outputs

### DIFF
--- a/quickjs/common/native/Context.h
+++ b/quickjs/common/native/Context.h
@@ -61,6 +61,8 @@ public:
   jclass integerClass;
   jclass doubleClass;
   jclass objectClass;
+  jclass stringClass;
+  jstring stringUtf8;
   jclass quickJsExceptionClass;
   jmethodID booleanValueOf;
   jmethodID booleanGetValue;
@@ -68,6 +70,8 @@ public:
   jmethodID integerGetValue;
   jmethodID doubleValueOf;
   jmethodID doubleGetValue;
+  jmethodID stringGetBytes;
+  jmethodID stringConstructor;
   jmethodID quickJsExceptionConstructor;
   std::vector<JsObjectProxy*> objectProxies;
   std::unordered_map<std::string, jclass> globalReferences;

--- a/quickjs/common/test/app/cash/quickjs/QuickJsTest.java
+++ b/quickjs/common/test/app/cash/quickjs/QuickJsTest.java
@@ -17,7 +17,6 @@ package app.cash.quickjs;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -85,9 +84,8 @@ public final class QuickJsTest {
     }
   }
 
-  @Ignore("https://github.com/cashapp/quickjs-java/issues/214")
   @Test public void emojiRoundTrip() {
-    assertThat(quickjs.evaluate("\"\uD83D\uDC1D️\""))
-        .isEqualTo("\uD83D\uDC1D️️");
+    assertThat(quickjs.evaluate("\"\uD83D\uDC1D\";"))
+        .isEqualTo("\uD83D\uDC1D");
   }
 }


### PR DESCRIPTION
Use the Java APIs rather than the JNI APIs to convert char* to UTF-8
and back. The Java APIs use UTF-8, not modified UTF-8.

Also include a trailing '\u0000', which QuickJS expects (even though
it accepts the string length as a parameter).

Also fix a bug where the test case had an unexpected unprintable
character.

Closes: https://github.com/cashapp/quickjs-java/issues/214