### PR TITLE
Less ugly exceptions

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -82,11 +82,11 @@ internal object ThrowableSerializer : KSerializer<Throwable> {
   override val descriptor = PrimitiveSerialDescriptor("ZiplineThrowable", PrimitiveKind.STRING)
 
   override fun serialize(encoder: Encoder, value: Throwable) {
-    encoder.encodeString(value.stackTraceToString())
+    encoder.encodeString(toOutboundString(value))
   }
 
   override fun deserialize(decoder: Decoder): Throwable {
-    return Exception(decoder.decodeString())
+    return toInboundThrowable(decoder.decodeString())
   }
 }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+internal expect fun toOutboundString(throwable: Throwable): String
+
+internal expect fun toInboundThrowable(string: String): Throwable

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/throwablesJni.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/throwablesJni.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+/** When encoding a stacktrace, chop Zipline frames off below the inbound call. */
+internal actual fun toOutboundString(throwable: Throwable): String {
+  for ((index, element) in throwable.stackTrace.withIndex()) {
+    if (element.className.startsWith(Endpoint::class.qualifiedName!!)) {
+      throwable.stackTrace = throwable.stackTrace.sliceArray(0 until index)
+      break
+    }
+  }
+
+  return throwable.stackTraceToString()
+}
+
+/** When decoding a stacktrace, chop Zipline frames off above the outbound call. */
+internal actual fun toInboundThrowable(string: String): Throwable {
+  // Strip empty lines and format 'at' to match java.lang.Throwable.
+  val canonicalString = string
+    .replace(Regex("\n[ ]+at "), "\n\tat ")
+    .replace(Regex("\n+"), "\n")
+    .trim()
+  val result = Exception(canonicalString)
+
+  val stackTrace = result.stackTrace
+  for (i in stackTrace.size - 1 downTo 0) {
+    if (stackTrace[i].className == OutboundCall::class.qualifiedName) {
+      result.stackTrace = stackTrace.sliceArray(i + 1 until stackTrace.size)
+      break
+    }
+  }
+
+  return result
+}

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ExceptionsTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ExceptionsTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.EchoRequest
+import app.cash.zipline.testing.EchoResponse
+import app.cash.zipline.testing.EchoService
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExceptionsTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher)
+
+  @Before fun setUp(): Unit = runBlocking(dispatcher) {
+    zipline.loadTestingJs()
+  }
+
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
+    zipline.close()
+  }
+
+  @Test fun jvmCallJsServiceThatThrows(): Unit = runBlocking(dispatcher) {
+    zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareThrowingJsBridges()")
+
+    val service = zipline.get<EchoService>("throwingService")
+
+    assertThat(assertFailsWith<Exception> {
+      service.echo(EchoRequest("Jake"))
+    }.stackTraceToString()).apply {
+      matches(
+        """(?s).*IllegalStateException: boom!""" +
+          """.*at goBoom1""" +
+          """.*at goBoom2""" +
+          """.*at goBoom3""" +
+          """.*"""
+      )
+    }
+  }
+
+  @Test fun jsCallJvmServiceThatThrows(): Unit = runBlocking(dispatcher) {
+    zipline.set<EchoService>("throwingService", JvmThrowingEchoService())
+
+    assertThat(assertFailsWith<QuickJsException> {
+      zipline.quickJs.evaluate("testing.app.cash.zipline.testing.callThrowingService('homie')")
+    }.stackTraceToString()).apply {
+      matches(
+        """(?s).*java\.lang\.IllegalStateException: boom!""" +
+          """.*JvmThrowingEchoService\.goBoom1""" +
+          """.*JvmThrowingEchoService\.goBoom2""" +
+          """.*JvmThrowingEchoService\.goBoom3""" +
+          """.*JvmThrowingEchoService\.echo""" +
+          """.*"""
+      )
+    }
+  }
+
+  @Test fun jvmCallJsCallsJvmServiceThatThrows(): Unit = runBlocking(dispatcher) {
+    zipline.set<EchoService>("throwingService", JvmThrowingEchoService())
+    zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareDelegatingService()")
+
+    val service = zipline.get<EchoService>("delegatingService")
+
+    assertThat(assertFailsWith<Exception> {
+      service.echo(EchoRequest("Jake"))
+    }.stackTraceToString()).apply {
+      matches(
+        """(?s).*IllegalStateException: boom!""" +
+          """.*at .*JvmThrowingEchoService\.goBoom1""" +
+          """.*at .*JvmThrowingEchoService\.goBoom2""" +
+          """.*at .*JvmThrowingEchoService\.goBoom3""" +
+          """.*at .*JvmThrowingEchoService\.echo""" +
+          """.*at delegate1""" +
+          """.*at delegate2""" +
+          """.*at delegate3""" +
+          """.*"""
+      )
+    }
+  }
+
+  private class JvmThrowingEchoService : EchoService {
+    override fun echo(request: EchoRequest): EchoResponse {
+      goBoom3()
+    }
+    private fun goBoom3(): Nothing {
+      goBoom2()
+    }
+    private fun goBoom2(): Nothing {
+      goBoom1()
+    }
+    private fun goBoom1(): Nothing {
+      throw IllegalStateException("boom!")
+    }
+  }
+}

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/throwablesJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/throwablesJs.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+internal actual fun toOutboundString(throwable: Throwable): String = throwable.stackTraceToString()
+
+internal actual fun toInboundThrowable(string: String): Throwable = Exception(string)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/throwablesNative.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/throwablesNative.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+internal actual fun toOutboundString(throwable: Throwable): String = throwable.stackTraceToString()
+
+internal actual fun toInboundThrowable(string: String): Throwable = Exception(string)

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
@@ -39,23 +39,3 @@ fun callSupService(message: String): String {
   val echoResponse = supService.echo(EchoRequest(message))
   return "JavaScript received '${echoResponse.message}' from the JVM"
 }
