### PR TITLE
Enable useArrayPolymorphism in kotlinx.serialization

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -34,6 +34,7 @@ internal abstract class InboundBridge<T : Any> {
     val serializersModule: SerializersModule,
   ) {
     val json = Json {
+      useArrayPolymorphism = true
       serializersModule = this@Context.serializersModule
     }
     val throwableSerializer = serializersModule.serializer<Throwable>()

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -37,6 +37,7 @@ internal abstract class OutboundBridge<T : Any> {
     internal val endpoint: Endpoint,
   ) {
     val json = Json {
+      useArrayPolymorphism = true
       serializersModule = this@Context.serializersModule
     }
     val throwableSerializer = serializersModule.serializer<Throwable>()


### PR DESCRIPTION
This isn't ideal but it fixes a crash and unblocks higher-leverage work.