### PR TITLE
Add native utilities for structs in arrays

### DIFF
--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -17,7 +17,6 @@ package app.cash.zipline
 
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.inboundChannelName
-import app.cash.zipline.quickjs.JSValue
 import app.cash.zipline.quickjs.JS_FreeAtom
 import app.cash.zipline.quickjs.JS_FreeValue
 import app.cash.zipline.quickjs.JS_GetGlobalObject
@@ -25,12 +24,7 @@ import app.cash.zipline.quickjs.JS_GetPropertyStr
 import app.cash.zipline.quickjs.JS_Invoke
 import app.cash.zipline.quickjs.JS_NewAtom
 import app.cash.zipline.quickjs.JS_NewString
-import kotlinx.cinterop.CArrayPointer
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.allocArray
-import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.useContents
 
 internal class InboundCallChannel(
   private val quickJs: QuickJs,
@@ -70,11 +64,7 @@ internal class InboundCallChannel(
     val arg2 = with(quickJs) { encodedArguments.toJsValue() }
 
     val jsResult = memScoped {
-      val args = allocArray<JSValue>(3)
-      args[0] = arg0
-      args[1] = arg1
-      args[2] = arg2
-
+      val args = allocArrayOf(arg0, arg1, arg2)
       JS_Invoke(context, inboundChannel, property, 3, args)
     }
     val kotlinResult = with(quickJs) { jsResult.toKotlinInstanceOrNull() } as Array<String>
@@ -107,12 +97,7 @@ internal class InboundCallChannel(
     val arg3 = JS_NewString(context, callbackName)
 
     val jsResult = memScoped {
-      val args = allocArray<JSValue>(4)
-      args[0] = arg0
-      args[1] = arg1
-      args[2] = arg2
-      args[3] = arg3
-
+      val args = allocArrayOf(arg0, arg1, arg2, arg3)
       JS_Invoke(context, inboundChannel, property, 4, args)
     }
 
@@ -135,9 +120,7 @@ internal class InboundCallChannel(
     val arg0 = JS_NewString(context, instanceName)
 
     val jsResult = memScoped {
-      val args = allocArray<JSValue>(1)
-      args[0] = arg0
-
+      val args = allocArrayOf(arg0)
       JS_Invoke(context, inboundChannel, property, 1, args)
     }
     val kotlinResult = with(quickJs) { jsResult.toKotlinInstanceOrNull() } as Boolean
@@ -148,14 +131,5 @@ internal class InboundCallChannel(
     JS_FreeValue(context, globalThis)
 
     return kotlinResult
-  }
-
-  private inline operator fun CArrayPointer<JSValue>.set(index: Int, value: CValue<JSValue>) {
-    val target = this[index]
-    value.useContents {
-      target.tag = tag
-      target.u.int32 = u.int32
-      target.u.float64 = u.float64
-    }
   }
 }

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/nativeUtils.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/nativeUtils.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import kotlinx.cinterop.CArrayPointer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CValues
+import kotlinx.cinterop.CVariable
+import kotlinx.cinterop.NativePlacement
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.interpretCPointer
+import kotlinx.cinterop.sizeOf
+
+/** Copy the data of [item] to the [index] of [this] as if it were an array of [T] structs. */
+internal inline operator fun <reified T : CVariable> CPointer<T>.set(index: Int, item: CValues<T>) {
+  val offset = index * sizeOf<T>()
+  item.place(interpretCPointer(rawValue + offset)!!)
+}
+
+/** Copy the values of [items] into a new array. */
+internal inline fun <reified T : CVariable> NativePlacement.allocArrayOf(
+  vararg items: CValues<T>,
+): CArrayPointer<T> {
+  val array = allocArray<T>(items.size)
+  items.forEachIndexed { index, item ->
+    array[index] = item
+  }
+  return array
+}


### PR DESCRIPTION
These dramatically simplify putting structs into struct arrays through operator-set and a varargs factory function.

cc @kpgalligan 