### PR TITLE
Rename the artifact for the native kotlin plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,10 @@ include(":zipline:testing")
 include(":zipline-gradle-plugin")
 include(":zipline-kotlin-plugin")
 include(":zipline-kotlin-plugin:hosted")
+project(":zipline-kotlin-plugin:hosted")
+  .apply {
+    name = "zipline-kotlin-plugin-hosted"
+  }
 include(":zipline-kotlin-plugin:tests")
 include(":zipline-tools")
 

--- a/zipline-gradle-plugin/build.gradle.kts
+++ b/zipline-gradle-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
 buildConfig {
   val compilerPlugin = project(":zipline-kotlin-plugin")
-  val compilerPluginHosted = project(":zipline-kotlin-plugin:hosted")
+  val compilerPluginHosted = project(":zipline-kotlin-plugin:zipline-kotlin-plugin-hosted")
   packageName("app.cash.zipline.gradle")
   buildConfigField("String", "KOTLIN_PLUGIN_ID", "\"${Ext.kotlinPluginId}\"")
   buildConfigField("String", "KOTLIN_PLUGIN_GROUP", "\"${compilerPlugin.group}\"")

--- a/zipline-kotlin-plugin/build.gradle.kts
+++ b/zipline-kotlin-plugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":zipline-kotlin-plugin:hosted"))
+  compileOnly(project(":zipline-kotlin-plugin:zipline-kotlin-plugin-hosted"))
 }
 
 val shadowJar = tasks.register("embeddedPlugin", ShadowJar::class.java) {

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -138,7 +138,7 @@ kotlin {
     targets.all {
       compilations.all {
         val pluginDependency = if (this is AbstractKotlinNativeCompilation) {
-          project(":zipline-kotlin-plugin:hosted")
+          project(":zipline-kotlin-plugin:zipline-kotlin-plugin-hosted")
         } else {
           project(":zipline-kotlin-plugin")
         }

--- a/zipline/testing/build.gradle.kts
+++ b/zipline/testing/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
   targets.all {
     compilations.all {
       val pluginDependency = if (this is AbstractKotlinNativeCompilation) {
-        project(":zipline-kotlin-plugin:hosted")
+        project(":zipline-kotlin-plugin:zipline-kotlin-plugin-hosted")
       } else {
         project(":zipline-kotlin-plugin")
       }


### PR DESCRIPTION
Before: 'app.cash.zipline:hosted'
After: 'app.cash.zipline:zipline-kotlin-plugin-hosted'