### PR TITLE
Fix problems with module loading

### DIFF
--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/defineJs.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/defineJs.kt
@@ -59,9 +59,9 @@ internal const val defineJs =
         }
       });
 
-      factory(...args);
+      var result = factory(...args);
 
-      idToExports[id] = exports;
+      idToExports[id] = result || exports;
     };
 
     // By convention, we set 'define.amd' to an object to declare we confirm to the AMD spec.

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/LoadJsModuleTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/LoadJsModuleTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * This exercises the code in [app.cash.zipline.internal.defineJs] to confirm that Zipline can load
+ * modules in the standard forms that the Kotlin compiler produces.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoadJsModuleTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher)
+
+  @Before fun setUp(): Unit = runBlocking(dispatcher) {
+  }
+
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
+    zipline.close()
+  }
+
+  @Test fun factoryPopulatesExports(): Unit = runBlocking(dispatcher) {
+    val moduleJs = """
+      (function (root, factory) {
+        if (typeof define === 'function' && define.amd)
+          define(['exports'], factory);
+        else if (typeof exports === 'object')
+          factory(module.exports);
+        else
+          root['example'] = factory(typeof this['example'] === 'undefined' ? {} : this['example']);
+      }(this, function (_) {
+        _.someValue = 4321;
+      }));
+    """.trimIndent()
+    zipline.loadJsModule(moduleJs, "example")
+    assertThat(zipline.quickJs.evaluate("JSON.stringify(require('example'))"))
+      .isEqualTo("""{"someValue":4321}""")
+  }
+
+  @Test fun factoryReturnsExports(): Unit = runBlocking(dispatcher) {
+    val moduleJs = """
+      (function webpackUniversalModuleDefinition(root, factory) {
+        if(typeof exports === 'object' && typeof module === 'object')
+          module.exports = factory();
+        else if(typeof define === 'function' && define.amd)
+          define([], factory);
+        else if(typeof exports === 'object')
+          exports["example"] = factory();
+        else
+          root["example"] = factory();
+      })(this, function() {
+        return {
+          someValue: 1234
+        };
+      });
+    """.trimIndent()
+    zipline.loadJsModule(moduleJs, "example")
+    assertThat(zipline.quickJs.evaluate("JSON.stringify(require('example'))"))
+      .isEqualTo("""{"someValue":1234}""")
+  }
+}


### PR DESCRIPTION
When I added support for loading Kotlin/JS-generated libraries I broke support
for loading Kotlin/JS-generated executables. This should fix that.