### PR TITLE
Fix ZiplineReference.get() to always work

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -76,6 +76,11 @@ internal class ZiplineApis(
   val inboundBridge: IrClassSymbol
     get() = pluginContext.referenceClass(bridgeFqName.child("InboundBridge"))!!
 
+  val inboundBridgeService: IrPropertySymbol
+    get() = pluginContext.referenceProperties(
+      bridgeFqName.child("InboundBridge").child("service")
+    ).single()
+
   val inboundBridgeContextFqName = bridgeFqName.child("InboundBridge").child("Context")
 
   val inboundBridgeContext: IrClassSymbol

--- a/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -85,6 +85,10 @@ public final class ZiplineTestInternals {
   /** Simulate generated code for inbound calls. */
   public static void setEchoService(Endpoint endpoint, String name, EchoService echoService) {
     endpoint.set(name, new InboundBridge<EchoService>() {
+      @Override public EchoService getService() {
+        return echoService;
+      }
+
       @Override public InboundCallHandler create(Context context) {
         KSerializer<EchoResponse> resultSerializer
             = (KSerializer) serializer(context.getSerializersModule(), echoResponseKt);
@@ -98,7 +102,7 @@ public final class ZiplineTestInternals {
 
           @Override public String[] call(InboundCall inboundCall) {
             if (inboundCall.getFunName().equals("echo")) {
-              return inboundCall.result(resultSerializer, echoService.echo(
+              return inboundCall.result(resultSerializer, getService().echo(
                   inboundCall.parameter(parameterSerializer)));
             } else {
               return inboundCall.unexpectedFunction();
@@ -137,6 +141,10 @@ public final class ZiplineTestInternals {
   public static void setGenericEchoService(
       Endpoint endpoint, String name, GenericEchoService<String> echoService) {
     endpoint.set(name, new InboundBridge<GenericEchoService<String>>() {
+      @Override public GenericEchoService<String> getService() {
+        return echoService;
+      }
+
       @Override public InboundCallHandler create(Context context) {
         KSerializer<List<String>> resultSerializer
             = (KSerializer) serializer(context.getSerializersModule(), listOfStringKt);
@@ -150,7 +158,7 @@ public final class ZiplineTestInternals {
 
           @Override public String[] call(InboundCall inboundCall) {
             if (inboundCall.getFunName().equals("genericEcho")) {
-              return inboundCall.result(resultSerializer, echoService.genericEcho(
+              return inboundCall.result(resultSerializer, getService().genericEcho(
                   inboundCall.parameter(parameterSerializer)));
             } else {
               return inboundCall.unexpectedFunction();

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
@@ -54,8 +54,7 @@ internal class InboundZiplineReference<T : Any>(
   }
 
   override fun get(outboundBridge: OutboundBridge<T>): T {
-    // TODO(jwilson): change generated subtypes to populate `T` on the super call.
-    throw IllegalStateException("get() on inbound handlers not yet implemented")
+    return inboundBridge.service
   }
 
   override fun close() {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -26,6 +26,8 @@ import kotlinx.serialization.serializer
  */
 @PublishedApi
 internal abstract class InboundBridge<T : Any> {
+  abstract val service: T
+
   abstract fun create(context: Context): InboundCallHandler
 
   class Context(

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineReferenceTest.kt
@@ -42,6 +42,13 @@ internal class ZiplineReferenceTest {
   }
 
   @Test
+  fun referenceCanBeUsedWithoutPassingThroughZipline() {
+    val helloService = GreetingService("hello")
+    val reference = ZiplineReference<EchoService>(helloService)
+    assertThat(reference.get()).isSameInstanceAs(helloService)
+  }
+
+  @Test
   fun bridgeServicesBeforeEndpointsConnected() {
     val requests = LinkedBlockingDeque<String>()
     val responses = LinkedBlockingDeque<String>()


### PR DESCRIPTION
Previously this crashed if the ZiplineReference was never sent
to the other runtime.