### PR TITLE
Read testing.js from resources

### DIFF
--- a/ktbridge/build.gradle.kts
+++ b/ktbridge/build.gradle.kts
@@ -6,13 +6,17 @@ plugins {
   id("org.jetbrains.dokka")
 }
 
+val copyTestingJs = tasks.register<Copy>("copyTestingJs") {
+  destinationDir = buildDir.resolve("generated/testingJs")
+  from("testing/build/distributions/testing.js")
+  dependsOn(":ktbridge:testing:jsBrowserProductionWebpack")
+}
+
 kotlin {
-  jvm {
-  }
+  jvm()
 
   js {
-    browser {
-    }
+    browser()
   }
 
   sourceSets {
@@ -28,18 +32,13 @@ kotlin {
       }
     }
     val jvmTest by getting {
+      resources.srcDir(copyTestingJs)
       dependencies {
         implementation(project(":ktbridge:testing"))
         implementation(Dependencies.junit)
         implementation(Dependencies.truth)
       }
     }
-  }
-}
-
-tasks {
-  val jvmTest by getting {
-    dependsOn(":ktbridge:testing:jsBrowserProductionWebpack")
   }
 }
 

--- a/ktbridge/src/jvmTest/kotlin/app/cash/quickjs/ktbridge/KtBridgeTest.kt
+++ b/ktbridge/src/jvmTest/kotlin/app/cash/quickjs/ktbridge/KtBridgeTest.kt
@@ -22,28 +22,21 @@ import app.cash.quickjs.ktbridge.testing.helloService
 import app.cash.quickjs.ktbridge.testing.prepareJvmBridges
 import app.cash.quickjs.ktbridge.testing.yoService
 import com.google.common.truth.Truth.assertThat
-import java.io.File
-import okio.buffer
-import okio.source
+import java.io.BufferedReader
 import org.junit.After
-import org.junit.Before
 import org.junit.Test
 
 class KtBridgeTest {
-  private lateinit var quickjs: QuickJs
-
-  @Before fun setUp() {
-    quickjs = QuickJs.create()
-  }
+  private val quickjs = QuickJs.create()
 
   @After fun tearDown() {
     quickjs.close()
   }
-  
+
   @Test fun `jvm call js service`() {
-    val testingJs = File("testing/build/distributions/testing.js").source().buffer().use { source ->
-      source.readUtf8()
-    }
+    val testingJs = KtBridgeTest::class.java.getResourceAsStream("/testing.js")!!
+        .bufferedReader()
+        .use(BufferedReader::readText)
     quickjs.evaluate(testingJs, "testing.js")
     quickjs.evaluate("testing.app.cash.quickjs.ktbridge.testing.prepareJsBridges()")
 
@@ -56,9 +49,9 @@ class KtBridgeTest {
   }
 
   @Test fun `js call jvm service`() {
-    val testingJs = File("testing/build/distributions/testing.js").source().buffer().use { source ->
-      source.readUtf8()
-    }
+    val testingJs = KtBridgeTest::class.java.getResourceAsStream("/testing.js")!!
+      .bufferedReader()
+      .use(BufferedReader::readText)
     quickjs.evaluate(testingJs, "testing.js")
 
     val ktBridge = createKtBridge(quickjs)

--- a/ktbridge/testing/build.gradle.kts
+++ b/ktbridge/testing/build.gradle.kts
@@ -8,8 +8,7 @@ kotlin {
   jvm()
 
   js {
-    browser {
-    }
+    browser()
     binaries.executable()
   }
 


### PR DESCRIPTION
Rather than directly from the filesystem relying on working directory and relative paths.