### PR TITLE
Split Console and EventLoop interfaces

### DIFF
--- a/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -16,30 +16,9 @@
 package app.cash.zipline.internal
 
 import android.util.Log
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
-internal actual fun createHostPlatform(
-  scope: CoroutineScope,
-  jsPlatform: JsPlatform,
-): HostPlatform {
-  return RealHostPlatform(scope, jsPlatform)
-}
-
-private class RealHostPlatform(
-  val scope: CoroutineScope,
-  val jsPlatform: JsPlatform,
-) : HostPlatform {
-  override fun setTimeout(timeoutId: Int, delayMillis: Int) {
-    scope.launch(start = UNDISPATCHED) {
-      delay(delayMillis.toLong())
-      jsPlatform.runJob(timeoutId)
-    }
-  }
-
-  override fun consoleMessage(level: String, message: String) {
+internal object HostConsole : Console {
+  override fun log(level: String, message: String) {
     val priority = when (level) {
       "warn" -> Log.WARN
       "error" -> Log.ERROR

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
@@ -15,21 +15,18 @@
  */
 package app.cash.zipline.internal
 
-internal const val hostPlatformName = "zipline/host"
+internal const val eventLoopName = "zipline/event_loop"
+internal const val consoleName = "zipline/console"
 internal const val jsPlatformName = "zipline/js"
 
-/**
- * Functions that are built in to regular JavaScript environments like the browser and NodeJS, but
- * must be added to QuickJS.
- *
- * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
- */
-internal interface HostPlatform {
-  // See org.w3c.dom.WindowOrWorkerGlobalScope
+internal interface EventLoop {
   fun setTimeout(timeoutId: Int, delayMillis: Int)
+  fun clearTimeout(timeoutId: Int)
+}
 
+internal interface Console {
   /** @param level one of `log`, `info`, `warn`, or `error`. */
-  fun consoleMessage(level: String, message: String)
+  fun log(level: String, message: String)
 }
 
 internal interface JsPlatform {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -15,7 +15,10 @@
  */
 package app.cash.zipline
 
-import app.cash.zipline.internal.HostPlatform
+import app.cash.zipline.internal.Console
+import app.cash.zipline.internal.CoroutineEventLoop
+import app.cash.zipline.internal.EventLoop
+import app.cash.zipline.internal.HostConsole
 import app.cash.zipline.internal.JsPlatform
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
@@ -23,8 +26,8 @@ import app.cash.zipline.internal.bridge.InboundBridge
 import app.cash.zipline.internal.bridge.OutboundBridge
 import app.cash.zipline.internal.bridge.inboundChannelName
 import app.cash.zipline.internal.bridge.outboundChannelName
-import app.cash.zipline.internal.createHostPlatform
-import app.cash.zipline.internal.hostPlatformName
+import app.cash.zipline.internal.consoleName
+import app.cash.zipline.internal.eventLoopName
 import app.cash.zipline.internal.jsPlatformName
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -95,13 +98,19 @@ actual class Zipline private constructor(
       instance = endpoint.inboundChannel
     )
 
+    endpoint.set<Console>(
+      name = consoleName,
+      instance = HostConsole,
+    )
+
     // Connect platforms using our newly-bootstrapped channels.
     val jsPlatform = endpoint.get<JsPlatform>(
       name = jsPlatformName,
     )
-    endpoint.set<HostPlatform>(
-      name = hostPlatformName,
-      instance = createHostPlatform(scope, jsPlatform),
+    val eventLoop = CoroutineEventLoop(scope, jsPlatform)
+    endpoint.set<EventLoop>(
+      name = eventLoopName,
+      instance = eventLoop,
     )
   }
 

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -15,7 +15,8 @@
  */
 package app.cash.zipline
 
-import app.cash.zipline.internal.hostPlatformName
+import app.cash.zipline.internal.consoleName
+import app.cash.zipline.internal.eventLoopName
 import app.cash.zipline.internal.jsPlatformName
 import app.cash.zipline.testing.EchoRequest
 import app.cash.zipline.testing.EchoResponse
@@ -112,7 +113,8 @@ class ZiplineTest {
 
   @Test fun serviceNamesAndClientNames(): Unit = runBlocking(dispatcher) {
     assertThat(zipline.serviceNames).containsExactly(
-      hostPlatformName,
+      eventLoopName,
+      consoleName,
     )
     assertThat(zipline.clientNames).containsExactly(
       jsPlatformName,
@@ -120,7 +122,8 @@ class ZiplineTest {
 
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareJsBridges()")
     assertThat(zipline.serviceNames).containsExactly(
-      hostPlatformName,
+      eventLoopName,
+      consoleName,
     )
     assertThat(zipline.clientNames).containsExactly(
       jsPlatformName,
@@ -130,7 +133,8 @@ class ZiplineTest {
 
     zipline.set<EchoService>("supService", JvmEchoService("sup"))
     assertThat(zipline.serviceNames).containsExactly(
-      hostPlatformName,
+      eventLoopName,
+      consoleName,
       "supService",
     )
     assertThat(zipline.clientNames).containsExactly(

--- a/zipline/src/jvmMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/jvmMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -17,32 +17,11 @@ package app.cash.zipline.internal
 
 import app.cash.zipline.Zipline
 import java.util.logging.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
-internal actual fun createHostPlatform(
-  scope: CoroutineScope,
-  jsPlatform: JsPlatform,
-): HostPlatform {
-  return RealHostPlatform(scope, jsPlatform)
-}
-
-private class RealHostPlatform(
-  val scope: CoroutineScope,
-  val jsPlatform: JsPlatform,
-) : HostPlatform {
+internal object HostConsole : Console {
   private val logger = Logger.getLogger(Zipline::class.qualifiedName)
 
-  override fun setTimeout(timeoutId: Int, delayMillis: Int) {
-    scope.launch(start = UNDISPATCHED) {
-      delay(delayMillis.toLong())
-      jsPlatform.runJob(timeoutId)
-    }
-  }
-
-  override fun consoleMessage(level: String, message: String) {
+  override fun log(level: String, message: String) {
     when (level) {
       "warn" -> logger.warning(message)
       "error" -> logger.severe(message)


### PR DESCRIPTION
Console is actually platform-specific whereas the EventLoop impl can be shared by all platforms.