### PR TITLE
Allow MemoryUsage to be remove by code shrinkers

### DIFF
--- a/zipline/src/jniMain/kotlin/app/cash/zipline/MemoryUsage.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/MemoryUsage.kt
@@ -15,10 +15,7 @@
  */
 package app.cash.zipline
 
-import androidx.annotation.Keep
-
 /** Introspect QuickJS for its current memory usage. */
-@Keep // Fully-qualified type and constructor used from native code.
 data class MemoryUsage(
   /** Memory allocated. */
   val memoryAllocatedCount: Long,

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -64,7 +64,7 @@ actual class QuickJs private constructor(
 
   /** Memory usage statistics for the JavaScript engine. */
   val memoryUsage: MemoryUsage
-    get() = memoryUsage(context)
+    get() = memoryUsage(context) ?: throw AssertionError()
 
   /** Default is -1. Use -1 for no limit. */
   actual var memoryLimit: Long = -1L
@@ -220,7 +220,7 @@ actual class QuickJs private constructor(
   private external fun call(context: Long, instance: Long, method: Any, args: Array<Any>): Any
   private external fun execute(context: Long, bytecode: ByteArray): Any?
   private external fun compile(context: Long, sourceCode: String, fileName: String): ByteArray
-  private external fun memoryUsage(context: Long): MemoryUsage
+  private external fun memoryUsage(context: Long): MemoryUsage?
   private external fun setMemoryLimit(context: Long, limit: Long)
   private external fun setGcThreshold(context: Long, gcThreshold: Long)
   private external fun setMaxStackSize(context: Long, stackSize: Long)

--- a/zipline/src/jniMain/resources/META-INF/proguard/app_cash_zipline.pro
+++ b/zipline/src/jniMain/resources/META-INF/proguard/app_cash_zipline.pro
@@ -1,0 +1,7 @@
+# Type fully-qualified name is resolved from JNI code.
+-keepnames class app.cash.zipline.MemoryUsage
+
+# Type constructor is resolved from JNI code.
+-keepclassmembers class app.cash.zipline.MemoryUsage {
+  <init>(...);
+}


### PR DESCRIPTION
If unused, of course.

This can be tested, but it requires _a lot_ of infrastructure. I'm happy to add that as a follow-up, if we think it's worthwhile.

Closes #255.