-
-class JsThrowingEchoService : EchoService {
-  override fun echo(request: EchoRequest): EchoResponse {
-    goBoom3()
-  }
-  private fun goBoom3(): Nothing {
-    goBoom2()
-  }
-  private fun goBoom2(): Nothing {
-    goBoom1()
-  }
-  private fun goBoom1(): Nothing {
-    throw IllegalStateException("boom!")
-  }
-}
-
-@JsExport
-fun prepareThrowingJsBridges() {
-  zipline.set<EchoService>("helloService", JsThrowingEchoService())
-}

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/throwingJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/throwingJs.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import app.cash.zipline.Zipline
+
+class JsThrowingEchoService : EchoService {
+  override fun echo(request: EchoRequest): EchoResponse {
+    goBoom3()
+  }
+  private fun goBoom3(): Nothing {
+    goBoom2()
+  }
+  private fun goBoom2(): Nothing {
+    goBoom1()
+  }
+  private fun goBoom1(): Nothing {
+    throw IllegalStateException("boom!")
+  }
+}
+
+class JsDelegatingEchoService(
+  private val delegate: EchoService
+) : EchoService {
+  override fun echo(request: EchoRequest): EchoResponse {
+    return delegate3(request)
+  }
+  private fun delegate3(request: EchoRequest): EchoResponse {
+    return delegate2(request)
+  }
+  private fun delegate2(request: EchoRequest): EchoResponse {
+    return delegate1(request)
+  }
+  private fun delegate1(request: EchoRequest): EchoResponse {
+    return delegate.echo(request)
+  }
+}
+
+private val zipline by lazy { Zipline.get() }
+
+@JsExport
+fun prepareThrowingJsBridges() {
+  zipline.set<EchoService>("throwingService", JsThrowingEchoService())
+}
+
+@JsExport
+fun callThrowingService(message: String): String {
+  val service = zipline.get<EchoService>("throwingService")
+  val echoResponse = service.echo(EchoRequest(message))
+  return "JavaScript received '${echoResponse.message}' from the JVM"
+}
+
+@JsExport
+fun prepareDelegatingService() {
+  val delegate = zipline.get<EchoService>("throwingService")
+  zipline.set<EchoService>("delegatingService", JsDelegatingEchoService(delegate))
+}


### PR DESCRIPTION
Before:

