### PR TITLE
Support creating UInt8Arrays from Java byte[] arrays

### DIFF
--- a/quickjs/common/native/Context.h
+++ b/quickjs/common/native/Context.h
@@ -53,6 +53,8 @@ public:
   jclass getGlobalRef(JNIEnv* env, jclass clazz);
   std::string toCppString(JNIEnv* env, jstring string) const;
   jstring toJavaString(JNIEnv* env, const JSValueConst& value) const;
+  jobject toJavaByteArray(JNIEnv* env, const JSValueConst& value) const;
+  JSValue toJsByteArray(JNIEnv* env, jbyteArray value) const;
 
   JavaVM* javaVm;
   const jint jniVersion;

--- a/quickjs/common/test/app/cash/quickjs/JsTypedArraysTest.java
+++ b/quickjs/common/test/app/cash/quickjs/JsTypedArraysTest.java
@@ -15,6 +15,7 @@
  */
 package app.cash.quickjs;
 
+import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +86,75 @@ public final class JsTypedArraysTest {
         + "array;");
     assertThat(byteArray).asList()
         .containsExactly((byte) 86, (byte) 7, (byte) 53, (byte) 0, (byte) 9);
+  }
+
+  interface ByteArrayTransformer {
+    byte[] transform(byte[] input);
+  }
+
+  @Test public void byteArrayWithProxy() {
+    quickJs.set("transformer", ByteArrayTransformer.class, new ByteArrayTransformer() {
+      @Override public byte[] transform(byte[] input) {
+        byte[] result = new byte[input.length + 2];
+        result[0] = (byte) 254;
+        result[1] = (byte) 255;
+        System.arraycopy(input, 0, result, 2, input.length);
+        Arrays.sort(result);
+        return result;
+      }
+    });
+
+    byte[] byteArray = (byte[]) quickJs.evaluate(""
+        + "var array = new Uint8Array(5);"
+        + "array[0] = 86;"
+        + "array[1] = 7;"
+        + "array[2] = 53;"
+        + "array[3] = 0;"
+        + "array[4] = 9;"
+        + "transformer.transform(array);");
+    assertThat(byteArray).asList().containsExactly(
+        (byte) 0, (byte) 9, (byte) 7, (byte) 53, (byte) 86, (byte) 254, (byte) 255);
+  }
+
+  @Test public void byteArrayWithProxyReturnsNull() {
+    quickJs.set("transformer", ByteArrayTransformer.class, new ByteArrayTransformer() {
+      @Override public byte[] transform(byte[] input) {
+        return null;
+      }
+    });
+
+    byte[] byteArray = (byte[]) quickJs.evaluate(""
+        + "var array = new Uint8Array(5);"
+        + "array[0] = 86;"
+        + "transformer.transform(array);");
+    assertThat(byteArray).isNull();
+  }
+
+  @Test public void byteArrayWithProxyReceivesNull() {
+    quickJs.set("transformer", ByteArrayTransformer.class, new ByteArrayTransformer() {
+      @Override public byte[] transform(byte[] input) {
+        return new byte[] { 86 };
+      }
+    });
+
+    byte[] byteArray = (byte[]) quickJs.evaluate(""
+        + "transformer.transform(null);");
+    assertThat(byteArray).asList().containsExactly((byte) 86);
+  }
+
+  @Test public void javaByteArrayConvertedToJsUint8Array() {
+    quickJs.set("transformer", ByteArrayTransformer.class, new ByteArrayTransformer() {
+      @Override public byte[] transform(byte[] input) {
+        return new byte[] { 86 };
+      }
+    });
+
+    String constructorName = (String) quickJs.evaluate(""
+        + "var array = new Uint8Array(5);"
+        + "array[0] = 86;"
+        + "var transformed = transformer.transform(array);"
+        + "transformed.constructor.name");
+    assertThat(constructorName).isEqualTo("Uint8Array");
   }
 
   @Test public void int16ArrayUnsupported() {


### PR DESCRIPTION
Previously we could decode a user-provided Uint8Array but we couldn't create one.