### PR TITLE
Don't encode parameter lists as bytes

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,6 +8,5 @@ object Dependencies {
   val kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
   val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
   val truth = "com.google.truth:truth:1.0"
-  val okio = "com.squareup.okio:okio:3.0.0-alpha.9"
-  val okioMultiplatform = "com.squareup.okio:okio-multiplatform:3.0.0-alpha.9"
+  val okio = "com.squareup.okio:okio:3.0.0-alpha.10"
 }

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
@@ -87,7 +87,7 @@ import org.jetbrains.kotlin.name.Name
  *         val serializer_0 = context.serializersModule.serializer<EchoRequest>()
  *         val serializer_1 = context.serializersModule.serializer<EchoResponse>()
  *         override val context: Context = context
- *         override fun call(inboundCall: InboundCall): ByteArray {
+ *         override fun call(inboundCall: InboundCall): Array<String> {
  *           return when {
  *             inboundCall.funName == "echo" -> {
  *               inboundCall.result(
@@ -367,7 +367,7 @@ internal class InboundBridgeRewriter(
     inboundCallHandler: IrClass,
     callSuspending: Boolean,
   ): IrSimpleFunction {
-    // override fun call(inboundCall: InboundCall): ByteArray {
+    // override fun call(inboundCall: InboundCall): Array<String> {
     // }
     val inboundBridgeCall = when {
       callSuspending -> ziplineApis.inboundCallHandlerCallSuspending
@@ -377,7 +377,7 @@ internal class InboundBridgeRewriter(
       name = inboundBridgeCall.owner.name
       visibility = DescriptorVisibilities.PUBLIC
       modality = Modality.OPEN
-      returnType = pluginContext.symbols.byteArrayType
+      returnType = ziplineApis.stringArrayType
       isSuspend = callSuspending
     }.apply {
       addDispatchReceiver {
@@ -468,7 +468,7 @@ internal class InboundBridgeRewriter(
     )
 
     return irWhen(
-      type = pluginContext.symbols.byteArrayType,
+      type = ziplineApis.stringArrayType,
       branches = result
     )
   }
@@ -566,7 +566,7 @@ internal class InboundBridgeRewriter(
     resultExpression: IrExpression
   ): IrExpression {
     return irCall(
-      type = pluginContext.symbols.byteArrayType,
+      type = ziplineApis.stringArrayType,
       callee = ziplineApis.inboundCallResult,
     ).apply {
       dispatchReceiver = irGetInboundCallParameter(callFunction)
@@ -588,7 +588,7 @@ internal class InboundBridgeRewriter(
     callFunction: IrSimpleFunction,
   ): IrExpression {
     return irCall(
-      type = pluginContext.symbols.byteArrayType,
+      type = ziplineApis.stringArrayType,
       callee = ziplineApis.inboundCallUnexpectedFunction,
     ).apply {
       dispatchReceiver = irGetInboundCallParameter(callFunction)

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -20,7 +20,10 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.name.FqName
 
@@ -38,6 +41,9 @@ internal class ZiplineApis(
 
   val any: IrClassSymbol
     get() = pluginContext.referenceClass(FqName("kotlin.Any"))!!
+
+  val stringArrayType: IrType =
+    pluginContext.symbols.array.typeWith(pluginContext.symbols.string.defaultType)
 
   val kSerializer: IrClassSymbol
     get() = pluginContext.referenceClass(serializationFqName.child("KSerializer"))!!

--- a/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -94,7 +94,7 @@ public final class ZiplineTestInternals {
             return context;
           }
 
-          @Override public byte[] call(InboundCall inboundCall) {
+          @Override public String[] call(InboundCall inboundCall) {
             if (inboundCall.getFunName().equals("echo")) {
               return inboundCall.result(resultSerializer, echoService.echo(
                   inboundCall.parameter(parameterSerializer)));
@@ -104,7 +104,7 @@ public final class ZiplineTestInternals {
           }
 
           @Override public Object callSuspending(
-              InboundCall inboundCall, Continuation<? super byte[]> continuation) {
+              InboundCall inboundCall, Continuation<? super String[]> continuation) {
             return inboundCall.unexpectedFunction();
           }
         };
@@ -147,7 +147,7 @@ public final class ZiplineTestInternals {
             return context;
           }
 
-          @Override public byte[] call(InboundCall inboundCall) {
+          @Override public String[] call(InboundCall inboundCall) {
             if (inboundCall.getFunName().equals("genericEcho")) {
               return inboundCall.result(resultSerializer, echoService.genericEcho(
                   inboundCall.parameter(parameterSerializer)));
@@ -157,7 +157,7 @@ public final class ZiplineTestInternals {
           }
 
           @Override public Object callSuspending(
-              InboundCall inboundCall, Continuation<? super byte[]> continuation) {
+              InboundCall inboundCall, Continuation<? super String[]> continuation) {
             return inboundCall.unexpectedFunction();
           }
         };

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -59,7 +59,6 @@ kotlin {
       dependencies {
         api(Dependencies.kotlinxCoroutines)
         api(Dependencies.kotlinxSerializationJson)
-        api(Dependencies.okioMultiplatform)
       }
     }
     val commonTest by getting {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
@@ -20,15 +20,16 @@ import app.cash.zipline.internal.bridge.InboundBridge
 import app.cash.zipline.internal.bridge.InboundCallHandler
 import app.cash.zipline.internal.bridge.OutboundBridge
 import kotlinx.serialization.modules.SerializersModule
-import okio.Closeable
 
-abstract class ZiplineReference<T : Any> internal constructor() : Closeable {
+abstract class ZiplineReference<T : Any> internal constructor() {
   fun get(serializersModule: SerializersModule): T {
     error("unexpected call to ZiplineReference.get: is the Zipline plugin configured?")
   }
 
   @PublishedApi
   internal abstract fun get(outboundBridge: OutboundBridge<T>): T
+
+  abstract fun close()
 }
 
 fun <T : Any> ZiplineReference(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -59,8 +59,8 @@ class Endpoint internal constructor(
     override fun invoke(
       instanceName: String,
       funName: String,
-      encodedArguments: ByteArray
-    ): ByteArray {
+      encodedArguments: Array<String>
+    ): Array<String> {
       val handler = inboundHandlers[instanceName] ?: error("no handler for $instanceName")
       val inboundCall = InboundCall(handler.context, funName, encodedArguments)
       return try {
@@ -73,7 +73,7 @@ class Endpoint internal constructor(
     override fun invokeSuspending(
       instanceName: String,
       funName: String,
-      encodedArguments: ByteArray,
+      encodedArguments: Array<String>,
       callbackName: String
     ) {
       val handler = inboundHandlers[instanceName] ?: error("no handler for $instanceName")

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/SuspendCallback.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/SuspendCallback.kt
@@ -18,5 +18,5 @@ package app.cash.zipline.internal.bridge
 /** A bridged interface to pass results from suspending calls. */
 @PublishedApi
 internal interface SuspendCallback {
-  fun call(encodedResponse: ByteArray)
+  fun call(response: Array<String>)
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -30,15 +30,15 @@ internal fun newEndpointPair(dipatcher: CoroutineDispatcher): Pair<Endpoint, End
       override fun invoke(
         instanceName: String,
         funName: String,
-        encodedArguments: ByteArray
-      ): ByteArray {
+        encodedArguments: Array<String>
+      ): Array<String> {
         return b.inboundChannel.invoke(instanceName, funName, encodedArguments)
       }
 
       override fun invokeSuspending(
         instanceName: String,
         funName: String,
-        encodedArguments: ByteArray,
+        encodedArguments: Array<String>,
         callbackName: String
       ) {
         return b.inboundChannel.invokeSuspending(

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/ziplineJni.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/ziplineJni.kt
@@ -132,8 +132,8 @@ private class ZiplineJni(
   override fun invoke(
     instanceName: String,
     funName: String,
-    encodedArguments: ByteArray
-  ): ByteArray {
+    encodedArguments: Array<String>
+  ): Array<String> {
     check(!closed) { "Zipline closed" }
     return jsInboundBridge.invoke(instanceName, funName, encodedArguments)
   }
@@ -141,7 +141,7 @@ private class ZiplineJni(
   override fun invokeSuspending(
     instanceName: String,
     funName: String,
-    encodedArguments: ByteArray,
+    encodedArguments: Array<String>,
     callbackName: String
   ) {
     check(!closed) { "Zipline closed" }

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -135,15 +135,15 @@ private class ZiplineJs : Zipline(), JsPlatform, CallChannel  {
   override fun invoke(
     instanceName: String,
     funName: String,
-    encodedArguments: ByteArray
-  ): ByteArray {
+    encodedArguments: Array<String>
+  ): Array<String> {
     return jsOutboundChannel.invoke(instanceName, funName, encodedArguments)
   }
 
   override fun invokeSuspending(
     instanceName: String,
     funName: String,
-    encodedArguments: ByteArray,
+    encodedArguments: Array<String>,
     callbackName: String
   ) {
     return jsOutboundChannel.invokeSuspending(instanceName, funName, encodedArguments, callbackName)


### PR DESCRIPTION
On QuickJS the performance of StringBuilder is quadratic. This impacts lots
of code in Zipline, but decoding large JSON bodies from UTF-8 is particularly
problematic.

Time to call CharArray.concatToString() running QuickJS on my MacBook Pro

| Array Size   | Time (seconds) |
| -----------: | :------------- |
|         100  | 0              |
|       1.000  | 0              |
|      10,000  | 0              |
|     100,000  | 1              |
|   1.000,000  | 24             |
|  10,000,000  | 3600+          |

We will want to solve this in QuickJS, Kotlin, and/or Okio. For now I'm
punting on the problem by not dealing with bytes where it isn't necessary.
As a bonus, the code is simpler.