### PR TITLE
Modular JS builds

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -37,10 +37,9 @@ abstract class VersionWriterTask : DefaultTask() {
 val versionWriterTaskProvider = tasks.register("writeVersion", VersionWriterTask::class)
 
 val copyTestingJs = tasks.register<Copy>("copyTestingJs") {
-  // Development is not minified and has useful stack traces.
-  dependsOn(":zipline:testing:jsBrowserDevelopmentWebpack")
+  dependsOn(":zipline:testing:compileDevelopmentLibraryKotlinJs")
   destinationDir = buildDir.resolve("generated/testingJs")
-  from(projectDir.resolve("testing/build/developmentExecutable/testing.js"))
+  from(projectDir.resolve("testing/build/compileSync/main/developmentLibrary/kotlin"))
 }
 
 kotlin {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -24,9 +24,9 @@ import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.internal.bridge.InboundBridge
 import app.cash.zipline.internal.bridge.OutboundBridge
-import app.cash.zipline.internal.bridge.inboundChannelName
-import app.cash.zipline.internal.bridge.outboundChannelName
 import app.cash.zipline.internal.consoleName
+import app.cash.zipline.internal.currentModuleId
+import app.cash.zipline.internal.defineJs
 import app.cash.zipline.internal.eventLoopName
 import app.cash.zipline.internal.jsPlatformName
 import kotlinx.coroutines.CoroutineDispatcher
@@ -141,6 +141,12 @@ actual class Zipline private constructor(
     quickJs.close()
   }
 
+  fun loadJsModule(script: String, id: String) {
+    quickJs.evaluate("globalThis.$currentModuleId = '$id';")
+    quickJs.evaluate(script, id)
+    quickJs.evaluate("delete globalThis.$currentModuleId;")
+  }
+
   companion object {
     fun create(
       dispatcher: CoroutineDispatcher,
@@ -149,6 +155,7 @@ actual class Zipline private constructor(
       val quickJs = QuickJs.create()
       // TODO(jwilson): figure out a 512 KiB limit caused intermittent stack overflow failures.
       quickJs.maxStackSize = 0L
+      quickJs.evaluate(defineJs, "define.js")
 
       val scope = CoroutineScope(dispatcher)
       return Zipline(quickJs, scope)

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/defineJs.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/defineJs.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+internal const val currentModuleId = "app_cash_zipline_currentModuleId"
+
+/**
+ * Implement a AMD module loader for Kotlin/JS AMD modules running on QuickJS.
+ * https://github.com/amdjs/amdjs-api/blob/master/AMD.md
+ */
+internal const val defineJs =
+  """
+  (function initJsModuleApi() {
+    // Maps module IDs (like './kotlin-kotlin-stdlib-js-ir' or 'export') to their exports.
+    var idToExports = {};
+
+    // Retrieve an exported module. This doesn't need to be a global function, but it's convenient
+    // for callers who want access to a library they just loaded.
+    globalThis.require = function(id) {
+      var resolved = idToExports[id];
+      if (!resolved) {
+        throw Error('"' + id + '" not found in ' + JSON.stringify(Object.keys(idToExports)));
+      }
+      return resolved;
+    }
+
+    // This function accepts three arguments:
+    //   id: an optional string. If absent, use the currently-loading file name.
+    //   dependencies: an optional array of IDs, empty if absent.
+    //   factory: user code that consumes and exports dependencies. The arguments to this function
+    //      correspond 1:1 with the dependency names.
+    globalThis.define = function() {
+      var args = Array.from(arguments);
+      var factory = args.pop();
+      var dependencies = (args.length > 0) ? args.pop() : [];
+      var id = (args.length > 0) ? args.pop() : globalThis.$currentModuleId;
+      var exports = {};
+
+      var args = dependencies.map(dependency => {
+        if (dependency == 'exports') {
+          return exports;
+        } else if (dependency == 'require') {
+          return globalThis.require;
+        } else {
+          return globalThis.require(dependency);
+        }
+      });
+
+      factory(...args);
+
+      idToExports[id] = exports;
+    };
+
+    // By convention, we set 'define.amd' to an object to declare we confirm to the AMD spec.
+    globalThis.define.amd = {};
+  })();
+  """

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/testUtil.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/testUtil.kt
@@ -17,12 +17,88 @@ package app.cash.zipline
 
 import java.io.BufferedReader
 import kotlin.reflect.KClass
+import org.intellij.lang.annotations.Language
+
+// TODO
+// create arraylist of the files
+// load them all progressively into quickjs
+
+// may need to look at how require works, rewrite as an assertion or recursive loader
+// quickjs doesn't handle require natively so we need to write our own
+// define export and require such that require blows up if code with matching export hasn't been loaded yet
+// load code bottom up
 
 fun Zipline.loadTestingJs() {
-  val testingJs = Zipline::class.java.getResourceAsStream("/testing.js")!!
-    .bufferedReader()
-    .use(BufferedReader::readText)
-  quickJs.evaluate(testingJs, "testing.js")
+  // may need to add support for id set to null
+  @Language("Javascript")
+  val script = """
+    var loadedModuleExports = {};
+
+    globalThis.require = function(id) {
+      return loadedModuleExports[id];
+    }
+
+    globalThis.define = function() {
+      var args = Array.from(arguments);
+      var factory = args.pop();
+      var dependencies = (args.length == 0) ? [] : args.pop();
+      var id = (args.length == 0) ? null : args.pop();
+      var exports = {};
+
+      var args = dependencies.map(dependency => {
+        if (dependency == 'exports') {
+          return exports;
+        }
+        if (dependency == 'require') {
+          return require;
+        }
+
+        var resolved = loadedModuleExports[dependency];
+        if (!resolved) {
+          throw Error("unable to resolve " + dependency + " for module '" + id + "'");
+        }
+
+        return resolved;
+      });
+
+      var loaded = factory(...args);
+
+      if (id == null) {
+        id = globalThis.currentFileName
+      }
+      loadedModuleExports[id] = exports;
+    };
+
+    globalThis.define.amd = {};
+    """.trimIndent()
+  quickJs.evaluate(
+    script, "require-export.js"
+  )
+
+  // TODO add a manifest to the JS directory that includes this information as an ordered by load list
+  val files = listOf(
+    "kotlin-kotlin-stdlib-js-ir.js",
+    "88b0986a7186d029-atomicfu-js-ir.js",
+    "kotlinx-serialization-kotlinx-serialization-core-js-ir.js",
+    "kotlinx-serialization-kotlinx-serialization-json-js-ir.js",
+    "kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js",
+    "zipline-root-zipline.js",
+    "zipline-root-testing.js",
+  )
+
+  files.forEach { fileName ->
+    quickJs.evaluate("""
+      globalThis.currentFileName = "./$fileName"
+    """.trimIndent(), "filename-setter.js")
+    val fileJs = Zipline::class.java.getResourceAsStream("/$fileName")!!
+      .bufferedReader()
+      .use(BufferedReader::readText)
+    quickJs.evaluate(fileJs, fileName)
+  }
+
+  quickJs.evaluate("""
+    globalThis['testing'] = require('./zipline-root-testing.js');
+  """.trimIndent(), "symlink.js")
 }
 
 operator fun <T : Any> QuickJs.set(name: String, type: KClass<T>, instance: T) {

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/testUtil.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/testUtil.kt
@@ -17,88 +17,26 @@ package app.cash.zipline
 
 import java.io.BufferedReader
 import kotlin.reflect.KClass
-import org.intellij.lang.annotations.Language
 
-// TODO
-// create arraylist of the files
-// load them all progressively into quickjs
-
-// may need to look at how require works, rewrite as an assertion or recursive loader
-// quickjs doesn't handle require natively so we need to write our own
-// define export and require such that require blows up if code with matching export hasn't been loaded yet
-// load code bottom up
-
+/** Load our testing libraries into QuickJS. */
 fun Zipline.loadTestingJs() {
-  // may need to add support for id set to null
-  @Language("Javascript")
-  val script = """
-    var loadedModuleExports = {};
+  // TODO: currently our module loader requires modules to be topologically-sorted and loaded leaves
+  //     first. We could use some easier-to-use abstractions here.
+  loadJsModuleFromResource("./kotlin-kotlin-stdlib-js-ir.js")
+  loadJsModuleFromResource("./88b0986a7186d029-atomicfu-js-ir.js")
+  loadJsModuleFromResource("./kotlinx-serialization-kotlinx-serialization-core-js-ir.js")
+  loadJsModuleFromResource("./kotlinx-serialization-kotlinx-serialization-json-js-ir.js")
+  loadJsModuleFromResource("./kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js")
+  loadJsModuleFromResource("./zipline-root-zipline.js")
+  loadJsModuleFromResource("./zipline-root-testing.js")
+  quickJs.evaluate("globalThis['testing'] = require('./zipline-root-testing.js');")
+}
 
-    globalThis.require = function(id) {
-      return loadedModuleExports[id];
-    }
-
-    globalThis.define = function() {
-      var args = Array.from(arguments);
-      var factory = args.pop();
-      var dependencies = (args.length == 0) ? [] : args.pop();
-      var id = (args.length == 0) ? null : args.pop();
-      var exports = {};
-
-      var args = dependencies.map(dependency => {
-        if (dependency == 'exports') {
-          return exports;
-        }
-        if (dependency == 'require') {
-          return require;
-        }
-
-        var resolved = loadedModuleExports[dependency];
-        if (!resolved) {
-          throw Error("unable to resolve " + dependency + " for module '" + id + "'");
-        }
-
-        return resolved;
-      });
-
-      var loaded = factory(...args);
-
-      if (id == null) {
-        id = globalThis.currentFileName
-      }
-      loadedModuleExports[id] = exports;
-    };
-
-    globalThis.define.amd = {};
-    """.trimIndent()
-  quickJs.evaluate(
-    script, "require-export.js"
-  )
-
-  // TODO add a manifest to the JS directory that includes this information as an ordered by load list
-  val files = listOf(
-    "kotlin-kotlin-stdlib-js-ir.js",
-    "88b0986a7186d029-atomicfu-js-ir.js",
-    "kotlinx-serialization-kotlinx-serialization-core-js-ir.js",
-    "kotlinx-serialization-kotlinx-serialization-json-js-ir.js",
-    "kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js",
-    "zipline-root-zipline.js",
-    "zipline-root-testing.js",
-  )
-
-  files.forEach { fileName ->
-    quickJs.evaluate("""
-      globalThis.currentFileName = "./$fileName"
-    """.trimIndent(), "filename-setter.js")
-    val fileJs = Zipline::class.java.getResourceAsStream("/$fileName")!!
-      .bufferedReader()
-      .use(BufferedReader::readText)
-    quickJs.evaluate(fileJs, fileName)
-  }
-
-  quickJs.evaluate("""
-    globalThis['testing'] = require('./zipline-root-testing.js');
-  """.trimIndent(), "symlink.js")
+private fun Zipline.loadJsModuleFromResource(fileName: String) {
+  val fileJs = Zipline::class.java.getResourceAsStream(fileName.removePrefix("."))!!
+    .bufferedReader()
+    .use(BufferedReader::readText)
+  loadJsModule(fileJs, fileName)
 }
 
 operator fun <T : Any> QuickJs.set(name: String, type: KClass<T>, instance: T) {

--- a/zipline/testing/build.gradle.kts
+++ b/zipline/testing/build.gradle.kts
@@ -66,8 +66,6 @@ kotlin {
 tasks {
   withType(KotlinJsCompile::class.java).all {
     kotlinOptions {
-//      sourceMap = true
-//      sourceMapEmbedSources = "always"
       freeCompilerArgs += listOf("-Xir-per-module")
     }
   }

--- a/zipline/testing/build.gradle.kts
+++ b/zipline/testing/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -12,7 +13,7 @@ kotlin {
 
   js {
     browser()
-    binaries.executable()
+    binaries.library()
   }
 
   linuxX64()
@@ -58,6 +59,16 @@ kotlin {
         target.disambiguationClassifier.orEmpty().capitalize() +
         compilationName.capitalize()
       project.dependencies.add(pluginConfigurationName, pluginDependency)
+    }
+  }
+}
+
+tasks {
+  withType(KotlinJsCompile::class.java).all {
+    kotlinOptions {
+//      sourceMap = true
+//      sourceMapEmbedSources = "always"
+      freeCompilerArgs += listOf("-Xir-per-module")
     }
   }
 }

--- a/zipline/testing/webpack.config.d/externals.js
+++ b/zipline/testing/webpack.config.d/externals.js
@@ -1,0 +1,6 @@
+//config.externals = {
+//  kotlin: 'kotlin'
+//};
+//
+//
+////HELLO WORLD

--- a/zipline/testing/webpack.config.d/externals.js
+++ b/zipline/testing/webpack.config.d/externals.js
@@ -1,6 +1,0 @@
-//config.externals = {
-//  kotlin: 'kotlin'
-//};
-//
-//
-////HELLO WORLD


### PR DESCRIPTION
Split compiled JS output into respective files and load separately into QuickJS to allow future developments such as OTA updates of much smaller JS files for changed app code but rely on Kotlin STD lib and other library code which changes less frequently that's shipped in app releases.