### PR TITLE
Use KClass for QuickJS interface binding

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -68,9 +68,12 @@ kotlin {
     }
 
     val engineMain by creating {
+      dependsOn(commonMain)
       kotlin.srcDir(versionWriterTaskProvider)
     }
-    val engineTest by creating
+    val engineTest by creating {
+      dependsOn(commonTest)
+    }
 
     val jniMain by creating {
       dependsOn(engineMain)

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -15,6 +15,8 @@
  */
 package app.cash.zipline
 
+import kotlin.reflect.KClass
+
 /**
  * An EMCAScript (Javascript) interpreter backed by the 'QuickJS' native engine.
  *
@@ -64,6 +66,29 @@ expect class QuickJs {
    * @throws QuickJsException if there is an error loading or executing the code.
    */
   fun execute(bytecode: ByteArray): Any?
+
+  /**
+   * Attaches to a global JavaScript object called `name` that implements `type`.
+   * `type` defines the interface implemented in JavaScript that will be accessible to Java.
+   * `type` must be an interface that does not extend any other interfaces, and cannot define
+   * any overloaded methods.
+   *
+   * Methods of the interface may return `void` or any of the following supported argument
+   * types: `boolean`, [Boolean], `int`, [Integer], `double`,
+   * [Double], [String].
+   */
+  operator fun <T : Any> get(name: String, type: KClass<T>): T
+
+  /**
+   * Provides [instance] to JavaScript as a global object called [name]. [type]
+   * defines the interface implemented by [instance] that will be accessible to JavaScript.
+   * [type] must be an interface that does not extend any other interfaces, and cannot define
+   * any overloaded methods.
+   *
+   * Methods of the interface may return `void` or any of the following supported argument
+   * types: `boolean`, [Boolean], `int`, [Integer], `double`, [Double], [String].
+   */
+  operator fun <T : Any> set(name: String, type: KClass<T>, instance: T)
 
   fun close()
 }

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -26,7 +26,6 @@ import app.cash.zipline.internal.bridge.outboundChannelName
 import app.cash.zipline.internal.createHostPlatform
 import app.cash.zipline.internal.hostPlatformName
 import app.cash.zipline.internal.jsPlatformName
