### PR TITLE
Unbreak imports of extension functions

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -193,9 +193,6 @@ android {
     }
 
     packagingOptions {
-      // Ensure we do not rely on the presence of metadata or module files for Kotlin reflection.
-      exclude("META-INF/*.kotlin_module")
-      exclude("kotlin/**")
       // We get multiple copies of some license files via JNA, which is a transitive dependency of
       // kotlinx-coroutines-test. Don't fail the build on these duplicates.
       exclude("META-INF/AL2.0")


### PR DESCRIPTION
Excluding these breaks builds in downstream projects.
https://stackoverflow.com/questions/61450260/extension-function-cant-be-imported-from-library