### PR TITLE
Directly reference and optimize ThrowableSerializer

### DIFF
--- a/zipline-kotlin-plugin/tests/build.gradle.kts
+++ b/zipline-kotlin-plugin/tests/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   testImplementation(project(":zipline"))
   testImplementation(project(":zipline:testing"))
   testImplementation(kotlin("test-junit"))
+  testImplementation(Dependencies.kotlinReflect)
   testImplementation(Dependencies.kotlinxCoroutinesTest)
   testImplementation(kotlin("compiler-embeddable"))
   testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.1")

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -98,7 +98,6 @@ kotlin {
       dependsOn(engineMain)
       dependencies {
         api(Dependencies.androidxAnnotation)
-        api(Dependencies.kotlinReflect)
       }
     }
     val androidMain by getting {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -20,10 +20,8 @@ import app.cash.zipline.OutboundZiplineReference
 import app.cash.zipline.ZiplineReference
 import kotlin.js.JsName
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -81,23 +79,16 @@ internal const val LABEL_NULL = "n"
 internal const val LABEL_EXCEPTION = "t"
 
 internal object ThrowableSerializer : KSerializer<Throwable> {
-  override val descriptor: SerialDescriptor = ThrowableSurrogate.serializer().descriptor
+  override val descriptor = PrimitiveSerialDescriptor("ZiplineThrowable", PrimitiveKind.STRING)
 
   override fun serialize(encoder: Encoder, value: Throwable) {
-    val surrogate = ThrowableSurrogate(value.toString())
-    encoder.encodeSerializableValue(ThrowableSurrogate.serializer(), surrogate)
+    encoder.encodeString(value.toString())
   }
 
   override fun deserialize(decoder: Decoder): Throwable {
-    val surrogate = decoder.decodeSerializableValue(ThrowableSurrogate.serializer())
-    return Exception(surrogate.message)
+    return Exception(decoder.decodeString())
   }
 }
-
-@Serializable
-private class ThrowableSurrogate(
-  val message: String
-)
 
 /**
  * This is a special serializer because it's scoped to an endpoint. It is not a general-purpose

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -59,7 +59,6 @@ class Endpoint internal constructor(
 
   private fun computeSerializersModule(): SerializersModule {
     return SerializersModule {
-      contextual(Throwable::class, ThrowableSerializer)
       contextual(FlowReference::class) {
         FlowReferenceSerializer(ziplineReferenceSerializer, it[0])
       }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -18,7 +18,6 @@ package app.cash.zipline.internal.bridge
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.serializer
 
 /**
  * Generated code extends this base class to receive calls into an application-layer interface from
@@ -38,7 +37,6 @@ internal abstract class InboundBridge<T : Any> {
       useArrayPolymorphism = true
       serializersModule = this@Context.serializersModule
     }
-    val throwableSerializer = serializersModule.serializer<Throwable>()
   }
 }
 
@@ -97,8 +95,7 @@ internal class InboundCall(
 
   fun unexpectedFunction(): Array<String> = error("unexpected function: $funName")
 
-  @OptIn(ExperimentalStdlibApi::class)
   fun resultException(e: Throwable): Array<String> {
-    return arrayOf(LABEL_EXCEPTION, context.json.encodeToString(context.throwableSerializer, e))
+    return arrayOf(LABEL_EXCEPTION, context.json.encodeToString(ThrowableSerializer, e))
   }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.serializer
 
 /**
  * Generated code extends this base class to make calls into an application-layer interface that is
@@ -40,7 +39,6 @@ internal abstract class OutboundBridge<T : Any> {
       useArrayPolymorphism = true
       serializersModule = this@Context.serializersModule
     }
-    val throwableSerializer = serializersModule.serializer<Throwable>()
 
     fun newCall(funName: String, parameterCount: Int): OutboundCall {
       return OutboundCall(
@@ -137,7 +135,7 @@ internal class OutboundCall(
           return Result.success(context.json.decodeFromString(serializer, this[1]))
         }
         LABEL_EXCEPTION -> {
-          return Result.failure(context.json.decodeFromString(context.throwableSerializer, this[1]))
+          return Result.failure(context.json.decodeFromString(ThrowableSerializer, this[1]))
         }
         else -> i += 2
       }


### PR DESCRIPTION
This serializer is an internal encoding and should not be available for general contextual serialization.

Eliminate surrogate indirection for now as we only serialize a single string.