-import kotlin.LazyThreadSafetyMode
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -44,7 +43,7 @@ actual class Zipline private constructor(
       private val jsInboundBridge: CallChannel by lazy(mode = LazyThreadSafetyMode.NONE) {
         quickJs.get(
           name = inboundChannelName,
-          type = CallChannel::class.java
+          type = CallChannel::class
         )
       }
 
@@ -92,7 +91,7 @@ actual class Zipline private constructor(
     // Eagerly publish the channel so they can call us.
     quickJs.set(
       name = outboundChannelName,
-      type = CallChannel::class.java,
+      type = CallChannel::class,
       instance = endpoint.inboundChannel
     )
 

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.util.logging.Logger
+import kotlin.reflect.KClass
 
 /**
  * An EMCAScript (Javascript) interpreter backed by the 'QuickJS' native engine.
@@ -106,7 +107,9 @@ actual class QuickJs private constructor(
    * Methods of the interface may return `void` or any of the following supported argument
    * types: `boolean`, [Boolean], `int`, [Integer], `double`, [Double], [String].
    */
-  operator fun <T : Any> set(name: String, type: Class<T>, instance: T) {
+  actual operator fun <T : Any> set(name: String, type: KClass<T>, instance: T) {
+    val type = type.java
+
     if (!type.isInterface) {
       throw UnsupportedOperationException(
           "Only interfaces can be bound. Received: $type")
@@ -137,7 +140,9 @@ actual class QuickJs private constructor(
    * types: `boolean`, [Boolean], `int`, [Integer], `double`,
    * [Double], [String].
    */
-  operator fun <T : Any> get(name: String, type: Class<T>): T {
+  actual operator fun <T : Any> get(name: String, type: KClass<T>): T {
+    val type = type.java
+
     if (!type.isInterface) {
       throw UnsupportedOperationException(
           "Only interfaces can be proxied. Received: $type")

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/JsTypedArraysTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/JsTypedArraysTest.kt
@@ -89,7 +89,7 @@ class JsTypedArraysTest {
   }
 
   @Test fun byteArrayWithProxy() {
-    quickJs.set("transformer", ByteArrayTransformer::class.java, ByteArrayTransformer { input ->
+    quickJs.set("transformer", ByteArrayTransformer::class, ByteArrayTransformer { input ->
       requireNotNull(input)
       val result = ByteArray(input.size + 2)
       result[0] = -1
@@ -111,7 +111,7 @@ class JsTypedArraysTest {
   }
 
   @Test fun byteArrayWithProxyReturnsNull() {
-    quickJs.set("transformer", ByteArrayTransformer::class.java, ByteArrayTransformer { null })
+    quickJs.set("transformer", ByteArrayTransformer::class, ByteArrayTransformer { null })
     val byteArray = quickJs.evaluate("""
       |var array = new Uint8Array(5);
       |array[0] = 86;
@@ -121,7 +121,7 @@ class JsTypedArraysTest {
   }
 
   @Test fun byteArrayWithProxyReceivesNull() {
-    quickJs.set("transformer", ByteArrayTransformer::class.java,
+    quickJs.set("transformer", ByteArrayTransformer::class,
         ByteArrayTransformer { byteArrayOf(86) })
     val byteArray = quickJs.evaluate("""
       |transformer.transform(null);
@@ -130,7 +130,7 @@ class JsTypedArraysTest {
   }
 
   @Test fun javaByteArrayConvertedToJsUint8Array() {
-    quickJs.set("transformer", ByteArrayTransformer::class.java,
+    quickJs.set("transformer", ByteArrayTransformer::class,
         ByteArrayTransformer { byteArrayOf(86) })
     val constructorName = quickJs.evaluate("""
       |var array = new Uint8Array(5);

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsCompileTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsCompileTest.kt
@@ -101,12 +101,12 @@ class QuickJsCompileTest {
     quickJs = QuickJs.create()
 
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.get("value", QuickJsGetTest.TestInterface::class.java)
+      quickJs.get("value", QuickJsGetTest.TestInterface::class)
     }
     assertEquals("A global JavaScript object called value was not found", t.message)
 
     quickJs.execute(proxyDef)
-    val proxy = quickJs.get("value", QuickJsGetTest.TestInterface::class.java)
+    val proxy = quickJs.get("value", QuickJsGetTest.TestInterface::class)
     assertEquals("8675309", proxy.value)
   }
 
@@ -122,7 +122,7 @@ class QuickJsCompileTest {
     }
     assertEquals("'value' is not defined", t.message)
 
-    quickJs.set("value", QuickJsSetTest.TestInterface::class.java,
+    quickJs.set("value", QuickJsSetTest.TestInterface::class,
         QuickJsSetTest.TestInterface { "8675309" })
     assertEquals("8675309", quickJs.execute(code))
   }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsGetTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsGetTest.kt
@@ -34,7 +34,7 @@ class QuickJsGetTest {
 
   @Test fun getNonInterface() {
     val t = assertThrows<UnsupportedOperationException> {
-      quickJs.get("s", String::class.java)
+      quickJs.get("s", String::class)
     }
     assertEquals("Only interfaces can be proxied. Received: class java.lang.String", t.message)
   }
@@ -45,13 +45,13 @@ class QuickJsGetTest {
 
   @Test fun get() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
     assertEquals("8675309", proxy.value)
   }
 
   @Test fun getMissingObjectThrows() {
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.get("DoesNotExist", TestInterface::class.java)
+      quickJs.get("DoesNotExist", TestInterface::class)
     }
     assertEquals("A global JavaScript object called DoesNotExist was not found", t.message)
   }
@@ -59,7 +59,7 @@ class QuickJsGetTest {
   @Test fun getMissingMethodThrows() {
     quickJs.evaluate("var value = { getOtherValue: function() { return '8675309'; } };")
     val t = assertThrows<QuickJsException> {
-      quickJs.get("value", TestInterface::class.java)
+      quickJs.get("value", TestInterface::class)
     }
     assertEquals("JavaScript global value has no method called getValue", t.message)
   }
@@ -67,14 +67,14 @@ class QuickJsGetTest {
   @Test fun getMethodNotCallableThrows() {
     quickJs.evaluate("var value = { getValue: '8675309' };")
     val t = assertThrows<QuickJsException> {
-      quickJs.get("value", TestInterface::class.java)
+      quickJs.get("value", TestInterface::class)
     }
     assertEquals("JavaScript property value.getValue not callable", t.message)
   }
 
   @Test fun proxyCalledAfterEngineClosed() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
 
     // Close the context - proxy can no longer be used.
     quickJs.close()
@@ -87,7 +87,7 @@ class QuickJsGetTest {
 
   @Test fun proxyCallThrows() {
     quickJs.evaluate("var value = { getValue: function() { throw 'nope'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
     val t = assertThrows<QuickJsException> {
       proxy.value
     }
@@ -97,7 +97,7 @@ class QuickJsGetTest {
   @Test fun proxyCallThrowsIncludeStacktrace() {
     quickJs.evaluate("function nop() { return 1; }")
     quickJs.evaluate("var value = { getValue: function() { return nope(); } };", "test.js")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
     val t = assertThrows<QuickJsException> {
       proxy.value
     }
@@ -108,7 +108,7 @@ class QuickJsGetTest {
   @Ignore("TODO: track JsMethodProxies.")
   @Test fun replaceProxiedObjectProxyReferencesOld() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
 
     // Now replace the proxied object with a new global.
     quickJs.evaluate("value = { getValue: function() { return '7471111'; } };")
@@ -119,14 +119,14 @@ class QuickJsGetTest {
     assertEquals("JavaScript object value has been garbage collected", t.message)
 
     // We can create a new proxy to the new object and call it.
-    val proxy2 = quickJs.get("value", TestInterface::class.java)
+    val proxy2 = quickJs.get("value", TestInterface::class)
     assertNotEquals(proxy, proxy2)
     assertEquals("7471111", proxy2.value)
   }
 
   @Test fun replaceProxiedMethodReferencesNew() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
     quickJs.evaluate("value.getValue = function() { return '7471111'; };")
     assertEquals("7471111", proxy.value)
   }
@@ -134,15 +134,15 @@ class QuickJsGetTest {
   @Test fun getNonObjectThrows() {
     quickJs.evaluate("var value = 2;")
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.get("value", TestInterface::class.java)
+      quickJs.get("value", TestInterface::class)
     }
     assertEquals("JavaScript global called value is not an object", t.message)
   }
 
   @Test fun getSameObjectTwice() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy1 = quickJs.get("value", TestInterface::class.java)
-    val proxy2 = quickJs.get("value", TestInterface::class.java)
+    val proxy1 = quickJs.get("value", TestInterface::class)
+    val proxy2 = quickJs.get("value", TestInterface::class)
     assertNotEquals(proxy1, proxy2)
     assertEquals(proxy1.value, proxy2.value)
   }
@@ -150,7 +150,7 @@ class QuickJsGetTest {
   @Ignore("TODO: track JsMethodProxies.")
   @Test fun proxyCalledAfterObjectGarbageCollected() {
     quickJs.evaluate("var value = { getValue: function() { return '8675309'; } };")
-    val proxy = quickJs.get("value", TestInterface::class.java)
+    val proxy = quickJs.get("value", TestInterface::class)
     quickJs.evaluate("delete value;")
     val t = assertThrows<QuickJsException> {
       proxy.value
@@ -165,7 +165,7 @@ class QuickJsGetTest {
   @Test fun proxyUnsupportedArgumentType() {
     quickJs.evaluate("var value = { set: function(d) { return d.toString(); } };")
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.get("value", UnsupportedArgumentType::class.java)
+      quickJs.get("value", UnsupportedArgumentType::class)
     }
     assertEquals("Unsupported Java type java.util.Date", t.message)
   }
@@ -183,7 +183,7 @@ class QuickJsGetTest {
       |  d: function(i, v) { return v / i; }
       |};
       |""".trimMargin())
-    val proxy = quickJs.get("value", TestPrimitiveTypes::class.java)
+    val proxy = quickJs.get("value", TestPrimitiveTypes::class)
     assertEquals(false, proxy.b(true))
     assertEquals(3.14159, proxy.d(2, 6.28318), 0.001)
   }
@@ -201,7 +201,7 @@ class QuickJsGetTest {
       |  }
       |};
       |""".trimMargin())
-    val printer = quickJs.get("printer", TestMultipleArgTypes::class.java)
+    val printer = quickJs.get("printer", TestMultipleArgTypes::class)
     assertEquals("boolean: true, int: 42, double: 2.718281828459", printer.print(true, 42, 2.718281828459))
   }
 
@@ -217,7 +217,7 @@ class QuickJsGetTest {
       |  d: function(v) { return v != null ? v / 2.0 : null; }
       |};
       |""".trimMargin())
-    val proxy = quickJs.get("value", TestBoxedPrimitiveArgTypes::class.java)
+    val proxy = quickJs.get("value", TestBoxedPrimitiveArgTypes::class)
     assertEquals(true, proxy.b(false))
     assertEquals(3.14159, proxy.d(6.28318)!!, 0.001)
     assertNull(proxy.b(null))
@@ -234,7 +234,7 @@ class QuickJsGetTest {
       |  get: function() { return 2; }
       |};
       |""".trimMargin())
-    val getter = quickJs.get("value", IntegerGetter::class.java)
+    val getter = quickJs.get("value", IntegerGetter::class)
     assertEquals(2, getter.get())
   }
 
@@ -250,7 +250,7 @@ class QuickJsGetTest {
       |  return 'boolean: ' + this + ', int: ' + i + ', double: ' + d;
       |}
       |""".trimMargin())
-    val printer = quickJs.get("printer", PrinterFunction::class.java)
+    val printer = quickJs.get("printer", PrinterFunction::class)
     assertEquals("boolean: true, int: 42, double: 2.718281828459", printer.call(true, 42, 2.718281828459))
   }
 
@@ -260,7 +260,7 @@ class QuickJsGetTest {
       |  return d;
       |}
       |""".trimMargin())
-    val printer = quickJs.get("printer", PrinterFunction::class.java)
+    val printer = quickJs.get("printer", PrinterFunction::class)
     val t = assertThrows<IllegalArgumentException> {
       printer.call(true, 42, 2.718281828459)
     }
@@ -279,7 +279,7 @@ class QuickJsGetTest {
       |  }
       |};
       |""".trimMargin())
-    val printer = quickJs.get("printer", TestMultipleObjectArgs::class.java)
+    val printer = quickJs.get("printer", TestMultipleObjectArgs::class)
     assertEquals("boolean: true, int: 42, double: 2.718281828459", printer.print(true, 42, 2.718281828459))
   }
 
@@ -291,7 +291,7 @@ class QuickJsGetTest {
       |  }
       |};
       |""".trimMargin())
-    val printer = quickJs.get("printer", TestMultipleObjectArgs::class.java)
+    val printer = quickJs.get("printer", TestMultipleObjectArgs::class)
     val t = assertThrows<IllegalArgumentException> {
       printer.print(true, 42, Date())
     }
@@ -313,7 +313,7 @@ class QuickJsGetTest {
       |  return result.toString();
       |}
       |""".trimMargin())
-    val joiner = quickJs.get("joiner", TestVarArgs::class.java)
+    val joiner = quickJs.get("joiner", TestVarArgs::class)
     assertEquals("", joiner.call("-"))
     assertEquals("1 + 2 + three", joiner.call(" + ", 1, 2, "three"))
     val t = assertThrows<IllegalArgumentException> {
@@ -342,7 +342,7 @@ class QuickJsGetTest {
       |  countTrues: function() { return this.sum.apply(this, arguments); }
       |};
       |""".trimMargin())
-    val summer = quickJs.get("summer", Summer::class.java)
+    val summer = quickJs.get("summer", Summer::class)
     assertEquals(0.0, summer.sumDoubles(), 0.001)
     assertEquals(10.0, summer.sumDoubles(1.0, 2.0, 3.0, 4.0), 0.001)
     assertEquals(0.0, summer.sumIntegers(), 0.001)
@@ -357,13 +357,13 @@ class QuickJsGetTest {
 
   @Test fun marshalArrayWithManyElements() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", ObjectSorter::class.java)
+    val sorter = quickJs.get("Sorter", ObjectSorter::class)
     assertEquals(100000, sorter.sort(arrayOfNulls<Any?>(100000))!!.size)
   }
 
   @Test fun arraysOfObjects() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", ObjectSorter::class.java)
+    val sorter = quickJs.get("Sorter", ObjectSorter::class)
     assertNull(sorter.sort(null))
     val original = arrayOf<Any?>(2, 4, 3, 1)
     val sorted = sorter.sort(original)
@@ -378,7 +378,7 @@ class QuickJsGetTest {
 
   @Test fun arraysOfStrings() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", StringSorter::class.java)
+    val sorter = quickJs.get("Sorter", StringSorter::class)
     assertArrayEquals(arrayOf("a", "b", "c", "d"), sorter.sort(arrayOf("b", "d", "c", "a")))
     assertArrayEquals(arrayOf("a", "b", "d", null), sorter.sort(arrayOf("b", "d", null, "a")))
 
@@ -396,7 +396,7 @@ class QuickJsGetTest {
 
   @Test fun arraysOfDoubles() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", DoubleSorter::class.java)
+    val sorter = quickJs.get("Sorter", DoubleSorter::class)
     assertArrayEquals(doubleArrayOf(1.0, 2.3, 2.9, 3.0),
         sorter.sort(doubleArrayOf(2.9, 2.3, 3.0, 1.0)), 0.0)
 
@@ -416,7 +416,7 @@ class QuickJsGetTest {
 
   @Test fun arraysOfInts() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", IntSorter::class.java)
+    val sorter = quickJs.get("Sorter", IntSorter::class)
     assertArrayEquals(doubleArrayOf(1.0, 2.0, 3.0, 4.0), sorter.sort(intArrayOf(2, 4, 3, 1)), 0.0)
     assertArrayEquals(arrayOf(1.0, 2.0, 3.0, null), sorter.sortNullable(arrayOf(2, null, 3, 1)))
 
@@ -435,7 +435,7 @@ class QuickJsGetTest {
 
   @Test fun arraysOfBooleans() {
     quickJs.evaluate(SORTER_FUNCTOR)
-    val sorter = quickJs.get("Sorter", BoolSorter::class.java)
+    val sorter = quickJs.get("Sorter", BoolSorter::class)
     assertArrayEquals(booleanArrayOf(false, false, true, true), sorter.sort(booleanArrayOf(true, false, true, false)))
     assertArrayEquals(arrayOf(false, null, true, true), sorter.sortNullable(arrayOf(null, true, false, true)))
 
@@ -461,7 +461,7 @@ class QuickJsGetTest {
       |    });
       |};
       |""".trimMargin())
-    val transposer = quickJs.get("transpose", MatrixTransposer::class.java)
+    val transposer = quickJs.get("transpose", MatrixTransposer::class)
     val matrix = Array(2) { arrayOfNulls<Double?>(2) }
     matrix[0][0] = 1.0
     matrix[0][1] = 2.0

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsSetTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsSetTest.kt
@@ -36,7 +36,7 @@ class QuickJsSetTest {
 
   @Test fun setNonInterface() {
     val t = assertThrows<UnsupportedOperationException> {
-      quickJs.set("s", String::class.java, "foo")
+      quickJs.set("s", String::class, "foo")
     }
     assertEquals("Only interfaces can be bound. Received: class java.lang.String", t.message)
   }
@@ -46,12 +46,12 @@ class QuickJsSetTest {
   }
 
   @Test fun callMethodOnJavaObject() {
-    quickJs.set("value", TestInterface::class.java, TestInterface { "8675309" })
+    quickJs.set("value", TestInterface::class, TestInterface { "8675309" })
     assertEquals("8675309", quickJs.evaluate("value.getValue();"))
   }
 
   @Test fun callMissingMethodOnJavaObjectFails() {
-    quickJs.set("value", TestInterface::class.java, TestInterface { throw AssertionError() })
+    quickJs.set("value", TestInterface::class, TestInterface { throw AssertionError() })
     val t = assertThrows<QuickJsException> {
       quickJs.evaluate("value.increment()")
     }
@@ -59,9 +59,9 @@ class QuickJsSetTest {
   }
 
   @Test fun setSameNameTwiceFails() {
-    quickJs.set("value", TestInterface::class.java, TestInterface { "foo" })
+    quickJs.set("value", TestInterface::class, TestInterface { "foo" })
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.set("value", TestInterface::class.java, TestInterface { throw AssertionError() })
+      quickJs.set("value", TestInterface::class, TestInterface { throw AssertionError() })
     }
     assertEquals("A global object called value already exists", t.message)
   }
@@ -73,7 +73,7 @@ class QuickJsSetTest {
         throw UnsupportedOperationException("Cannot getValue")
       }
     }
-    quickJs.set("value", TestInterface::class.java, boundObject)
+    quickJs.set("value", TestInterface::class, boundObject)
 
     val t = assertThrows<UnsupportedOperationException> {
       quickJs.evaluate("""
@@ -122,7 +122,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callMethodOnJavaObjectThrowsJavaException() {
-    quickJs.set("value", TestInterface::class.java,
+    quickJs.set("value", TestInterface::class,
         TestInterface { throw UnsupportedOperationException("This is an error message.") })
     val t = assertThrows<UnsupportedOperationException> {
       quickJs.evaluate("value.getValue()")
@@ -131,7 +131,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callMethodWithArgsOnJavaObject() {
-    quickJs.set("value", TestInterfaceArgs::class.java,
+    quickJs.set("value", TestInterfaceArgs::class,
         TestInterfaceArgs { a, b, c -> if (a != null) a + b + c else null })
 
     assertEquals("This is a test", quickJs.evaluate("value.foo('This', ' is a ', 'test')"))
@@ -159,7 +159,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callVoidJavaMethod() {
-    quickJs.set("value", TestInterfaceVoids::class.java, object : TestInterfaceVoids {
+    quickJs.set("value", TestInterfaceVoids::class, object : TestInterfaceVoids {
       private var result = "not called"
       override fun getResult(): String = result
       override fun func() {
@@ -179,7 +179,7 @@ class QuickJsSetTest {
 
   // Verify that primitive types can be used as both arguments and return values from Java methods.
   @Test fun callJavaMethodWithPrimitiveTypes() {
-    quickJs.set("value", TestPrimitiveTypes::class.java, object : TestPrimitiveTypes {
+    quickJs.set("value", TestPrimitiveTypes::class, object : TestPrimitiveTypes {
       override fun b(b: Boolean): Boolean = !b
       override fun i(i: Int): Int = i * i
       override fun d(d: Double): Double = d / 2.0
@@ -198,7 +198,7 @@ class QuickJsSetTest {
   // Double check that arguments of different types are processed in the correct order from the
   // QuickJs stack.
   @Test fun callJavaMethodWithAllArgTypes() {
-    quickJs.set("printer", TestMultipleArgTypes::class.java, TestMultipleArgTypes { b, i, d ->
+    quickJs.set("printer", TestMultipleArgTypes::class, TestMultipleArgTypes { b, i, d ->
       String.format("boolean: %s, int: %s, double: %s", b, i, d)
     })
     assertEquals("boolean: true, int: 42, double: 2.718281828459",
@@ -212,7 +212,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callJavaMethodWithBoxedPrimitiveTypes() {
-    quickJs.set("value", TestBoxedPrimitiveArgTypes::class.java,
+    quickJs.set("value", TestBoxedPrimitiveArgTypes::class,
         object : TestBoxedPrimitiveArgTypes {
           override fun b(b: Boolean?): Boolean? = if (b != null) !b else null
           override fun i(i: Int?): Int? = if (i != null) i * i else null
@@ -234,7 +234,7 @@ class QuickJsSetTest {
 
   @Test fun setUnsupportedReturnType() {
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.set("value", UnsupportedReturnType::class.java, UnsupportedReturnType { null })
+      quickJs.set("value", UnsupportedReturnType::class, UnsupportedReturnType { null })
     }
     assertEquals("Unsupported Java type java.util.Date", t.message)
   }
@@ -245,7 +245,7 @@ class QuickJsSetTest {
 
   @Test fun setUnsupportedArgumentType() {
     val t = assertThrows<IllegalArgumentException> {
-      quickJs.set("value", UnsupportedArgumentType::class.java, UnsupportedArgumentType { })
+      quickJs.set("value", UnsupportedArgumentType::class, UnsupportedArgumentType { })
     }
     assertEquals("Unsupported Java type java.util.Date", t.message)
   }
@@ -257,7 +257,7 @@ class QuickJsSetTest {
 
   @Test fun setOverloadedMethod() {
     val t = assertThrows<UnsupportedOperationException> {
-      quickJs.set("value", OverloadedMethod::class.java, object : OverloadedMethod {
+      quickJs.set("value", OverloadedMethod::class, object : OverloadedMethod {
         override fun foo(i: Int) {}
         override fun foo(d: Double) {}
       })
@@ -269,17 +269,17 @@ class QuickJsSetTest {
 
   @Test fun setExtendedInterface() {
     val t = assertThrows<UnsupportedOperationException> {
-      quickJs.set("value", ExtendedInterface::class.java, ExtendedInterface { "nope" })
+      quickJs.set("value", ExtendedInterface::class, ExtendedInterface { "nope" })
     }
     assertEquals(ExtendedInterface::class.java.toString() + " must not extend other interfaces",
         t.message)
   }
 
   @Test fun setFailureLeavesQuickJsConsistent() {
-    quickJs.set("value", TestInterface::class.java, TestInterface { "8675309" })
+    quickJs.set("value", TestInterface::class, TestInterface { "8675309" })
     quickJs.evaluate("var localVar = 42;")
     assertThrows<IllegalArgumentException> {
-      quickJs.set("illegal", UnsupportedArgumentType::class.java, UnsupportedArgumentType { })
+      quickJs.set("illegal", UnsupportedArgumentType::class, UnsupportedArgumentType { })
     }
 
     // The state of our QuickJs context is still valid, containing what was there before.
@@ -294,7 +294,7 @@ class QuickJsSetTest {
   // Double check that arguments of different types are processed in the correct order from the
   // QuickJs stack.
   @Test fun callJavaMethodObjectArgs() {
-    quickJs.set("printer", TestMultipleObjectArgs::class.java, TestMultipleObjectArgs { b, i, d ->
+    quickJs.set("printer", TestMultipleObjectArgs::class, TestMultipleObjectArgs { b, i, d ->
       String.format("boolean: %s, int: %s, double: %s", b, i, d)
     })
     assertEquals("boolean: true, int: 42, double: 2.718281828459",
@@ -302,7 +302,7 @@ class QuickJsSetTest {
   }
 
   @Test fun passUnsupportedTypeAsObjectFails() {
-    quickJs.set("printer", TestMultipleObjectArgs::class.java, TestMultipleObjectArgs { b, i, d ->
+    quickJs.set("printer", TestMultipleObjectArgs::class, TestMultipleObjectArgs { b, i, d ->
       String.format("boolean: %s, int: %s, double: %s", b, i, d)
     })
     val t = assertThrows<QuickJsException> {
@@ -316,7 +316,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callVarArgMethod() {
-    quickJs.set("formatter", TestVarArgs::class.java,
+    quickJs.set("formatter", TestVarArgs::class,
         TestVarArgs { format, args -> String.format(format!!, *args) })
     assertEquals("okay", quickJs.evaluate("formatter.format('okay')"))
     assertEquals("1999-12-31 23:59:59.999 - FATAL: failure", quickJs.evaluate(
@@ -333,7 +333,7 @@ class QuickJsSetTest {
   }
 
   @Test fun callVarArgPrimitiveMethod() {
-    quickJs.set("Summer", Summer::class.java, object : Summer {
+    quickJs.set("Summer", Summer::class, object : Summer {
       override fun sumIntegers(vararg args: Int): Int {
         var v = 0
         for (arg in args) {
@@ -386,7 +386,7 @@ class QuickJsSetTest {
   }
 
   @Test fun arraysOfObjects() {
-    quickJs.set("Sorter", ObjectSorter::class.java, object : ObjectSorter {
+    quickJs.set("Sorter", ObjectSorter::class, object : ObjectSorter {
       override fun sort(args: Array<Any>?): Array<Any>? {
         if (args == null) return null
         Arrays.sort(args, Comparator<Any?> { lhs, rhs ->
@@ -417,7 +417,7 @@ class QuickJsSetTest {
   }
 
   @Test fun arraysOfStrings() {
-    quickJs.set("Sorter", StringSorter::class.java, StringSorter { args ->
+    quickJs.set("Sorter", StringSorter::class, StringSorter { args ->
       Arrays.sort(args)
       args
     })
@@ -438,7 +438,7 @@ class QuickJsSetTest {
   }
 
   @Test fun arraysOfDoubles() {
-    quickJs.set("Sorter", DoubleSorter::class.java, object : DoubleSorter {
+    quickJs.set("Sorter", DoubleSorter::class, object : DoubleSorter {
       override fun sort(args: DoubleArray): DoubleArray {
         Arrays.sort(args)
         return args
@@ -472,7 +472,7 @@ class QuickJsSetTest {
   }
 
   @Test fun arraysOfInts() {
-    quickJs.set("Sorter", IntSorter::class.java, object : IntSorter {
+    quickJs.set("Sorter", IntSorter::class, object : IntSorter {
       override fun sort(args: IntArray): IntArray {
         Arrays.sort(args)
         return args
@@ -508,7 +508,7 @@ class QuickJsSetTest {
   }
 
   @Test fun arraysOfBooleans() {
-    quickJs.set("Sorter", BoolSorter::class.java, object : BoolSorter {
+    quickJs.set("Sorter", BoolSorter::class, object : BoolSorter {
       override fun sort(args: BooleanArray): BooleanArray {
         var count = 0
         for (arg in args) {
@@ -544,7 +544,7 @@ class QuickJsSetTest {
   }
 
   @Test fun lotsOfLocalTemps() {
-    quickJs.set("foo", TestInterfaceArgs::class.java,
+    quickJs.set("foo", TestInterfaceArgs::class,
         TestInterfaceArgs { a, b, c -> a + b + c })
     val result = quickJs.evaluate("""
       |var len = 0;
@@ -1111,7 +1111,7 @@ class QuickJsSetTest {
   }
 
   @Test fun lotsOfInterfaceMethodsAndArgs() {
-    quickJs.set("foo", HugeInterface::class.java, object : HugeInterface {
+    quickJs.set("foo", HugeInterface::class, object : HugeInterface {
       override fun method01(
         a: String?, b: String?, c: String?, d: String?, e: String?, f: String?, g: String?,
         h: String?

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/Utf8Test.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/Utf8Test.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline
 
+import app.cash.zipline.Utf8Test.Formatter
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -61,12 +62,12 @@ class Utf8Test {
       |  }
       |};
       |""".trimMargin())
-    val formatter = quickjs.get("formatter", Formatter::class.java)
+    val formatter = quickjs.get("formatter", Formatter::class)
     assertEquals("(a\uD83D\uDC1Dcdefg, a\uD83D\uDC1Dcdefg)", formatter.format("a\uD83D\uDC1Dcdefg"))
   }
 
   @Test fun nonAsciiInBoundObjectInputAndOutput() {
-    quickjs.set("formatter", Formatter::class.java,
+    quickjs.set("formatter", Formatter::class,
         Formatter { message -> "($message, $message)" })
     assertEquals("(a\uD83D\uDC1Dcdefg, a\uD83D\uDC1Dcdefg)",
         quickjs.evaluate("formatter.format('a\uD83D\uDC1Dcdefg');"))
@@ -80,7 +81,7 @@ class Utf8Test {
       |  }
       |};
       |""".trimMargin())
-    val formatter = quickjs.get("formatter", Formatter::class.java)
+    val formatter = quickjs.get("formatter", Formatter::class)
     val t = assertThrows<QuickJsException> {
       formatter.format("")
     }
@@ -88,7 +89,7 @@ class Utf8Test {
   }
 
   @Test fun nonAsciiInExceptionThrownInJava() {
-    quickjs.set("formatter", Formatter::class.java,
+    quickjs.set("formatter", Formatter::class,
         Formatter { throw RuntimeException("a\uD83D\uDC1Dcdefg") })
     val t = assertThrows<RuntimeException> {
       quickjs.evaluate("formatter.format('');")
@@ -104,7 +105,7 @@ class Utf8Test {
       |  }
       |};
       |""".trimMargin())
-    val formatter = quickjs.get("formatter", Formatter::class.java)
+    val formatter = quickjs.get("formatter", Formatter::class)
     assertEquals("a\uD83D\uDC1Dcdefg", formatter.format(""))
   }
 }


### PR DESCRIPTION
Also promote those methods to the engineMain expect since they are needed to make Zipline compile.