### PR TITLE
Expose more tuning options in QuickJs

### DIFF
--- a/quickjs/src/jniMain/kotlin/app/cash/quickjs/JniQuickJs.kt
+++ b/quickjs/src/jniMain/kotlin/app/cash/quickjs/JniQuickJs.kt
@@ -38,6 +38,27 @@ internal class JniQuickJs(private var context: Long) : QuickJs() {
 
   override val engineVersion get() = quickJsVersion
 
+  override val memoryUsage: MemoryUsage
+    get() = memoryUsage(context)
+
+  override var memoryLimit: Long = -1L
+    set(value) {
+      field = value
+      setMemoryLimit(context, value)
+    }
+
+  override var gcThreshold: Long = -1L
+    set(value) {
+      field = value
+      setGcThreshold(context, value)
+    }
+
+  override var maxStackSize: Long = -1L
+    set(value) {
+      field = value
+      setMaxStackSize(context, value)
+    }
+
   override fun evaluate(script: String, fileName: String): Any? {
     return evaluate(context, script, fileName)
   }
@@ -114,10 +135,6 @@ internal class JniQuickJs(private var context: Long) : QuickJs() {
     return execute(context, bytecode)
   }
 
-  override fun memoryUsage(): MemoryUsage {
-    return memoryUsage(context)
-  }
-
   override fun close() {
     val contextToClose = context
     if (contextToClose != 0L) {
@@ -140,4 +157,7 @@ internal class JniQuickJs(private var context: Long) : QuickJs() {
   private external fun execute(context: Long, bytecode: ByteArray): Any?
   private external fun compile(context: Long, sourceCode: String, fileName: String): ByteArray
   private external fun memoryUsage(context: Long): MemoryUsage
+  private external fun setMemoryLimit(context: Long, limit: Long)
+  private external fun setGcThreshold(context: Long, gcThreshold: Long)
+  private external fun setMaxStackSize(context: Long, stackSize: Long)
 }

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/TuningApisTest.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/TuningApisTest.kt
@@ -20,15 +20,34 @@ import kotlin.test.assertTrue
 import org.junit.After
 import org.junit.Test
 
-class MemoryUsageTest {
+class TuningApisTest {
   private val quickjs = QuickJs.create()
 
   @After fun tearDown() {
     quickjs.close()
   }
 
+  @Test fun setMemoryLimit() {
+    val value = 1024L * 1024L + 1L
+    quickjs.memoryLimit = value
+    assertEquals(value, quickjs.memoryLimit)
+    assertEquals(value, quickjs.memoryUsage.memoryAllocatedLimit)
+  }
+
+  @Test fun setGcThreshold() {
+    val value = 1024L * 1024L + 2L
+    quickjs.gcThreshold = value
+    assertEquals(value, quickjs.gcThreshold)
+  }
+
+  @Test fun setMaxStackSize() {
+    val value = 1024L * 1024L + 3L
+    quickjs.maxStackSize = value
+    assertEquals(value, quickjs.maxStackSize)
+  }
+
   @Test fun initialMemoryUsage() {
-    val usage = quickjs.memoryUsage()
+    val usage = quickjs.memoryUsage
     assertTrue(usage.memoryAllocatedCount > 0L, usage.toString())
     assertTrue(usage.memoryAllocatedSize > 0L, usage.toString())
     assertTrue(usage.memoryAllocatedLimit != 0L, usage.toString())
@@ -80,9 +99,9 @@ class MemoryUsageTest {
   }
 
   private fun diffMemoryUsage(block: () -> Unit): MemoryUsage {
-    val before = quickjs.memoryUsage()
+    val before = quickjs.memoryUsage
     block()
-    val after = quickjs.memoryUsage()
+    val after = quickjs.memoryUsage
 
     return MemoryUsage(
       memoryAllocatedCount = after.memoryAllocatedCount - before.memoryAllocatedCount,

--- a/quickjs/src/native/Context.cpp
+++ b/quickjs/src/native/Context.cpp
@@ -82,8 +82,6 @@ Context::Context(JNIEnv* env)
       quickJsExceptionConstructor(env->GetMethodID(quickJsExceptionClass, "<init>",
                                                    "(Ljava/lang/String;Ljava/lang/String;)V")) {
   env->GetJavaVM(&javaVm);
-  // Increase the JavaScript stack size. (default is 256 * 1024).
-  JS_SetMaxStackSize(jsRuntime, 512 * 1024);
   JS_SetRuntimeOpaque(jsRuntime, this);
 }
 
@@ -201,6 +199,18 @@ jobject Context::memoryUsage(JNIEnv* env) {
     jsMemoryUsage.binary_object_count,
     jsMemoryUsage.binary_object_size
   ));
+}
+
+void Context::setMemoryLimit(JNIEnv* env, jlong limit) {
+  JS_SetMemoryLimit(jsRuntime, limit);
+}
+
+void Context::setGcThreshold(JNIEnv* env, jlong gcThreshold) {
+  JS_SetGCThreshold(jsRuntime, gcThreshold);
+}
+
+void Context::setMaxStackSize(JNIEnv* env, jlong stackSize) {
+  JS_SetMaxStackSize(jsRuntime, stackSize);
 }
 
 JsObjectProxy* Context::getObjectProxy(JNIEnv* env, jstring name, jobjectArray methods) {

--- a/quickjs/src/native/Context.h
+++ b/quickjs/src/native/Context.h
@@ -37,6 +37,9 @@ public:
   jobject execute(JNIEnv*, jbyteArray byteCode);
   jbyteArray compile(JNIEnv*, jstring source, jstring file);
   jobject memoryUsage(JNIEnv*);
+  void setMemoryLimit(JNIEnv* env, jlong limit);
+  void setGcThreshold(JNIEnv* env, jlong gcThreshold);
+  void setMaxStackSize(JNIEnv* env, jlong stackSize);
   typedef std::function<JSValueConst(Context*, JNIEnv*, jvalue)> JavaToJavaScript;
   JavaToJavaScript getJavaToJsConverter(JNIEnv*, jclass type, bool boxed);
   typedef std::function<jvalue(Context*, JNIEnv*, JSValueConst)> JavaScriptToJava;

--- a/quickjs/src/native/quickjs-jni.cpp
+++ b/quickjs/src/native/quickjs-jni.cpp
@@ -123,3 +123,36 @@ Java_app_cash_quickjs_JniQuickJs_memoryUsage(JNIEnv* env, jobject type, jlong co
   }
   return context->memoryUsage(env);
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_app_cash_quickjs_JniQuickJs_setMemoryLimit(JNIEnv* env, jobject type, jlong context_, jlong limit) {
+  Context* context = reinterpret_cast<Context*>(context_);
+  if (!context) {
+    throwJavaException(env, "java/lang/NullPointerException",
+                       "Null QuickJs context - did you close your QuickJs?");
+    return;
+  }
+  context->setMemoryLimit(env, limit);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_app_cash_quickjs_JniQuickJs_setGcThreshold(JNIEnv* env, jobject type, jlong context_, jlong gcThreshold) {
+  Context* context = reinterpret_cast<Context*>(context_);
+  if (!context) {
+    throwJavaException(env, "java/lang/NullPointerException",
+                       "Null QuickJs context - did you close your QuickJs?");
+    return;
+  }
+  context->setGcThreshold(env, gcThreshold);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_app_cash_quickjs_JniQuickJs_setMaxStackSize(JNIEnv* env, jobject type, jlong context_, jlong stackSize) {
+  Context* context = reinterpret_cast<Context*>(context_);
+  if (!context) {
+    throwJavaException(env, "java/lang/NullPointerException",
+                       "Null QuickJs context - did you close your QuickJs?");
+    return;
+  }
+  context->setMaxStackSize(env, stackSize);
+}


### PR DESCRIPTION
We had been customizing the stack size in native code. I'd prefer to do
this in JVM code so we can change it more easily, and per instance.