### PR TITLE
Propagate Zipline CoroutineScope downward into machinery

### DIFF
--- a/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -29,11 +29,13 @@ import java.util.List;
 import kotlin.Pair;
 import kotlin.PublishedApi;
 import kotlin.coroutines.Continuation;
+import kotlin.coroutines.EmptyCoroutineContext;
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KType;
 import kotlin.reflect.KTypeProjection;
 import kotlin.reflect.full.KClassifiers;
-import kotlinx.coroutines.test.TestCoroutineDispatcher;
+import kotlinx.coroutines.CoroutineScope;
+import kotlinx.coroutines.CoroutineScopeKt;
 import kotlinx.serialization.KSerializer;
 
 import static java.util.Collections.emptyList;
@@ -57,7 +59,8 @@ public final class ZiplineTestInternals {
       singletonList(KTypeProjection.invariant(stringKt)), false, emptyList());
 
   public static Pair<Endpoint, Endpoint> newEndpointPair() {
-    return app.cash.zipline.testing.EndpointsKt.newEndpointPair(new TestCoroutineDispatcher());
+    CoroutineScope scope = CoroutineScopeKt.CoroutineScope(EmptyCoroutineContext.INSTANCE);
+    return app.cash.zipline.testing.EndpointsKt.newEndpointPair(scope);
   }
 
   /** Simulate generated code for outbound calls. */

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -18,7 +18,6 @@ package app.cash.zipline.internal.bridge
 import app.cash.zipline.InboundZiplineReference
 import app.cash.zipline.OutboundZiplineReference
 import app.cash.zipline.ZiplineReference
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -29,7 +28,7 @@ import kotlinx.serialization.modules.SerializersModule
  * receiving calls from the other platform.
  */
 class Endpoint internal constructor(
-  internal val dispatcher: CoroutineDispatcher,
+  internal val scope: CoroutineScope,
   internal val outboundChannel: CallChannel,
 ) {
   internal val inboundHandlers = mutableMapOf<String, InboundCallHandler>()
@@ -85,7 +84,7 @@ class Endpoint internal constructor(
       callbackName: String
     ) {
       val handler = inboundHandlers[instanceName] ?: error("no handler for $instanceName")
-      CoroutineScope(dispatcher).launch {
+      scope.launch {
         val callback = get<SuspendCallback>(callbackName)
         val inboundCall = InboundCall(handler.context, funName, encodedArguments)
         val result = try {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -17,7 +17,6 @@ package app.cash.zipline.internal.bridge
 
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -99,7 +98,7 @@ internal class OutboundCall(
   internal suspend fun <R> invokeSuspending(serializer: KSerializer<R>): R {
     require(callCount++ == parameterCount)
     return suspendCoroutine { continuation ->
-      CoroutineScope(context.endpoint.dispatcher).launch {
+      context.endpoint.scope.launch {
         val callbackName = endpoint.generateName()
         val callback = RealSuspendCallback(callbackName, continuation, serializer)
         endpoint.set<SuspendCallback>(callbackName, callback)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -17,12 +17,12 @@ package app.cash.zipline.testing
 
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 
 /** Returns a pair of endpoints connected to each other for testing. */
-internal fun newEndpointPair(dipatcher: CoroutineDispatcher): Pair<Endpoint, Endpoint> {
+internal fun newEndpointPair(scope: CoroutineScope): Pair<Endpoint, Endpoint> {
   val pair = object : Any() {
-    val a: Endpoint = Endpoint(dipatcher, object : CallChannel {
+    val a: Endpoint = Endpoint(scope, object : CallChannel {
       override fun serviceNamesArray(): Array<String> {
         return b.inboundChannel.serviceNamesArray()
       }
@@ -51,7 +51,7 @@ internal fun newEndpointPair(dipatcher: CoroutineDispatcher): Pair<Endpoint, End
       }
     })
 
-    val b: Endpoint = Endpoint(dipatcher, a.inboundChannel)
+    val b: Endpoint = Endpoint(scope, a.inboundChannel)
   }
 
   return pair.a to pair.b

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -23,6 +23,7 @@ import app.cash.zipline.testing.SuspendingEchoService
 import app.cash.zipline.testing.newEndpointPair
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.LinkedBlockingDeque
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -40,7 +41,7 @@ internal class EndpointTest {
   private val endpointB: Endpoint
 
   init {
-    val (endpointA, endpointB) = newEndpointPair(dispatcher)
+    val (endpointA, endpointB) = newEndpointPair(CoroutineScope(dispatcher))
     this.endpointA = endpointA
     this.endpointB = endpointB
   }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/FlowTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/FlowTest.kt
@@ -18,6 +18,7 @@ package app.cash.zipline
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.testing.newEndpointPair
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -38,7 +39,7 @@ internal class FlowTest {
   private val endpointB: Endpoint
 
   init {
-    val (endpointA, endpointB) = newEndpointPair(dispatcher)
+    val (endpointA, endpointB) = newEndpointPair(CoroutineScope(dispatcher))
     this.endpointA = endpointA
     this.endpointB = endpointB
   }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
@@ -22,6 +22,7 @@ import app.cash.zipline.testing.EchoService
 import app.cash.zipline.testing.newEndpointPair
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.LinkedBlockingDeque
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
@@ -35,7 +36,7 @@ internal class ZiplineReferenceTest {
   private val endpointB: Endpoint
 
   init {
-    val (endpointA, endpointB) = newEndpointPair(dispatcher)
+    val (endpointA, endpointB) = newEndpointPair(CoroutineScope(dispatcher))
     this.endpointA = endpointA
     this.endpointB = endpointB
   }

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -25,13 +25,13 @@ import app.cash.zipline.internal.bridge.inboundChannelName
 import app.cash.zipline.internal.bridge.outboundChannelName
 import app.cash.zipline.internal.hostPlatformName
 import app.cash.zipline.internal.jsPlatformName
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
 actual class Zipline internal constructor() {
   private val endpoint = Endpoint(
-    dispatcher = Dispatchers.Main,
+    scope = GlobalScope,
     outboundChannel = object : CallChannel {
       /** Lazily fetch the channel to call out. */
       @Suppress("UnsafeCastFromDynamic")

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
@@ -16,9 +16,7 @@
 package app.cash.zipline.testing
 
 import app.cash.zipline.Zipline
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 class JsSuspendingEchoService(
@@ -42,7 +40,7 @@ fun prepareSuspendingJsBridges() {
 @JsExport
 fun callSuspendingEchoService(message: String) {
   val service = zipline.get<SuspendingEchoService>("jvmSuspendingEchoService")
-  CoroutineScope(EmptyCoroutineContext).launch(Dispatchers.Main) {
+  GlobalScope.launch {
     service.suspendingEcho(EchoRequest(message))
   }
 }


### PR DESCRIPTION
This ensures everything is launching into the same scope and will be properly canceled if the Zipline instance is closed.