### PR TITLE
Expose HostConsole properly in engineMain

### DIFF
--- a/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -17,7 +17,7 @@ package app.cash.zipline.internal
 
 import android.util.Log
 
-internal object HostConsole : Console {
+internal actual object HostConsole : Console {
   override fun log(level: String, message: String) {
     val priority = when (level) {
       "warn" -> Log.WARN

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -15,17 +15,4 @@
  */
 package app.cash.zipline.internal
 
-import app.cash.zipline.Zipline
-import java.util.logging.Logger
-
-internal actual object HostConsole : Console {
-  private val logger = Logger.getLogger(Zipline::class.qualifiedName)
-
-  override fun log(level: String, message: String) {
-    when (level) {
-      "warn" -> logger.warning(message)
-      "error" -> logger.severe(message)
-      else -> logger.info(message)
-    }
-  }
-}
+internal expect object HostConsole : Console


### PR DESCRIPTION
Currently we rely on the fact that this source set is not truly multiplatform and merely joins JVM or Android to compile.