### PR TITLE
Include function names in QuickJS binaries

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -197,6 +197,11 @@ android {
       // kotlinx-coroutines-test. Don't fail the build on these duplicates.
       exclude("META-INF/AL2.0")
       exclude("META-INF/LGPL2.1")
+
+      // Keep debug symbols to get function names if QuickJS crashes in native code. This grows the
+      // release libquickjs.so artifact from 793 KiB to 2.1 MiB. (We expect that release builds of
+      // applications will strip these away later.)
+      jniLibs.keepDebugSymbols += "**/libquickjs.so"
     }
   }
 


### PR DESCRIPTION
This makes debugging much easier.

```diff
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'Android/sdk_phone_x86/generic_x86:11/RSR1.210210.001.A1/7193139:userdebug/dev-keys'
Revision: '0'
ABI: 'x86'
Timestamp: 2021-12-10 14:23:15-0500
pid: 13456, tid: 13622, name: Treehouse  >>> com.squareup.cash.beta.debug <<<
uid: 10123
signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
    eax 00000000  ebx 00003490  ecx 00003536  edx 00000006
    edi f15a781e  esi b1e4cf90
    ebp f718db90  esp b1e4cf38  eip f718db99
backtrace:
      #00 pc 00000b99  [vdso] (__kernel_vsyscall+9)
      #01 pc 0005ad68  /apex/com.android.runtime/lib/bionic/libc.so (syscall+40) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
      #02 pc 00076511  /apex/com.android.runtime/lib/bionic/libc.so (abort+209) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #03 pc 0001c2fe  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #03 pc 0001c3fb  .../lib/x86/libquickjs.so (lre_exec_backtrack+8859) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
      #04 pc 0001a040  .../lib/x86/libquickjs.so (lre_exec+512) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #05 pc 00083e69  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #06 pc 00026c10  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #07 pc 000419f6  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #08 pc 0003489b  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #09 pc 00088bee  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #10 pc 000853de  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #11 pc 00026c10  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #12 pc 000419f6  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #13 pc 0003489b  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #14 pc 000dadf9  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #15 pc 00026cbb  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #16 pc 000419f6  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
-      #17 pc 00043d75  .../lib/x86/libquickjs.so (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #05 pc 00083f9f  .../lib/x86/libquickjs.so (js_regexp_exec+1119) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #06 pc 00026d10  .../lib/x86/libquickjs.so (js_call_c_function+800) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #07 pc 00041af6  .../lib/x86/libquickjs.so (JS_CallInternal+854) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #08 pc 0003499b  .../lib/x86/libquickjs.so (JS_CallFree+187) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #09 pc 00088d2e  .../lib/x86/libquickjs.so (JS_RegExpExec+318) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #10 pc 0008551e  .../lib/x86/libquickjs.so (js_regexp_Symbol_replace+1454) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #11 pc 00026d10  .../lib/x86/libquickjs.so (js_call_c_function+800) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #12 pc 00041af6  .../lib/x86/libquickjs.so (JS_CallInternal+854) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #13 pc 0003499b  .../lib/x86/libquickjs.so (JS_CallFree+187) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #14 pc 000db05f  .../lib/x86/libquickjs.so (js_string_replace+1151) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #15 pc 00026dbb  .../lib/x86/libquickjs.so (js_call_c_function+971) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #16 pc 00041af6  .../lib/x86/libquickjs.so (JS_CallInternal+854) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
+      #17 pc 00043e75  .../lib/x86/libquickjs.so (JS_CallInternal+9941) (BuildId: 2539dc85945961cb383130f6aae24a219f935b45)
```