### PR TITLE
Return String[] and not Object[] on CallChannel.invoke

### DIFF
--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -30,7 +30,7 @@ public:
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
   jobjectArray invoke(Context *context, JNIEnv* env, jstring instanceName, jstring funName, jobjectArray encodedArguments) const;
   void invokeSuspending(Context *context, JNIEnv* env, jstring instanceName, jstring funName, jobjectArray encodedArguments, jstring callbackName) const;
-  jobject disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
+  jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
   const std::string name;
 };

--- a/zipline/native/quickjs-jni.cpp
+++ b/zipline/native/quickjs-jni.cpp
@@ -208,7 +208,7 @@ Java_app_cash_zipline_JniCallChannel_invokeSuspending(JNIEnv* env, jobject thiz,
   channel->invokeSuspending(context, env, instanceName, funName, encodedArguments, callbackName);
 }
 
-extern "C" JNIEXPORT jobject JNICALL
+extern "C" JNIEXPORT jboolean JNICALL
 Java_app_cash_zipline_JniCallChannel_disconnect(JNIEnv* env, jobject thiz, jlong _context,
                                                 jlong instance, jstring instanceName) {
   Context* context = reinterpret_cast<Context*>(_context);

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -60,12 +60,12 @@ internal class JniCallChannel(
     callbackName: String,
   )
 
-  override fun disconnect(instanceName: String) =
-    disconnect(quickJs.context, instance, instanceName) == true
+  override fun disconnect(instanceName: String): Boolean =
+    disconnect(quickJs.context, instance, instanceName)
 
   private external fun disconnect(
     context: Long,
     instance: Long,
     instanceName: String
-  ): Boolean?
+  ): Boolean
 }


### PR DESCRIPTION
This was incorrect. The JVM didn't mind but Android crashes.