### PR TITLE
Unbreak tests which have been flaky

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,6 +5,7 @@ object Dependencies {
   val junit = "junit:junit:4.13.2"
   val kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect"
   val kotlinxCoroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
+  val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
   val truth = "com.google.truth:truth:1.0"
   val okio = "com.squareup.okio:okio:3.0.0-alpha.9"
   val okioMultiplatform = "com.squareup.okio:okio-multiplatform:3.0.0-alpha.9"

--- a/quickjs-kotlin-plugin/build.gradle.kts
+++ b/quickjs-kotlin-plugin/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   testImplementation(project(":quickjs"))
   testImplementation(project(":quickjs:testing"))
   testImplementation(kotlin("test-junit"))
+  testImplementation(Dependencies.kotlinxCoroutinesTest)
   testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.1")
   testImplementation("com.google.truth:truth:1.0")

--- a/quickjs-kotlin-plugin/src/test/java/app/cash/quickjs/ktbridge/plugin/KtBridgeTestInternals.java
+++ b/quickjs-kotlin-plugin/src/test/java/app/cash/quickjs/ktbridge/plugin/KtBridgeTestInternals.java
@@ -30,12 +30,11 @@ import java.util.List;
 import kotlin.Pair;
 import kotlin.PublishedApi;
 import kotlin.coroutines.Continuation;
-import kotlin.coroutines.CoroutineContext;
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KType;
 import kotlin.reflect.KTypeProjection;
 import kotlin.reflect.full.KClassifiers;
-import kotlinx.coroutines.CoroutineDispatcher;
+import kotlinx.coroutines.test.TestCoroutineDispatcher;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -56,16 +55,8 @@ public final class KtBridgeTestInternals {
       JvmClassMappingKt.getKotlinClass(List.class),
       singletonList(KTypeProjection.invariant(stringKt)), false, emptyList());
 
-  /** Refuse to dispatch anything. */
-  private static final CoroutineDispatcher NULL_DISPATCHER = new CoroutineDispatcher() {
-    @Override public void dispatch(CoroutineContext coroutineContext, Runnable runnable) {
-      throw new IllegalStateException();
-    }
-  };
-
-
   public static Pair<KtBridge, KtBridge> newKtBridgePair() {
-    return app.cash.quickjs.testing.BridgesKt.newKtBridgePair(NULL_DISPATCHER);
+    return app.cash.quickjs.testing.BridgesKt.newKtBridgePair(new TestCoroutineDispatcher());
   }
 
   /** Simulate generated code for outbound calls. */

--- a/quickjs/build.gradle.kts
+++ b/quickjs/build.gradle.kts
@@ -80,6 +80,7 @@ kotlin {
       resources.srcDir(copyTestingJs)
       dependencies {
         implementation(Dependencies.truth)
+        implementation(Dependencies.kotlinxCoroutinesTest)
         implementation(project(":quickjs:testing"))
       }
     }
@@ -91,6 +92,7 @@ android {
 
   defaultConfig {
     minSdkVersion(18)
+    multiDexEnabled = true
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -104,6 +106,13 @@ android {
         cFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
         cppFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
       }
+    }
+
+    packagingOptions {
+      // We get multiple copies of some license files via JNA, which is a transitive dependency of
+      // kotlinx-coroutines-test. Don't fail the build on these duplicates.
+      exclude("META-INF/AL2.0")
+      exclude("META-INF/LGPL2.1")
     }
   }
 
@@ -159,6 +168,7 @@ dependencies {
   androidTestImplementation(Dependencies.junit)
   androidTestImplementation(Dependencies.androidxTestRunner)
   androidTestImplementation(Dependencies.truth)
+  androidTestImplementation(Dependencies.kotlinxCoroutinesTest)
   androidTestImplementation(project(":quickjs:testing"))
 
   add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(":quickjs-kotlin-plugin"))

--- a/quickjs/src/jniMain/kotlin/app/cash/quickjs/ziplineJni.kt
+++ b/quickjs/src/jniMain/kotlin/app/cash/quickjs/ziplineJni.kt
@@ -19,12 +19,10 @@ import app.cash.quickjs.internal.bridge.InboundService
 import app.cash.quickjs.internal.bridge.InternalBridge
 import app.cash.quickjs.internal.bridge.KtBridge
 import app.cash.quickjs.internal.bridge.OutboundClientFactory
-import java.util.concurrent.Executors
 import java.util.logging.Logger
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -54,9 +52,11 @@ actual abstract class Zipline {
 
   companion object {
     fun create(
-      dispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
+      dispatcher: CoroutineDispatcher,
     ): Zipline {
       val quickJs = QuickJs.create()
+      // TODO(jwilson): figure out a 512 KiB limit caused intermittent stack overflow failures.
+      quickJs.maxStackSize = 0L
       return ZiplineJvm(quickJs, dispatcher)
     }
   }

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/ConsoleTest.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/ConsoleTest.kt
@@ -22,15 +22,19 @@ import java.util.logging.LogRecord
 import java.util.logging.Logger
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ConsoleTest {
-  private val zipline = Zipline.create()
-  private val logMessages = LinkedBlockingDeque<String>()
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher)
 
+  private val logMessages = LinkedBlockingDeque<String>()
   private val logHandler = object : Handler() {
     override fun publish(record: LogRecord) {
       logMessages += "${record.level}: ${record.message}"
@@ -46,28 +50,21 @@ class ConsoleTest {
   }
 
   @Before
-  fun setUp() {
-    zipline.runBlocking {
-      loadTestingJs()
-    }
+  fun setUp(): Unit = runBlocking(dispatcher) {
+    zipline.loadTestingJs()
     Logger.getLogger(Zipline::class.qualifiedName).apply {
       level = Level.FINEST
       addHandler(logHandler)
     }
   }
 
-  @After fun tearDown() {
-    zipline.runBlocking {
-      quickJs.close()
-    }
-    (zipline.dispatcher as? ExecutorCoroutineDispatcher)?.close()
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
     Logger.getLogger(Zipline::class.qualifiedName).removeHandler(logHandler)
+    zipline.quickJs.close()
   }
 
-  @Test fun logAllLevels() {
-    zipline.runBlocking {
-      zipline.quickJs.evaluate("testing.app.cash.quickjs.testing.consoleLogAllLevels()")
-    }
+  @Test fun logAllLevels(): Unit = runBlocking(dispatcher) {
+    zipline.quickJs.evaluate("testing.app.cash.quickjs.testing.consoleLogAllLevels()")
     assertEquals("INFO: 1. this is message 1 of 5. Its level is 'info'.", logMessages.poll())
     assertEquals("INFO: 2. this message has level 'log'.", logMessages.poll())
     assertEquals("WARNING: 3. this message has level 'warn'.", logMessages.poll())
@@ -80,10 +77,8 @@ class ConsoleTest {
    * Note that this test is checking our expected behavior, but our behavior falls short of what
    * browsers implement. In particular, we don't do string replacement for `%s`, `%d`, etc.
    */
-  @Test fun logWithArguments() {
-    zipline.runBlocking {
-      zipline.quickJs.evaluate("testing.app.cash.quickjs.testing.consoleLogWithArguments()")
-    }
+  @Test fun logWithArguments(): Unit = runBlocking(dispatcher) {
+    zipline.quickJs.evaluate("testing.app.cash.quickjs.testing.consoleLogWithArguments()")
     assertEquals("INFO: this message for %s is a %d out of %d Jesse 8 10", logMessages.poll())
     assertNull(logMessages.poll())
   }

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/ZiplineTest.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/ZiplineTest.kt
@@ -15,20 +15,23 @@
  */
 package app.cash.quickjs
 
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.After
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ZiplineTest {
-  private val zipline = Zipline.create()
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher)
 
-  @After fun tearDown() {
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
     zipline.quickJs.close()
-    (zipline.dispatcher as? ExecutorCoroutineDispatcher)?.close()
   }
 
-  @Test fun version() {
+  @Test fun version(): Unit = runBlocking(dispatcher) {
     assertNotEquals("", zipline.engineVersion)
   }
 }

--- a/quickjs/src/jniTest/kotlin/app/cash/quickjs/testUtil.kt
+++ b/quickjs/src/jniTest/kotlin/app/cash/quickjs/testUtil.kt
@@ -16,9 +16,6 @@
 package app.cash.quickjs
 
 import java.io.BufferedReader
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 inline fun <reified T : Throwable> assertThrows(body: () -> Unit): T {
   try {
@@ -38,18 +35,4 @@ fun Zipline.loadTestingJs() {
     .bufferedReader()
     .use(BufferedReader::readText)
   quickJs.evaluate(testingJs, "testing.js")
-}
-
-/** Execute [block] on the JavaScript dispatcher and wait for it to return. */
-inline fun <T> Zipline.runBlocking(crossinline block: suspend Zipline.() -> T): T {
-  return kotlinx.coroutines.runBlocking(dispatcher) {
-    block()
-  }
-}
-
-/** Enqueue [block] to run on the JavaScript dispatcher and return immediately. */
-inline fun Zipline.launch(crossinline block: suspend Zipline.() -> Unit) {
-  CoroutineScope(EmptyCoroutineContext).launch(dispatcher) {
-    block()
-  }
 }


### PR DESCRIPTION
Tests have been failing like this:

    app.cash.quickjs.QuickJsException: stack overflow
        at app.cash.quickjs.QuickJs.evaluate(Native Method)

The initial fix is pretty heavy-handed; I'm just setting the stack size
to 0 which ultimately removes the stack size limit. But this motivates
further investigation.

See: https://github.com/cashapp/quickjs-java/issues/260

Also adopt TestCoroutineDispatcher for more predictable tests.