```
java.lang.Exception: Exception: java.lang.IllegalStateException: boom!
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom1(ExceptionsTest.kt:112)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom2(ExceptionsTest.kt:109)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom3(ExceptionsTest.kt:106)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.echo(ExceptionsTest.kt:103)
  at app.cash.zipline.ExceptionsTest$jvmCallJsCallsJvmServiceThatThrows$1$1$create$1.call(ExceptionsTest.kt:79)
  at app.cash.zipline.internal.bridge.Endpoint$inboundChannel$1.invoke(Endpoint.kt:83)
  at app.cash.zipline.JniCallChannel.invoke(Native Method)
  at app.cash.zipline.JniCallChannel.invoke(JniCallChannel.kt:35)
  at app.cash.zipline.Zipline$endpoint$1.invoke(Zipline.kt:60)
  at app.cash.zipline.internal.bridge.OutboundCall.invoke(outbound.kt:87)
  at app.cash.zipline.ExceptionsTest$jvmCallJsCallsJvmServiceThatThrows$1$service$1$create$1.echo(ExceptionsTest.kt:82)

    at captureStack (./kotlin-kotlin-stdlib-js-ir.js:20884)
    at Exception_init_$Create$_0 (./kotlin-kotlin-stdlib-js-ir.js:23000)
    at toInboundThrowable (./zipline-root-zipline.js:1922)
    at <anonymous> (./zipline-root-zipline.js:911)
    at decodeSerializableValuePolymorphic (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:2493)
    at <anonymous> (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:2936)
    at <anonymous> (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:271)
    at decodeResult (./zipline-root-zipline.js:1631)
    at <anonymous> (./zipline-root-zipline.js:1851)
    at <anonymous> (./zipline-root-testing.js:2085)
    at delegate1 (./zipline-root-testing.js:1894)
    at delegate2 (./zipline-root-testing.js:1891)
    at delegate3 (./zipline-root-testing.js:1888)
    at <anonymous> (./zipline-root-testing.js:1900)
    at <anonymous> (./zipline-root-testing.js:2146)
    at <anonymous> (./zipline-root-zipline.js:1130)
    at <anonymous> (./zipline-root-zipline.js:1145)


  at app.cash.zipline.internal.bridge.ThrowablesJniKt.toInboundThrowable(throwablesJni.kt:32)
  at app.cash.zipline.internal.bridge.ThrowableSerializer.deserialize(CallChannel.kt:89)
  at app.cash.zipline.internal.bridge.ThrowableSerializer.deserialize(CallChannel.kt:81)
  at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:59)
  at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:35)
  at kotlinx.serialization.json.Json.decodeFromString(Json.kt:100)
  at app.cash.zipline.internal.bridge.OutboundCall.decodeResult-gIAlu-s(outbound.kt:138)
  at app.cash.zipline.internal.bridge.OutboundCall.invoke(outbound.kt:93)
  at app.cash.zipline.ExceptionsTest$jvmCallJsCallsJvmServiceThatThrows$1$service$1$create$1.echo(ExceptionsTest.kt:82)
```

After:

```
java.lang.Exception: Exception: java.lang.IllegalStateException: boom!
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom1(ExceptionsTest.kt:112)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom2(ExceptionsTest.kt:109)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.goBoom3(ExceptionsTest.kt:106)
  at app.cash.zipline.ExceptionsTest$JvmThrowingEchoService.echo(ExceptionsTest.kt:103)
  at app.cash.zipline.ExceptionsTest$jvmCallJsCallsJvmServiceThatThrows$1$1$create$1.call(ExceptionsTest.kt:79)
  at captureStack (./kotlin-kotlin-stdlib-js-ir.js:20884)
  at Exception_init_$Create$_0 (./kotlin-kotlin-stdlib-js-ir.js:23000)
  at toInboundThrowable (./zipline-root-zipline.js:1922)
  at <anonymous> (./zipline-root-zipline.js:911)
  at decodeSerializableValuePolymorphic (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:2493)
  at <anonymous> (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:2936)
  at <anonymous> (./kotlinx-serialization-kotlinx-serialization-json-js-ir.js:271)
  at decodeResult (./zipline-root-zipline.js:1631)
  at <anonymous> (./zipline-root-zipline.js:1851)
  at <anonymous> (./zipline-root-testing.js:2085)
  at delegate1 (./zipline-root-testing.js:1894)
  at delegate2 (./zipline-root-testing.js:1891)
  at delegate3 (./zipline-root-testing.js:1888)
  at <anonymous> (./zipline-root-testing.js:1900)
  at <anonymous> (./zipline-root-testing.js:2146)
  at <anonymous> (./zipline-root-zipline.js:1130)
  at <anonymous> (./zipline-root-zipline.js:1145)
  at app.cash.zipline.ExceptionsTest$jvmCallJsCallsJvmServiceThatThrows$1$service$1$create$1.echo(ExceptionsTest.kt:82)
```
