### PR TITLE
Support exceptions in Console.log

### DIFF
--- a/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/androidMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -18,12 +18,11 @@ package app.cash.zipline.internal
 import android.util.Log
 
 internal actual object HostConsole : Console {
-  override fun log(level: String, message: String) {
-    val priority = when (level) {
-      "warn" -> Log.WARN
-      "error" -> Log.ERROR
-      else -> Log.INFO
+  override fun log(level: String, message: String, throwable: Throwable?) {
+    when (level) {
+      "warn" -> Log.w("Zipline", message, throwable)
+      "error" -> Log.e("Zipline", message, throwable)
+      else ->  Log.i("Zipline", message, throwable)
     }
-    Log.println(priority, "Zipline", message)
   }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -59,6 +59,7 @@ class Endpoint internal constructor(
 
   private fun computeSerializersModule(): SerializersModule {
     return SerializersModule {
+      contextual(Throwable::class, ThrowableSerializer)
       contextual(FlowReference::class) {
         FlowReferenceSerializer(ziplineReferenceSerializer, it[0])
       }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
@@ -26,7 +26,7 @@ internal interface EventLoop {
 
 internal interface Console {
   /** @param level one of `log`, `info`, `warn`, or `error`. */
-  fun log(level: String, message: String)
+  fun log(level: String, message: String, throwable: Throwable?)
 }
 
 internal interface JsPlatform {

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -152,7 +152,7 @@ actual class QuickJs private constructor(
 
   protected fun finalize() {
     if (context != 0L) {
-      HostConsole.log("warn", "QuickJs instance leaked!")
+      HostConsole.log("warn", "QuickJs instance leaked!", null)
     }
   }
 

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -188,7 +188,16 @@ private class RealJsPlatform(
    */
   @JsName("consoleMessage")
   fun consoleMessage(level: String, vararg arguments: Any?) {
-    console.log(level, arguments.joinToString(separator = " "))
+    var throwable: Throwable? = null
+    val argumentsList = mutableListOf<Any?>()
+    for (argument in arguments) {
+      if (throwable == null && argument is Throwable) {
+        throwable = argument
+      } else {
+        argumentsList += argument
+      }
+    }
+    console.log(level, argumentsList.joinToString(separator = " "), throwable)
   }
 
   private class Job(

--- a/zipline/src/jvmMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/jvmMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -16,16 +16,17 @@
 package app.cash.zipline.internal
 
 import app.cash.zipline.Zipline
+import java.util.logging.Level
 import java.util.logging.Logger
 
 internal actual object HostConsole : Console {
   private val logger = Logger.getLogger(Zipline::class.qualifiedName)
 
-  override fun log(level: String, message: String) {
+  override fun log(level: String, message: String, throwable: Throwable?) {
     when (level) {
-      "warn" -> logger.warning(message)
-      "error" -> logger.severe(message)
-      else -> logger.info(message)
+      "warn" -> logger.log(Level.WARNING, message, throwable)
+      "error" -> logger.log(Level.SEVERE, message, throwable)
+      else -> logger.log(Level.INFO, message, throwable)
     }
   }
 }

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/HostConsole.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/HostConsole.kt
@@ -16,7 +16,11 @@
 package app.cash.zipline.internal
 
 internal actual object HostConsole : Console {
-  override fun log(level: String, message: String) {
-    println("Zipline[$level]: $message")
+  override fun log(level: String, message: String, throwable: Throwable?) {
+    if (throwable != null) {
+      println("Zipline[$level]: $message\n${throwable.stackTraceToString()}")
+    } else {
+      println("Zipline[$level]: $message")
+    }
   }
 }

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/console.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/console.kt
@@ -28,3 +28,32 @@ fun consoleLogAllLevels() {
 fun consoleLogWithArguments() {
   console.info("this message for %s is a %d out of %d", "Jesse", 8, 10)
 }
+
+@JsExport
+fun consoleLogWithThrowable() {
+  try {
+    goBoom3()
+  } catch (e: Throwable) {
+    console.error("1. something went wrong", e)
+  }
+  console.error(IllegalStateException("2. exception only"))
+  console.error(
+    "3. multiple exceptions",
+    IllegalStateException("number one!"),
+    IllegalStateException("number two!")
+  )
+  console.error(IllegalStateException("exception first!"), "4. message second")
+  console.info("5. info with exception", IllegalStateException())
+}
+
+private fun goBoom3(): Nothing {
+  goBoom2()
+}
+
+private fun goBoom2(): Nothing {
+  goBoom1()
+}
+
+private fun goBoom1(): Nothing {
+  throw IllegalStateException("boom!")
+}


### PR DESCRIPTION
Previously we were calling toString() on them and losing stack traces.