### PR TITLE
Free "compiled" if "compiled" is an exception.

### DIFF
--- a/zipline/native/Context.cpp
+++ b/zipline/native/Context.cpp
@@ -177,6 +177,7 @@ jbyteArray Context::compile(JNIEnv* env, jstring source, jstring file) {
   if (JS_IsException(compiled)) {
     // TODO: figure out how to get the failing line number into the exception.
     throwJsException(env, compiled);
+    JS_FreeValue(jsContext, compiled);
     return nullptr;
   }
 


### PR DESCRIPTION
Avoid the probable memory leak in "compile" API.
Fix the bug "https://github.com/cashapp/zipline/issues/314".