### PR TITLE
Move runtime types out of 'ktbridge' package

### DIFF
--- a/quickjs-kotlin-plugin/src/main/kotlin/app/cash/quickjs/ktbridge/plugin/KtBridgeApis.kt
+++ b/quickjs-kotlin-plugin/src/main/kotlin/app/cash/quickjs/ktbridge/plugin/KtBridgeApis.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.name.FqName
 internal class KtBridgeApis(
   private val pluginContext: IrPluginContext,
 ) {
-  private val packageFqName = FqName("app.cash.quickjs.ktbridge")
+  private val packageFqName = FqName("app.cash.quickjs")
 
   val any: IrClassSymbol
     get() = pluginContext.referenceClass(FqName("kotlin.Any"))!!

--- a/quickjs-kotlin-plugin/src/test/java/app/cash/quickjs/ktbridge/plugin/KtBridgeTestInternals.java
+++ b/quickjs-kotlin-plugin/src/test/java/app/cash/quickjs/ktbridge/plugin/KtBridgeTestInternals.java
@@ -15,15 +15,15 @@
  */
 package app.cash.quickjs.ktbridge.plugin;
 
-import app.cash.quickjs.ktbridge.InboundCall;
-import app.cash.quickjs.ktbridge.InboundService;
-import app.cash.quickjs.ktbridge.KtBridge;
-import app.cash.quickjs.ktbridge.OutboundCall;
-import app.cash.quickjs.ktbridge.OutboundClientFactory;
-import app.cash.quickjs.ktbridge.testing.EchoJsAdapter;
-import app.cash.quickjs.ktbridge.testing.EchoRequest;
-import app.cash.quickjs.ktbridge.testing.EchoResponse;
-import app.cash.quickjs.ktbridge.testing.EchoService;
+import app.cash.quickjs.InboundCall;
+import app.cash.quickjs.InboundService;
+import app.cash.quickjs.KtBridge;
+import app.cash.quickjs.OutboundCall;
+import app.cash.quickjs.OutboundClientFactory;
+import app.cash.quickjs.testing.EchoJsAdapter;
+import app.cash.quickjs.testing.EchoRequest;
+import app.cash.quickjs.testing.EchoResponse;
+import app.cash.quickjs.testing.EchoService;
 import kotlin.PublishedApi;
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KType;

--- a/quickjs-kotlin-plugin/src/test/kotlin/app/cash/quickjs/ktbridge/plugin/KtBridgePluginTest.kt
+++ b/quickjs-kotlin-plugin/src/test/kotlin/app/cash/quickjs/ktbridge/plugin/KtBridgePluginTest.kt
@@ -16,11 +16,11 @@
 
 package app.cash.quickjs.ktbridge.plugin
 
-import app.cash.quickjs.ktbridge.KtBridge
-import app.cash.quickjs.ktbridge.testing.EchoRequest
-import app.cash.quickjs.ktbridge.testing.EchoResponse
-import app.cash.quickjs.ktbridge.testing.EchoService
-import app.cash.quickjs.ktbridge.testing.KtBridgePair
+import app.cash.quickjs.KtBridge
+import app.cash.quickjs.testing.EchoRequest
+import app.cash.quickjs.testing.EchoResponse
+import app.cash.quickjs.testing.EchoService
+import app.cash.quickjs.testing.KtBridgePair
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
@@ -39,9 +39,9 @@ class KtBridgePluginTest {
       sourceFile = SourceFile.kotlin(
         "main.kt",
         """
-        package app.cash.quickjs.ktbridge.testing
+        package app.cash.quickjs.testing
         
-        import app.cash.quickjs.ktbridge.KtBridge
+        import app.cash.quickjs.KtBridge
         
         class TestingEchoService(
           private val greeting: String
@@ -60,7 +60,7 @@ class KtBridgePluginTest {
     assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
 
     val bridges = KtBridgePair()
-    val mainKt = result.classLoader.loadClass("app.cash.quickjs.ktbridge.testing.MainKt")
+    val mainKt = result.classLoader.loadClass("app.cash.quickjs.testing.MainKt")
     mainKt.getDeclaredMethod("prepareJsBridges", KtBridge::class.java).invoke(null, bridges.a)
 
     val helloService = KtBridgeTestInternals.getEchoClient(bridges.b, "helloService")
@@ -74,9 +74,9 @@ class KtBridgePluginTest {
       sourceFile = SourceFile.kotlin(
         "main.kt",
         """
-        package app.cash.quickjs.ktbridge.testing
+        package app.cash.quickjs.testing
         
-        import app.cash.quickjs.ktbridge.KtBridge
+        import app.cash.quickjs.KtBridge
         
         fun getHelloService(ktBridge: KtBridge): EchoService {
           return ktBridge.get("helloService", EchoJsAdapter)
@@ -95,7 +95,7 @@ class KtBridgePluginTest {
     }
     KtBridgeTestInternals.setEchoService(bridges.b, "helloService", testingEchoService)
 
-    val mainKt = result.classLoader.loadClass("app.cash.quickjs.ktbridge.testing.MainKt")
+    val mainKt = result.classLoader.loadClass("app.cash.quickjs.testing.MainKt")
     val helloService = mainKt.getDeclaredMethod("getHelloService", KtBridge::class.java)
       .invoke(null, bridges.a) as EchoService
 
@@ -109,9 +109,9 @@ class KtBridgePluginTest {
       sourceFile = SourceFile.kotlin(
         "main.kt",
         """
-        package app.cash.quickjs.ktbridge.testing
+        package app.cash.quickjs.testing
         
-        import app.cash.quickjs.ktbridge.KtBridge
+        import app.cash.quickjs.KtBridge
         
         fun prepareJsBridges(ktBridge: KtBridge) {
           ktBridge.set<TestingEchoService>("helloService", EchoJsAdapter, TestingEchoService)
@@ -134,9 +134,9 @@ class KtBridgePluginTest {
       sourceFile = SourceFile.kotlin(
         "main.kt",
         """
-        package app.cash.quickjs.ktbridge.testing
+        package app.cash.quickjs.testing
         
-        import app.cash.quickjs.ktbridge.KtBridge
+        import app.cash.quickjs.KtBridge
         
         fun getHelloService(ktBridge: KtBridge): String {
           return ktBridge.get("helloService", EchoJsAdapter)

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/InboundCall.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/InboundCall.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/InboundService.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/InboundService.kt
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
-import kotlin.reflect.KType
-import okio.Buffer
-
-// TODO(jwilson): Moshi-style nested Factory interface that binds `type` eagerly.
-interface JsAdapter {
-  fun <T : Any> encode(value: T, sink: Buffer, type: KType)
-  fun <T : Any> decode(source: Buffer, type: KType): T
+/**
+ * Generated code extends this base class to receive calls into an application-layer interface from
+ * another platform in the same process.
+ */
+@PublishedApi
+internal abstract class InboundService<T : Any>(
+  internal val jsAdapter: JsAdapter
+) {
+  abstract fun call(inboundCall: InboundCall): ByteArray
 }

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/InternalBridge.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/InternalBridge.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
 import kotlin.js.JsName
 

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/JsAdapter.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/JsAdapter.kt
@@ -13,22 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge.testing
+package app.cash.quickjs
 
-import app.cash.quickjs.ktbridge.InternalBridge
-import app.cash.quickjs.ktbridge.KtBridge
+import kotlin.reflect.KType
+import okio.Buffer
 
-/** A pair of bridges connected to each other for testing. */
-class KtBridgePair {
-  val a: KtBridge = KtBridge(object : InternalBridge {
-    override fun invokeJs(
-      instanceName: String,
-      funName: String,
-      encodedArguments: ByteArray
-    ): ByteArray {
-      return b.inboundBridge.invokeJs(instanceName, funName, encodedArguments)
-    }
-  })
-
-  val b: KtBridge = KtBridge(a.inboundBridge)
+// TODO(jwilson): Moshi-style nested Factory interface that binds `type` eagerly.
+interface JsAdapter {
+  fun <T : Any> encode(value: T, sink: Buffer, type: KType)
+  fun <T : Any> decode(source: Buffer, type: KType): T
 }

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/KtBridge.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/KtBridge.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
 // TODO(jwilson): merge with QuickJs?
 class KtBridge internal constructor(
@@ -51,7 +51,7 @@ class KtBridge internal constructor(
     outboundClientFactory: OutboundClientFactory<T>
   ): T {
     return outboundClientFactory.create(
-      OutboundCall.Factory(name, outboundClientFactory.jsAdapter, outboundBridge)
+        OutboundCall.Factory(name, outboundClientFactory.jsAdapter, outboundBridge)
     )
   }
 }

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/OutboundCall.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/OutboundCall.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
-import app.cash.quickjs.ktbridge.OutboundCall.Factory
+import app.cash.quickjs.OutboundCall.Factory
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import okio.Buffer

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/OutboundClientFactory.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/OutboundClientFactory.kt
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge.testing
+package app.cash.quickjs
 
-import app.cash.quickjs.ktbridge.KtBridge
-
-val KtBridge.helloService: EchoService
-  get() = get("helloService", EchoJsAdapter)
-
-val KtBridge.yoService: EchoService
-  get() = get("yoService", EchoJsAdapter)
-
-class JvmEchoService(
-  private val greeting: String
-) : EchoService {
-  override fun echo(request: EchoRequest): EchoResponse {
-    return EchoResponse("$greeting from the JVM, ${request.message}")
-  }
-}
-
-fun prepareJvmBridges(ktBridge: KtBridge) {
-  ktBridge.set<EchoService>("supService", EchoJsAdapter, JvmEchoService("sup"))
+/**
+ * Generated code extends this base class to make calls into an application-layer interface that is
+ * implemented by another platform in the same process.
+ */
+@PublishedApi
+internal abstract class OutboundClientFactory<T : Any>(
+  internal val jsAdapter: JsAdapter
+) {
+  abstract fun create(callFactory: OutboundCall.Factory): T
 }

--- a/quickjs/src/commonMain/kotlin/app/cash/quickjs/testing/KtBridgePair.kt
+++ b/quickjs/src/commonMain/kotlin/app/cash/quickjs/testing/KtBridgePair.kt
@@ -13,15 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs.testing
 
-/**
- * Generated code extends this base class to receive calls into an application-layer interface from
- * another platform in the same process.
- */
-@PublishedApi
-internal abstract class InboundService<T : Any>(
-  internal val jsAdapter: JsAdapter
-) {
-  abstract fun call(inboundCall: InboundCall): ByteArray
+import app.cash.quickjs.InternalBridge
+import app.cash.quickjs.KtBridge
+
+/** A pair of bridges connected to each other for testing. */
+class KtBridgePair {
+  val a: KtBridge = KtBridge(object : InternalBridge {
+    override fun invokeJs(
+      instanceName: String,
+      funName: String,
+      encodedArguments: ByteArray
+    ): ByteArray {
+      return b.inboundBridge.invokeJs(instanceName, funName, encodedArguments)
+    }
+  })
+
+  val b: KtBridge = KtBridge(a.inboundBridge)
 }

--- a/quickjs/src/jniMain/kotlin/app/cash/quickjs/ktBridgeJvm.kt
+++ b/quickjs/src/jniMain/kotlin/app/cash/quickjs/ktBridgeJvm.kt
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
-
-import app.cash.quickjs.QuickJs
+package app.cash.quickjs
 
 fun createKtBridge(quickJs: QuickJs): KtBridge {
   // Lazily fetch the bridge to call them.

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/CallBridgesTest.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/CallBridgesTest.kt
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
-import app.cash.quickjs.ktbridge.testing.EchoJsAdapter
-import app.cash.quickjs.ktbridge.testing.EchoRequest
-import app.cash.quickjs.ktbridge.testing.EchoResponse
-import app.cash.quickjs.ktbridge.testing.EchoService
-import app.cash.quickjs.ktbridge.testing.KtBridgePair
+import app.cash.quickjs.testing.EchoJsAdapter
+import app.cash.quickjs.testing.EchoRequest
+import app.cash.quickjs.testing.EchoResponse
+import app.cash.quickjs.testing.EchoService
+import app.cash.quickjs.testing.KtBridgePair
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.LinkedBlockingDeque
 import org.junit.Assert.assertEquals

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/KtBridgeTest.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/KtBridgeTest.kt
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
-import app.cash.quickjs.QuickJs
-import app.cash.quickjs.ktbridge.testing.EchoRequest
-import app.cash.quickjs.ktbridge.testing.EchoResponse
-import app.cash.quickjs.ktbridge.testing.helloService
-import app.cash.quickjs.ktbridge.testing.prepareJvmBridges
-import app.cash.quickjs.ktbridge.testing.yoService
+import app.cash.quickjs.testing.EchoRequest
+import app.cash.quickjs.testing.EchoResponse
+import app.cash.quickjs.testing.helloService
+import app.cash.quickjs.testing.prepareJvmBridges
+import app.cash.quickjs.testing.yoService
 import com.google.common.truth.Truth.assertThat
 import java.io.BufferedReader
 import org.junit.After
@@ -38,7 +37,7 @@ class KtBridgeTest {
         .bufferedReader()
         .use(BufferedReader::readText)
     quickjs.evaluate(testingJs, "testing.js")
-    quickjs.evaluate("testing.app.cash.quickjs.ktbridge.testing.prepareJsBridges()")
+    quickjs.evaluate("testing.app.cash.quickjs.testing.prepareJsBridges()")
 
     val ktBridge = createKtBridge(quickjs)
 
@@ -58,7 +57,7 @@ class KtBridgeTest {
     prepareJvmBridges(ktBridge)
 
     assertThat(quickjs.evaluate(
-      "testing.app.cash.quickjs.ktbridge.testing.callSupService('homie')"
+      "testing.app.cash.quickjs.testing.callSupService('homie')"
     )).isEqualTo("JavaScript received 'sup from the JVM, homie' from the JVM")
   }
 }

--- a/quickjs/src/jsMain/kotlin/app/cash/quickjs/ktBridgeJs.kt
+++ b/quickjs/src/jsMain/kotlin/app/cash/quickjs/ktBridgeJs.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs
 
 val ktBridge = KtBridge(object : InternalBridge {
   // Lazily fetch the bridge to call them.

--- a/quickjs/testing/src/commonMain/kotlin/app/cash/quickjs/testing/echo.kt
+++ b/quickjs/testing/src/commonMain/kotlin/app/cash/quickjs/testing/echo.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge.testing
+package app.cash.quickjs.testing
 
-import app.cash.quickjs.ktbridge.JsAdapter
+import app.cash.quickjs.JsAdapter
 import kotlin.reflect.KType
 import okio.Buffer
 

--- a/quickjs/testing/src/jsMain/kotlin/app/cash/quickjs/testing/echoJs.kt
+++ b/quickjs/testing/src/jsMain/kotlin/app/cash/quickjs/testing/echoJs.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge.testing
+package app.cash.quickjs.testing
 
-import app.cash.quickjs.ktbridge.ktBridge
+import app.cash.quickjs.ktBridge
 
 class JsEchoService(
   private val greeting: String

--- a/quickjs/testing/src/jvmMain/kotlin/app/cash/quickjs/testing/echoJvm.kt
+++ b/quickjs/testing/src/jvmMain/kotlin/app/cash/quickjs/testing/echoJvm.kt
@@ -13,15 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.quickjs.ktbridge
+package app.cash.quickjs.testing
 
-/**
- * Generated code extends this base class to make calls into an application-layer interface that is
- * implemented by another platform in the same process.
- */
-@PublishedApi
-internal abstract class OutboundClientFactory<T : Any>(
-  internal val jsAdapter: JsAdapter
-) {
-  abstract fun create(callFactory: OutboundCall.Factory): T
+import app.cash.quickjs.KtBridge
+
+val KtBridge.helloService: EchoService
+  get() = get("helloService", EchoJsAdapter)
+
+val KtBridge.yoService: EchoService
+  get() = get("yoService", EchoJsAdapter)
+
+class JvmEchoService(
+  private val greeting: String
+) : EchoService {
+  override fun echo(request: EchoRequest): EchoResponse {
+    return EchoResponse("$greeting from the JVM, ${request.message}")
+  }
+}
+
+fun prepareJvmBridges(ktBridge: KtBridge) {
+  ktBridge.set<EchoService>("supService", EchoJsAdapter, JvmEchoService("sup"))
 }


### PR DESCRIPTION
And into the main package.

Step 1 of a few. This makes merging `KtBridge` and `QuickJs` easier because the plugin currently uses a base package name to find all types. Could I just have used a FQCN in this one instance? Sure, but why do that when I can do all this work instead...