### PR TITLE
Fix test case to exclude unprintable characters

### DIFF
--- a/quickjs/common/test/app/cash/quickjs/QuickJsTest.java
+++ b/quickjs/common/test/app/cash/quickjs/QuickJsTest.java
@@ -85,9 +85,8 @@ public final class QuickJsTest {
     }
   }
 
-  @Ignore("https://github.com/cashapp/quickjs-java/issues/214")
   @Test public void emojiRoundTrip() {
-    assertThat(quickjs.evaluate("\"\uD83D\uDC1D️\""))
-        .isEqualTo("\uD83D\uDC1D️️");
+    assertThat(quickjs.evaluate("\"\uD83D\uDC1D\""))
+        .isEqualTo("\uD83D\uDC1D");
   }
 }


### PR DESCRIPTION
It seems our UTF-8 and emoji problems were related to bad test data,
not to bad behavior in QuickJS.

Closes: https://github.com/cashapp/quickjs-java/issues/214