### PR TITLE
Rename Handle to ZiplineReference

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
@@ -109,11 +109,11 @@ import org.jetbrains.kotlin.name.Name
  * For suspending functions, everything is the same except overridden method is `callSuspending()`.
  * Both methods area always overridden, but may contain only the `unexpectedFunction()` case.
  *
- * This also rewrites calls to `Handle()`, which is similar to `Zipline.set()` but without a leading
- * name parameter:
+ * This also rewrites calls to `ZiplineReference()`, which is similar to `Zipline.set()` but without
+ * a leading name parameter:
  *
  * ```
- * val handle = Handle<EchoService>(
+ * val reference = ZiplineReference<EchoService>(
  *   EchoSerializersModule,
  *   TestingEchoService("hello")
  * )
@@ -122,7 +122,7 @@ import org.jetbrains.kotlin.name.Name
  * The above is rewritten to:
  *
  * ```
- * val handle = InboundHandle<EchoService>(
+ * val reference = InboundZiplineReference<EchoService>(
  *   object : InboundBridge<EchoService>(EchoSerializersModule) {
  *     ...
  *   }
@@ -169,7 +169,7 @@ internal class InboundBridgeRewriter(
         }
       }
       is IrConstructorSymbol -> {
-        // Construct InboundHandle<EchoService>(...).
+        // Construct InboundZiplineReference<EchoService>(...).
         return IrConstructorCallImpl(
           startOffset = original.startOffset,
           endOffset = original.endOffset,

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/OutboundBridgeRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/OutboundBridgeRewriter.kt
@@ -85,12 +85,12 @@ import org.jetbrains.kotlin.name.Name
  *
  * For suspending functions, everything is the same except the call is to `invokeSuspending()`.
  *
- * This also rewrites calls to `Handle.get()`, which is similar to `Zipline.get()` but without a
- * leading name parameter:
+ * This also rewrites calls to `ZiplineReference.get()`, which is similar to
+ * `ZiplineReference.get()` but without a leading name parameter:
  *
  * ```
- * val handle: Handle<EchoService> = ...
- * val helloService = handle.get(
+ * val reference: ZiplineReference<EchoService> = ...
+ * val helloService = reference.get(
  *   EchoSerializersModule
  * )
  * ```
@@ -98,8 +98,8 @@ import org.jetbrains.kotlin.name.Name
  * The above is rewritten to:
  *
  * ```
- * val handle: Handle<EchoService> = ...
- * val helloService = handle.get(
+ * val reference: ZiplineReference<EchoService> = ...
+ * val helloService = reference.get(
  *   object : OutboundBridge<EchoService>(EchoSerializersModule) {
  *     ...
  *   }
@@ -120,9 +120,9 @@ internal class OutboundBridgeRewriter(
       // If it's Zipline.get(), the interface type is on get().
       original.getTypeArgument(0)!!
     } else {
-      // If it's Handle.get(), the interface type is on Handle.
-      val handleType = original.dispatchReceiver!!.type as IrSimpleType
-      handleType.arguments[0].typeOrNull!!
+      // If it's ZiplineReference.get(), the interface type is on ZiplineReference.
+      val ziplineReferenceType = original.dispatchReceiver!!.type as IrSimpleType
+      ziplineReferenceType.arguments[0].typeOrNull!!
     }
   }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
@@ -20,6 +20,12 @@ import kotlinx.serialization.modules.SerializersModule
 expect abstract class Zipline {
   abstract val engineVersion: String
 
+  /** Name of services that have been published with [set]. */
+  abstract val serviceNames: Set<String>
+
+  /** Names of services that can be consumed with [get]. */
+  abstract val clientNames: Set<String>
+
   fun <T : Any> get(name: String, serializersModule: SerializersModule): T
 
   fun <T : Any> set(name: String, serializersModule: SerializersModule, instance: T)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -23,6 +23,10 @@ import kotlinx.coroutines.CoroutineDispatcher
 internal fun newEndpointPair(dipatcher: CoroutineDispatcher): Pair<Endpoint, Endpoint> {
   val pair = object : Any() {
     val a: Endpoint = Endpoint(dipatcher, object : CallChannel {
+      override fun serviceNamesArray(): Array<String> {
+        return b.inboundChannel.serviceNamesArray()
+      }
+
       override fun invoke(
         instanceName: String,
         funName: String,
@@ -40,6 +44,10 @@ internal fun newEndpointPair(dipatcher: CoroutineDispatcher): Pair<Endpoint, End
         return b.inboundChannel.invokeSuspending(
           instanceName, funName, encodedArguments, callbackName
         )
+      }
+
+      override fun disconnect(instanceName: String): Boolean {
+        return b.inboundChannel.disconnect(instanceName)
       }
     })
 

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.internal.bridge.Endpoint
+import app.cash.zipline.testing.EchoRequest
+import app.cash.zipline.testing.EchoResponse
+import app.cash.zipline.testing.EchoSerializersModule
+import app.cash.zipline.testing.EchoService
+import app.cash.zipline.testing.newEndpointPair
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.LinkedBlockingDeque
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.serialization.modules.EmptySerializersModule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ZiplineReferenceTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val endpointA: Endpoint
+  private val endpointB: Endpoint
+
+  init {
+    val (endpointA, endpointB) = newEndpointPair(dispatcher)
+    this.endpointA = endpointA
+    this.endpointB = endpointB
+  }
+
+  @Test
+  fun bridgeServicesBeforeEndpointsConnected() {
+    val requests = LinkedBlockingDeque<String>()
+    val responses = LinkedBlockingDeque<String>()
+    val service = object : EchoService {
+      override fun echo(request: EchoRequest): EchoResponse {
+        requests += request.message
+        return EchoResponse(responses.take())
+      }
+    }
+
+    val referenceA = ZiplineReference<EchoService>(EchoSerializersModule, service)
+    (referenceA as InboundZiplineReference<*>).connect(endpointA, "helloService")
+
+    // Note that we cast OutboundZiplineReference<EchoService> down to ZiplineReference<EchoService>
+    // before calling get(). This is necessary because we don't implement rewrites for overrides.
+    val referenceB: ZiplineReference<EchoService> = OutboundZiplineReference()
+    (referenceB as OutboundZiplineReference<EchoService>).connect(endpointB, "helloService")
+
+    val client = referenceB.get(EchoSerializersModule)
+
+    responses += "this is a curt response"
+    val response = client.echo(EchoRequest("this is a happy request"))
+    assertEquals("this is a curt response", response.message)
+    assertEquals("this is a happy request", requests.poll())
+    assertNull(responses.poll())
+    assertNull(requests.poll())
+  }
+
+  interface EchoServiceFactory {
+    fun create(greeting: String): ZiplineReference<EchoService>
+  }
+
+  @Test
+  fun transmitReferences() {
+    endpointA.set<EchoServiceFactory>("factory", EmptySerializersModule, FactoryService())
+    val factoryClient = endpointB.get<EchoServiceFactory>("factory", EmptySerializersModule)
+
+    val helloServiceReference = factoryClient.create("hello")
+    val helloService = helloServiceReference.get(EmptySerializersModule)
+
+    val supServiceReference = factoryClient.create("sup")
+    val supService = supServiceReference.get(EmptySerializersModule)
+
+    assertThat(helloService.echo(EchoRequest("Jesse"))).isEqualTo(EchoResponse("hello Jesse"))
+    assertThat(supService.echo(EchoRequest("Kevin"))).isEqualTo(EchoResponse("sup Kevin"))
+    assertThat(helloService.echo(EchoRequest("Jake"))).isEqualTo(EchoResponse("hello Jake"))
+    assertThat(supService.echo(EchoRequest("Stephen"))).isEqualTo(EchoResponse("sup Stephen"))
+  }
+
+  @Test
+  fun closingAnOutboundReferenceRemovesItAndPreventsFurtherCalls() {
+    endpointA.set<EchoServiceFactory>("factory", EmptySerializersModule, FactoryService())
+    val factoryClient = endpointB.get<EchoServiceFactory>("factory", EmptySerializersModule)
+    assertThat(endpointA.serviceNames).containsExactly("factory")
+
+    val outboundReference = factoryClient.create("hello")
+    assertThat(endpointA.serviceNames).containsExactly("factory", "zipline/1")
+    val service = outboundReference.get(EmptySerializersModule)
+
+    assertThat(service.echo(EchoRequest("Jesse"))).isEqualTo(EchoResponse("hello Jesse"))
+    outboundReference.close()
+    assertThat(assertThrows<IllegalStateException> {
+      service.echo(EchoRequest("Jesse"))
+    }).hasMessageThat().contains("no handler")
+    assertThat(endpointA.serviceNames).containsExactly("factory")
+  }
+
+  @Test
+  fun closingAnInboundReferenceRemovesItAndPreventsFurtherCalls() {
+    // Eagerly create this so we have something to return later.
+    val inboundReference = ZiplineReference<EchoService>(
+      EmptySerializersModule,
+      GreetingService("hello")
+    )
+    class FactoryService : EchoServiceFactory {
+      override fun create(greeting: String): ZiplineReference<EchoService> {
+        return inboundReference
+      }
+    }
+
+    endpointA.set<EchoServiceFactory>("factory", EmptySerializersModule, FactoryService())
+    val factoryClient = endpointB.get<EchoServiceFactory>("factory", EmptySerializersModule)
+    assertThat(endpointA.serviceNames).containsExactly("factory")
+
+    val outboundReference = factoryClient.create("hello")
+    assertThat(endpointA.serviceNames).containsExactly("factory", "zipline/1")
+    val service = outboundReference.get(EmptySerializersModule)
+
+    assertThat(service.echo(EchoRequest("Jesse"))).isEqualTo(EchoResponse("hello Jesse"))
+    inboundReference.close()
+    assertThat(assertThrows<IllegalStateException> {
+      service.echo(EchoRequest("Jesse"))
+    }).hasMessageThat().contains("no handler")
+    assertThat(endpointA.serviceNames).containsExactly("factory")
+  }
+
+  class GreetingService(val greeting: String) : EchoService {
+    override fun echo(request: EchoRequest): EchoResponse {
+      return EchoResponse("$greeting ${request.message}")
+    }
+  }
+
+  class FactoryService : EchoServiceFactory {
+    override fun create(greeting: String): ZiplineReference<EchoService> {
+      val service = GreetingService(greeting)
+      return ZiplineReference(EmptySerializersModule, service)
+    }
+  }
+}


### PR DESCRIPTION
Like AtomicReference and WeakReference it creates a special ability
for its subject.

Also add diagnostic APIs to Zipline to get the list of active
services both published and consumed. This is intended to be useful
in detecting leaked objects.

Also implement close() that works on a ZiplineReference and can be
called by either inbound or outbound side.