### PR TITLE
Hoist the SerializersModule into Zipline

### DIFF
--- a/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/presentersJs.kt
+++ b/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/presentersJs.kt
@@ -17,19 +17,18 @@ package app.cash.zipline.samples.emojisearch
 
 import app.cash.zipline.Zipline
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.modules.EmptySerializersModule
+
+private val zipline by lazy { Zipline.get() }
 
 @OptIn(ExperimentalSerializationApi::class)
 @JsExport
 fun preparePresenters() {
-  val hostApi = Zipline.get<HostApi>(
-    name = "hostApi",
-    serializersModule = EmptySerializersModule
+  val hostApi = zipline.get<HostApi>(
+    name = "hostApi"
   )
 
-  Zipline.set<EmojiSearchPresenter>(
+  zipline.set<EmojiSearchPresenter>(
     name = "emojiSearchPresenter",
-    serializersModule = EmptySerializersModule,
     instance = RealEmojiSearchPresenter(hostApi)
   )
 }

--- a/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.launch
-import kotlinx.serialization.modules.EmptySerializersModule
 
 class EmojiSearchZipline {
   private val executorService = Executors.newSingleThreadExecutor { Thread(it, "Zipline") }
@@ -41,14 +40,11 @@ class EmojiSearchZipline {
     val job = coroutineScope.launch(dispatcher) {
       val presentersJs = hostApi.httpCall("http://10.0.2.2:8080/presenters.js", mapOf())
       zipline.quickJs.evaluate(presentersJs, "presenters.js")
-      zipline.set<HostApi>("hostApi", EmptySerializersModule, hostApi)
+      zipline.set<HostApi>("hostApi", hostApi)
       zipline.quickJs.evaluate(
         "presenters.app.cash.zipline.samples.emojisearch.preparePresenters()"
       )
-      val presenter = zipline.get<EmojiSearchPresenter>(
-        name = "emojiSearchPresenter",
-        serializersModule = EmptySerializersModule,
-      )
+      val presenter = zipline.get<EmojiSearchPresenter>("emojiSearchPresenter")
 
       val eventsFlowReference = eventFlow.asFlowReference(EmojiSearchEvent.serializer())
       val modelsFlowReference = presenter.produceModels(eventsFlowReference)

--- a/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -36,7 +36,6 @@ import kotlin.reflect.full.KClassifiers;
 import kotlinx.coroutines.test.TestCoroutineDispatcher;
 import kotlinx.serialization.KSerializer;
 
-import static app.cash.zipline.testing.EchoKt.getEchoSerializersModule;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static kotlinx.serialization.SerializersKt.serializer;
@@ -63,7 +62,7 @@ public final class ZiplineTestInternals {
 
   /** Simulate generated code for outbound calls. */
   public static EchoService getEchoClient(Endpoint endpoint, String name) {
-    return endpoint.get(name, new OutboundBridge<EchoService>(getEchoSerializersModule()) {
+    return endpoint.get(name, new OutboundBridge<EchoService>() {
       @Override public EchoService create(OutboundBridge.Context context) {
         KSerializer<EchoRequest> parameterSerializer
             = (KSerializer) serializer(context.getSerializersModule(), echoRequestKt);
@@ -82,7 +81,7 @@ public final class ZiplineTestInternals {
 
   /** Simulate generated code for inbound calls. */
   public static void setEchoService(Endpoint endpoint, String name, EchoService echoService) {
-    endpoint.set(name, new InboundBridge<EchoService>(getEchoSerializersModule()) {
+    endpoint.set(name, new InboundBridge<EchoService>() {
       @Override public InboundCallHandler create(Context context) {
         KSerializer<EchoResponse> resultSerializer
             = (KSerializer) serializer(context.getSerializersModule(), echoResponseKt);
@@ -114,8 +113,7 @@ public final class ZiplineTestInternals {
 
   /** Simulate generated code for outbound calls. */
   public static GenericEchoService<String> getGenericEchoService(Endpoint endpoint, String name) {
-    return endpoint.get(name, new OutboundBridge<GenericEchoService<String>>(
-        getEchoSerializersModule()) {
+    return endpoint.get(name, new OutboundBridge<GenericEchoService<String>>() {
       @Override public GenericEchoService<String> create(OutboundBridge.Context context) {
         KSerializer<String> parameterSerializer
             = (KSerializer) serializer(context.getSerializersModule(), stringKt);
@@ -135,7 +133,7 @@ public final class ZiplineTestInternals {
   /** Simulate generated code for inbound calls. */
   public static void setGenericEchoService(
       Endpoint endpoint, String name, GenericEchoService<String> echoService) {
-    endpoint.set(name, new InboundBridge<GenericEchoService<String>>(getEchoSerializersModule()) {
+    endpoint.set(name, new InboundBridge<GenericEchoService<String>>() {
       @Override public InboundCallHandler create(Context context) {
         KSerializer<List<String>> resultSerializer
             = (KSerializer) serializer(context.getSerializersModule(), listOfStringKt);

--- a/zipline-kotlin-plugin/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -36,9 +36,9 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         class TestingEchoService(
           private val greeting: String
         ) : EchoService {
@@ -46,9 +46,9 @@ class ZiplineKotlinPluginTest {
             return EchoResponse("${'$'}greeting from the compiler plugin, ${'$'}{request.message}")
           }
         }
-        
+
         fun prepareJsBridges(endpoint: Endpoint) {
-          endpoint.set<EchoService>("helloService", EchoSerializersModule, TestingEchoService("hello"))
+          endpoint.set<EchoService>("helloService", TestingEchoService("hello"))
         }
         """
       )
@@ -71,11 +71,11 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         fun getHelloService(endpoint: Endpoint): EchoService {
-          return endpoint.get("helloService", EchoSerializersModule)
+          return endpoint.get("helloService")
         }
         """
       )
@@ -106,11 +106,11 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         fun prepareJsBridges(endpoint: Endpoint) {
-          endpoint.set<TestingEchoService>("helloService", EchoSerializersModule, TestingEchoService)
+          endpoint.set<TestingEchoService>("helloService", TestingEchoService)
         }
 
         object TestingEchoService : EchoService {
@@ -131,11 +131,11 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         fun getHelloService(endpoint: Endpoint): String {
-          return endpoint.get("helloService", EchoSerializersModule)
+          return endpoint.get("helloService")
         }
         """
       )
@@ -152,19 +152,18 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         class TestingGenericEchoService : GenericEchoService<String> {
           override fun genericEcho(request: String): List<String> {
             return listOf("received a generic ${'$'}request!")
           }
         }
-        
+
         fun prepareJsBridges(endpoint: Endpoint) {
           endpoint.set<GenericEchoService<String>>(
             "genericService",
-            EchoSerializersModule,
             TestingGenericEchoService()
           )
         }
@@ -188,11 +187,11 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         fun getGenericService(endpoint: Endpoint): GenericEchoService<String> {
-          return endpoint.get("genericService", EchoSerializersModule)
+          return endpoint.get("genericService")
         }
         """
       )
@@ -223,11 +222,11 @@ class ZiplineKotlinPluginTest {
         "main.kt",
         """
         package app.cash.zipline.testing
-        
+
         import app.cash.zipline.internal.bridge.Endpoint
-        
+
         fun prepareJsBridges(endpoint: Endpoint) {
-          endpoint.set<EchoService>("helloService", EchoSerializersModule, object : EchoService {
+          endpoint.set<EchoService>("helloService", object : EchoService {
             override fun echo(request: EchoRequest): EchoResponse {
               return EchoResponse("hello from anonymous, ${'$'}{request.message}")
             }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
@@ -17,16 +17,18 @@ package app.cash.zipline
 
 import kotlinx.serialization.modules.SerializersModule
 
-expect abstract class Zipline {
-  abstract val engineVersion: String
+expect class Zipline {
+  val engineVersion: String
+
+  val serializersModule: SerializersModule
 
   /** Name of services that have been published with [set]. */
-  abstract val serviceNames: Set<String>
+  val serviceNames: Set<String>
 
   /** Names of services that can be consumed with [get]. */
-  abstract val clientNames: Set<String>
+  val clientNames: Set<String>
 
-  fun <T : Any> get(name: String, serializersModule: SerializersModule): T
+  fun <T : Any> get(name: String): T
 
-  fun <T : Any> set(name: String, serializersModule: SerializersModule, instance: T)
+  fun <T : Any> set(name: String, instance: T)
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -25,9 +25,7 @@ import kotlinx.serialization.serializer
  * another platform in the same process.
  */
 @PublishedApi
-internal abstract class InboundBridge<T : Any>(
-  val serializersModule: SerializersModule
-) {
+internal abstract class InboundBridge<T : Any> {
   abstract fun create(context: Context): InboundCallHandler
 
   class Context(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
@@ -30,9 +29,7 @@ import kotlinx.serialization.serializer
  * implemented by another platform in the same process.
  */
 @PublishedApi
-internal abstract class OutboundBridge<T : Any>(
-  val serializersModule: SerializersModule
-) {
+internal abstract class OutboundBridge<T : Any> {
   abstract fun create(context: Context): T
 
   class Context(
@@ -105,7 +102,7 @@ internal class OutboundCall(
       CoroutineScope(context.endpoint.dispatcher).launch {
         val callbackName = endpoint.generateName()
         val callback = RealSuspendCallback(callbackName, continuation, serializer)
-        endpoint.set<SuspendCallback>(callbackName, EmptySerializersModule, callback)
+        endpoint.set<SuspendCallback>(callbackName, callback)
         endpoint.outboundChannel.invokeSuspending(
           instanceName,
           funName,

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -18,7 +18,6 @@ package app.cash.zipline
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.testing.EchoRequest
 import app.cash.zipline.testing.EchoResponse
-import app.cash.zipline.testing.EchoSerializersModule
 import app.cash.zipline.testing.EchoService
 import app.cash.zipline.testing.SuspendingEchoService
 import app.cash.zipline.testing.newEndpointPair
@@ -30,7 +29,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.serialization.modules.EmptySerializersModule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -58,8 +56,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<EchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<EchoService>("helloService", EchoSerializersModule)
+    endpointA.set<EchoService>("helloService", service)
+    val client = endpointB.get<EchoService>("helloService")
 
     responses += "this is a curt response"
     val response = client.echo(EchoRequest("this is a happy request"))
@@ -82,8 +80,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<NullableEchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<NullableEchoService>("helloService", EchoSerializersModule)
+    endpointA.set<NullableEchoService>("helloService", service)
+    val client = endpointB.get<NullableEchoService>("helloService")
 
     val response = client.echo(null)
     assertThat(response?.message).isEqualTo("received null")
@@ -98,8 +96,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<NullableEchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<NullableEchoService>("helloService", EchoSerializersModule)
+    endpointA.set<NullableEchoService>("helloService", service)
+    val client = endpointB.get<NullableEchoService>("helloService")
 
     val response = client.echo(EchoRequest("send me null please?"))
     assertNull(response)
@@ -116,8 +114,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<SuspendingEchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<SuspendingEchoService>("helloService", EchoSerializersModule)
+    endpointA.set<SuspendingEchoService>("helloService", service)
+    val client = endpointB.get<SuspendingEchoService>("helloService")
 
     val deferredResponse: Deferred<EchoResponse> = async {
       client.suspendingEcho(EchoRequest("this is a happy request"))
@@ -137,8 +135,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<EchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<EchoService>("helloService", EchoSerializersModule)
+    endpointA.set<EchoService>("helloService", service)
+    val client = endpointB.get<EchoService>("helloService")
 
     val thrownException = assertThrows<Exception> {
       client.echo(EchoRequest(""))
@@ -155,8 +153,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<SuspendingEchoService>("helloService", EchoSerializersModule, service)
-    val client = endpointB.get<SuspendingEchoService>("helloService", EchoSerializersModule)
+    endpointA.set<SuspendingEchoService>("helloService", service)
+    val client = endpointB.get<SuspendingEchoService>("helloService")
 
     val thrownException = assertThrows<Exception> {
       client.suspendingEcho(EchoRequest(""))
@@ -178,8 +176,8 @@ internal class EndpointTest {
       }
     }
 
-    endpointA.set<SuspendingEchoService>("echoService", EmptySerializersModule, echoService)
-    val client = endpointB.get<SuspendingEchoService>("echoService", EmptySerializersModule)
+    endpointA.set<SuspendingEchoService>("echoService", echoService)
+    val client = endpointB.get<SuspendingEchoService>("echoService")
 
     val echoResponse = client.suspendingEcho(EchoRequest("Jesse"))
     assertThat(echoResponse).isEqualTo(EchoResponse("hello, Jesse"))

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/FlowTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/FlowTest.kt
@@ -16,7 +16,6 @@
 package app.cash.zipline
 
 import app.cash.zipline.internal.bridge.Endpoint
-import app.cash.zipline.testing.EchoSerializersModule
 import app.cash.zipline.testing.newEndpointPair
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -69,8 +68,8 @@ internal class FlowTest {
   fun flowReturnValueWorks(): Unit = runBlocking(dispatcher) {
     val service = RealFlowEchoService()
 
-    endpointA.set<FlowEchoService>("service", EchoSerializersModule, service)
-    val client = endpointB.get<FlowEchoService>("service", EchoSerializersModule)
+    endpointA.set<FlowEchoService>("service", service)
+    val client = endpointB.get<FlowEchoService>("service")
     val initialServiceNames = endpointA.serviceNames
     val initialClientNames = endpointA.clientNames
 
@@ -87,8 +86,8 @@ internal class FlowTest {
   fun flowParameterWorks(): Unit = runBlocking(dispatcher) {
     val service = RealFlowEchoService()
 
-    endpointA.set<FlowEchoService>("service", EchoSerializersModule, service)
-    val client = endpointB.get<FlowEchoService>("service", EchoSerializersModule)
+    endpointA.set<FlowEchoService>("service", service)
+    val client = endpointB.get<FlowEchoService>("service")
     val initialServiceNames = endpointA.serviceNames
     val initialClientNames = endpointA.clientNames
 

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/SerializersTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/SerializersTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.AdaptersRequest
+import app.cash.zipline.testing.AdaptersRequestSerializersModule
+import app.cash.zipline.testing.AdaptersResponse
+import app.cash.zipline.testing.AdaptersResponseSerializersModule
+import app.cash.zipline.testing.AdaptersSerializersModule
+import app.cash.zipline.testing.AdaptersService
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SerializersTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher, AdaptersSerializersModule)
+  private val ziplineRequestOnly = Zipline.create(dispatcher, AdaptersRequestSerializersModule)
+  private val ziplineResponseOnly = Zipline.create(dispatcher, AdaptersResponseSerializersModule)
+
+  @Before fun setUp(): Unit = runBlocking(dispatcher) {
+    zipline.loadTestingJs()
+    ziplineRequestOnly.loadTestingJs()
+    ziplineResponseOnly.loadTestingJs()
+  }
+
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
+    zipline.close()
+    ziplineRequestOnly.close()
+    ziplineResponseOnly.close()
+  }
+
+  @Test fun missingGetReturnValueSerializerFailsFast(): Unit = runBlocking(dispatcher) {
+    assertThat(assertThrows<IllegalArgumentException> {
+      ziplineRequestOnly.get<AdaptersService>("adaptersService")
+    }).hasMessageThat().contains("Serializer for class 'AdaptersResponse' is not found.")
+  }
+
+  @Test fun missingGetParameterSerializerFailsFast(): Unit = runBlocking(dispatcher) {
+    assertThat(assertThrows<IllegalArgumentException> {
+      ziplineResponseOnly.get<AdaptersService>("adaptersService")
+    }).hasMessageThat().contains("Serializer for class 'AdaptersRequest' is not found.")
+  }
+
+  @Test fun presentGetSerializersSucceeds(): Unit = runBlocking(dispatcher) {
+    val service = zipline.get<AdaptersService>("adaptersService")
+    zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareAdaptersJsBridges()")
+
+    assertThat(service.echo(AdaptersRequest("Andrew")))
+      .isEqualTo(AdaptersResponse("thank you for using your serializers, Andrew"))
+  }
+
+  @Test fun missingSetReturnValueSerializerFailsFast(): Unit = runBlocking(dispatcher) {
+    assertThat(assertThrows<IllegalArgumentException> {
+      ziplineRequestOnly.set<AdaptersService>(
+        "adaptersService",
+        JvmAdaptersService()
+      )
+    }).hasMessageThat().contains("Serializer for class 'AdaptersResponse' is not found.")
+  }
+
+  @Test fun missingSetParameterSerializerFailsFast(): Unit = runBlocking(dispatcher) {
+    assertThat(assertThrows<IllegalArgumentException> {
+      ziplineResponseOnly.set<AdaptersService>(
+        "adaptersService",
+        JvmAdaptersService()
+      )
+    }).hasMessageThat().contains("Serializer for class 'AdaptersRequest' is not found.")
+  }
+
+  @Test fun presentSetSerializersSucceeds(): Unit = runBlocking(dispatcher) {
+    zipline.set<AdaptersService>(
+      "adaptersService",
+      JvmAdaptersService()
+    )
+    assertThat(zipline.quickJs.evaluate("testing.app.cash.zipline.testing.callAdaptersService()"))
+      .isEqualTo("JavaScript received nice adapters, Jesse")
+  }
+
+  private class JvmAdaptersService : AdaptersService {
+    override fun echo(request: AdaptersRequest): AdaptersResponse {
+      return AdaptersResponse("nice adapters, ${request.message}")
+    }
+  }
+}

--- a/zipline/src/jsTest/kotlin/app/cash/zipline/ZiplineJsTest.kt
+++ b/zipline/src/jsTest/kotlin/app/cash/zipline/ZiplineJsTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertNotEquals
 
 class ZiplineJsTest {
   @Test fun version() {
-    assertNotEquals("", Zipline.engineVersion)
+    val zipline = Zipline.get()
+    assertNotEquals("", zipline.engineVersion)
   }
 }

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/echo.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/echo.kt
@@ -16,7 +16,6 @@
 package app.cash.zipline.testing
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 interface EchoService {
   fun echo(request: EchoRequest): EchoResponse
@@ -31,6 +30,3 @@ data class EchoRequest(
 data class EchoResponse(
   val message: String
 )
-
-val EchoSerializersModule: SerializersModule = SerializersModule {
-}

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/adaptersJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/adaptersJs.kt
@@ -23,18 +23,19 @@ class JsAdaptersService : AdaptersService {
   }
 }
 
+private val zipline by lazy { Zipline.get(AdaptersSerializersModule) }
+
 @JsExport
 fun prepareAdaptersJsBridges() {
-  Zipline.set<AdaptersService>(
+  zipline.set<AdaptersService>(
     "adaptersService",
-    AdaptersSerializersModule,
     JsAdaptersService()
   )
 }
 
 @JsExport
 fun callAdaptersService(): String {
-  val service = Zipline.get<AdaptersService>("adaptersService", AdaptersSerializersModule)
+  val service = zipline.get<AdaptersService>("adaptersService")
   val response = service.echo(AdaptersRequest("Jesse"))
   return "JavaScript received ${response.message}"
 }

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
@@ -25,15 +25,17 @@ class JsEchoService(
   }
 }
 
+private val zipline by lazy { Zipline.get() }
+
 @JsExport
 fun prepareJsBridges() {
-  Zipline.set<EchoService>("helloService", EchoSerializersModule, JsEchoService("hello"))
-  Zipline.set<EchoService>("yoService", EchoSerializersModule, JsEchoService("yo"))
+  zipline.set<EchoService>("helloService", JsEchoService("hello"))
+  zipline.set<EchoService>("yoService", JsEchoService("yo"))
 }
 
 @JsExport
 fun callSupService(message: String): String {
-  val supService = Zipline.get<EchoService>("supService", EchoSerializersModule)
+  val supService = zipline.get<EchoService>("supService")
   val echoResponse = supService.echo(EchoRequest(message))
   return "JavaScript received '${echoResponse.message}' from the JVM"
 }
@@ -46,5 +48,5 @@ class JsThrowingEchoService : EchoService {
 
 @JsExport
 fun prepareThrowingJsBridges() {
-  Zipline.set<EchoService>("helloService", EchoSerializersModule, JsThrowingEchoService())
+  zipline.set<EchoService>("helloService", JsThrowingEchoService())
 }

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
@@ -29,18 +29,19 @@ class JsSuspendingEchoService(
   }
 }
 
+private val zipline by lazy { Zipline.get() }
+
 @JsExport
 fun prepareSuspendingJsBridges() {
-  Zipline.set<SuspendingEchoService>(
+  zipline.set<SuspendingEchoService>(
     "jsSuspendingEchoService",
-    EchoSerializersModule,
     JsSuspendingEchoService("hello")
   )
 }
 
 @JsExport
 fun callSuspendingEchoService(message: String) {
-  val service = Zipline.get<SuspendingEchoService>("jvmSuspendingEchoService", EchoSerializersModule)
+  val service = zipline.get<SuspendingEchoService>("jvmSuspendingEchoService")
   CoroutineScope(EmptyCoroutineContext).launch(Dispatchers.Main) {
     service.suspendingEcho(EchoRequest(message))
   }

--- a/zipline/testing/src/jvmMain/kotlin/app/cash/zipline/testing/echoJvm.kt
+++ b/zipline/testing/src/jvmMain/kotlin/app/cash/zipline/testing/echoJvm.kt
@@ -18,7 +18,7 @@ package app.cash.zipline.testing
 import app.cash.zipline.Zipline
 
 val Zipline.helloService: EchoService
-  get() = get("helloService", EchoSerializersModule)
+  get() = get("helloService")
 
 val Zipline.yoService: EchoService
-  get() = get("yoService", EchoSerializersModule)
+  get() = get("yoService")

--- a/zipline/testing/src/jvmMain/kotlin/app/cash/zipline/testing/suspendingJvm.kt
+++ b/zipline/testing/src/jvmMain/kotlin/app/cash/zipline/testing/suspendingJvm.kt
@@ -18,7 +18,7 @@ package app.cash.zipline.testing
 import app.cash.zipline.Zipline
 
 val Zipline.jsSuspendingEchoService: SuspendingEchoService
-  get() = get("jsSuspendingEchoService", EchoSerializersModule)
+  get() = get("jsSuspendingEchoService")
 
 class JvmSuspendingEchoService(
   private val greeting: String
@@ -31,7 +31,6 @@ class JvmSuspendingEchoService(
 fun prepareSuspendingJvmBridges(zipline: Zipline) {
   zipline.set<SuspendingEchoService>(
     "jvmSuspendingEchoService",
-    EchoSerializersModule,
     JvmSuspendingEchoService("sup")
   )
 }


### PR DESCRIPTION
This makes initializing the singleton on JavaScript a bit clumsier,
but it simplifies serializer access everywhere and should be a net
win for integrating features like Flows.