### PR TITLE
Fix a bug that was crashing release builds

### DIFF
--- a/zipline/native/Context.h
+++ b/zipline/native/Context.h
@@ -60,6 +60,11 @@ public:
   JSRuntime *jsRuntime;
   JSContext *jsContext;
   JSClassID jsClassId;
+  JSAtom lengthAtom;
+  JSAtom serviceNamesArrayAtom;
+  JSAtom invokeAtom;
+  JSAtom invokeSuspendingAtom;
+  JSAtom disconnectAtom;
   jclass booleanClass;
   jclass integerClass;
   jclass doubleClass;

--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -19,12 +19,13 @@
 #include <jni.h>
 #include <vector>
 #include <string>
+#include "quickjs/quickjs.h"
 
 class Context;
 
 class InboundCallChannel {
 public:
-  InboundCallChannel(const char *name);
+  InboundCallChannel(JSContext *jsContext, const char *name);
   ~InboundCallChannel();
 
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
@@ -32,7 +33,8 @@ public:
   void invokeSuspending(Context *context, JNIEnv* env, jstring instanceName, jstring funName, jobjectArray encodedArguments, jstring callbackName) const;
   jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
-  const std::string name;
+  JSContext *jsContext;
+  JSAtom nameAtom;
 };
 
 #endif //QUICKJS_ANDROID_INBOUNDCALLCHANNEL_H


### PR DESCRIPTION
I was doing useful work inside an assert() statement, and in release
builds that assert statement was optimized out.

Also convert QuickJS API uses to use JSAtom where possible. This is
represented as a single integer and should speed up some common operations.