### PR TITLE
ZiplineService

### DIFF
--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -1,0 +1,799 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.kotlin
+
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
+import org.jetbrains.kotlin.backend.common.ir.createImplicitParameterDeclarationWithWrappedDescriptor
+import org.jetbrains.kotlin.backend.common.ir.isSuspend
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
+import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.declarations.addConstructor
+import org.jetbrains.kotlin.ir.builders.declarations.addDispatchReceiver
+import org.jetbrains.kotlin.ir.builders.declarations.addFunction
+import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
+import org.jetbrains.kotlin.ir.builders.declarations.buildClass
+import org.jetbrains.kotlin.ir.builders.irBlock
+import org.jetbrains.kotlin.ir.builders.irBranch
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irElseBranch
+import org.jetbrains.kotlin.ir.builders.irEquals
+import org.jetbrains.kotlin.ir.builders.irExprBody
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irInt
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.builders.irTemporary
+import org.jetbrains.kotlin.ir.builders.irWhen
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrFactory
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrBranch
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.getPropertyGetter
+import org.jetbrains.kotlin.ir.util.patchDeclarationParents
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Adds an `Adapter` nested class to the companion object of an interface that extends
+ * `ZiplineService`. See `SampleService.Companion.ManualAdapter` for a sample implementation
+ * that this class attempts to generate.
+ */
+internal class AdapterGenerator(
+  private val pluginContext: IrPluginContext,
+  private val ziplineApis: ZiplineApis,
+  private val original: IrClass
+) {
+  private val irFactory: IrFactory
+    get() = pluginContext.irFactory
+
+  fun generateAdapterIfAbsent(): IrClass {
+    val companion = original.getOrCreateCompanion(pluginContext)
+    val adapterClass = getOrCreateAdapterClass(companion)
+    companion.declarations += adapterClass
+    companion.patchDeclarationParents(original)
+    return adapterClass
+  }
+
+  private fun getOrCreateAdapterClass(
+    companion: IrClass
+  ): IrClass {
+    // object Adapter : ZiplineServiceAdapter<SampleService>() {
+    //   ...
+    // }
+    val existing = companion.declarations.firstOrNull {
+      it is IrClass && it.name.identifier == "Adapter"
+    }
+    if (existing != null) return existing as IrClass
+
+    val adapterClass = irFactory.buildClass {
+      initDefaults(original)
+      name = Name.identifier("Adapter")
+      kind = ClassKind.OBJECT
+      visibility = DescriptorVisibilities.PUBLIC
+    }.apply {
+      parent = companion
+      superTypes = listOf(ziplineApis.ziplineServiceAdapter.typeWith(original.defaultType))
+      createImplicitParameterDeclarationWithWrappedDescriptor()
+    }
+
+    adapterClass.addConstructor {
+      initDefaults(adapterClass)
+      visibility = DescriptorVisibilities.PRIVATE
+    }.apply {
+      irConstructorBody(pluginContext) { statements ->
+        statements += irDelegatingConstructorCall(
+          context = pluginContext,
+          symbol = ziplineApis.ziplineServiceAdapter.constructors.single(),
+          typeArgumentsCount = 1
+        ) {
+          putTypeArgument(0, original.defaultType)
+        }
+        statements += irInstanceInitializerCall(
+          context = pluginContext,
+          classSymbol = adapterClass.symbol,
+        )
+      }
+    }
+
+    val serialNameProperty = irSerialNameProperty(adapterClass)
+    adapterClass.declarations += serialNameProperty
+
+    val inboundBridgedInterface = BridgedInterface.create(
+      pluginContext,
+      ziplineApis,
+      original,
+      "Zipline.get()",
+      original.defaultType
+    )
+    val outboundBridgedInterface = BridgedInterface.create(
+      pluginContext,
+      ziplineApis,
+      original,
+      "Zipline.get()",
+      original.defaultType
+    )
+
+    val inboundCallHandlerClass = irInboundCallHandlerClass(inboundBridgedInterface, adapterClass)
+    val inboundCallHandlerFunction = irInboundCallHandlerFunction(
+      bridgedInterface = inboundBridgedInterface,
+      adapterClass = adapterClass,
+      inboundCallHandlerClass = inboundCallHandlerClass,
+    )
+
+    val outboundServiceClass = irOutboundServiceClass(outboundBridgedInterface, adapterClass)
+    val outboundServiceFunction = irOutboundServiceFunction(
+      bridgedInterface = outboundBridgedInterface,
+      adapterClass = adapterClass,
+      outboundServiceClass = outboundServiceClass,
+    )
+
+    adapterClass.declarations += inboundCallHandlerClass
+    adapterClass.declarations += outboundServiceClass
+
+    adapterClass.addFakeOverrides(
+      pluginContext.irBuiltIns,
+      listOf(
+        serialNameProperty,
+        inboundCallHandlerFunction,
+        outboundServiceFunction
+      )
+    )
+
+    return adapterClass
+  }
+
+  /**
+   * Override `ZiplineServiceAdapter.serialName`. The constant value is the service's simple name,
+   * like "SampleService".
+   */
+  private fun irSerialNameProperty(adapterClass: IrClass): IrProperty {
+    return irVal(
+      pluginContext = pluginContext,
+      propertyType = pluginContext.symbols.string.defaultType,
+      declaringClass = adapterClass,
+      propertyName = ziplineApis.ziplineServiceAdapterSerialName.owner.name,
+      overriddenProperty = ziplineApis.ziplineServiceAdapterSerialName,
+    ) {
+      irExprBody(irString(original.name.identifier))
+    }
+  }
+
+  /** Override `ZiplineServiceAdapter.inboundCallHandler()`. */
+  private fun irInboundCallHandlerFunction(
+    bridgedInterface: BridgedInterface,
+    adapterClass: IrClass,
+    inboundCallHandlerClass: IrClass,
+  ): IrSimpleFunction {
+    // override fun inboundCallHandler(context: InboundBridge.Context): InboundCallHandler {
+    // }
+    val inboundCallHandlerFunction = adapterClass.addFunction {
+      initDefaults(original)
+      name = ziplineApis.ziplineServiceAdapterInboundCallHandler.owner.name
+      returnType = ziplineApis.inboundCallHandler.defaultType
+    }.apply {
+      addDispatchReceiver {
+        initDefaults(original)
+        type = adapterClass.defaultType
+      }
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("service")
+        type = bridgedInterface.type
+      }
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("context")
+        type = ziplineApis.inboundBridgeContext.defaultType
+      }
+      overriddenSymbols = listOf(ziplineApis.ziplineServiceAdapterInboundCallHandler)
+    }
+    inboundCallHandlerFunction.irFunctionBody(
+      context = pluginContext,
+      scopeOwnerSymbol = inboundCallHandlerFunction.symbol,
+    ) {
+      +irReturn(
+        irCall(
+          callee = inboundCallHandlerClass.constructors.single().symbol,
+          type = inboundCallHandlerClass.defaultType
+        ).apply {
+          putValueArgument(0, irGet(inboundCallHandlerFunction.valueParameters[0]))
+          putValueArgument(1, irGet(inboundCallHandlerFunction.valueParameters[1]))
+        }
+      )
+    }
+    return inboundCallHandlerFunction
+  }
+
+  // private class GeneratedInboundCallHandler(
+  //   private val service: SampleService,
+  //   override val context: InboundBridge.Context,
+  // ) : InboundCallHandler {
+  //   private val serializer_0 = context.serializersModule.serializer<SampleRequest>()
+  //   private val serializer_1 = context.serializersModule.serializer<SampleResponse>()
+  //
+  //   override fun call(inboundCall: InboundCall): Array<String> { ... }
+  //   override suspend fun callSuspending(inboundCall: InboundCall): Array<String> { ... }
+  // }
+  private fun irInboundCallHandlerClass(
+    bridgedInterface: BridgedInterface,
+    adapterClass: IrClass
+  ): IrClass {
+    val inboundCallHandler = irFactory.buildClass {
+      initDefaults(original)
+      name = Name.identifier("GeneratedInboundCallHandler")
+      visibility = DescriptorVisibilities.PRIVATE
+    }.apply {
+      parent = adapterClass
+      superTypes = listOf(ziplineApis.inboundCallHandler.defaultType)
+      createImplicitParameterDeclarationWithWrappedDescriptor()
+    }
+
+    val constructor = inboundCallHandler.addConstructor {
+      initDefaults(adapterClass)
+    }.apply {
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("service")
+        type = bridgedInterface.type
+      }
+      addValueParameter {
+        initDefaults(adapterClass)
+        name = Name.identifier("context")
+        type = ziplineApis.inboundBridgeContext.defaultType
+      }
+      irConstructorBody(pluginContext) { statements ->
+        statements += irDelegatingConstructorCall(
+          context = pluginContext,
+          symbol = ziplineApis.any.constructors.single(),
+        )
+        statements += irInstanceInitializerCall(
+          context = pluginContext,
+          classSymbol = inboundCallHandler.symbol,
+        )
+      }
+    }
+
+    val serviceProperty = irInboundServiceProperty(
+      bridgedInterface,
+      inboundCallHandler,
+      constructor.valueParameters[0]
+    )
+    inboundCallHandler.declarations += serviceProperty
+
+    val contextProperty = irInboundContextProperty(
+      inboundCallHandler,
+      constructor.valueParameters[1]
+    )
+    inboundCallHandler.declarations += contextProperty
+
+    bridgedInterface.declareSerializerProperties(
+      inboundCallHandler,
+      constructor.valueParameters[1]
+    )
+
+    val callFunction = irCallFunction(
+      inboundCallHandler = inboundCallHandler,
+      callSuspending = false
+    )
+    val callSuspendingFunction = irCallFunction(
+      inboundCallHandler = inboundCallHandler,
+      callSuspending = true
+    )
+
+    // We add overrides here so we can call them below.
+    inboundCallHandler.addFakeOverrides(
+      pluginContext.irBuiltIns,
+      listOf(contextProperty, callFunction, callSuspendingFunction)
+    )
+
+    callFunction.irFunctionBody(
+      context = pluginContext,
+      scopeOwnerSymbol = callFunction.symbol,
+    ) {
+      +irReturn(
+        irCallFunctionBody(bridgedInterface, callFunction, serviceProperty)
+      )
+    }
+    callSuspendingFunction.irFunctionBody(
+      context = pluginContext,
+      scopeOwnerSymbol = callSuspendingFunction.symbol,
+    ) {
+      +irReturn(
+        irCallFunctionBody(bridgedInterface, callSuspendingFunction, serviceProperty)
+      )
+    }
+
+    return inboundCallHandler
+  }
+
+  // private val service: SampleService = service
+  private fun irInboundServiceProperty(
+    bridgedInterface: BridgedInterface,
+    inboundCallHandlerClass: IrClass,
+    irServiceParameter: IrValueParameter
+  ): IrProperty {
+    return irVal(
+      pluginContext = pluginContext,
+      propertyType = bridgedInterface.type,
+      declaringClass = inboundCallHandlerClass,
+      propertyName = Name.identifier("service"),
+    ) {
+      irExprBody(irGet(irServiceParameter))
+    }
+  }
+
+  // override val context: InboundBridge.Context = context
+  private fun irInboundContextProperty(
+    inboundCallHandlerClass: IrClass,
+    irContextParameter: IrValueParameter
+  ): IrProperty {
+    return irVal(
+      pluginContext = pluginContext,
+      propertyType = ziplineApis.inboundBridgeContext.defaultType,
+      declaringClass = inboundCallHandlerClass,
+      propertyName = Name.identifier("context"),
+      overriddenProperty = ziplineApis.inboundCallHandlerContext,
+    ) {
+      irExprBody(irGet(irContextParameter))
+    }
+  }
+
+  /** Override either `InboundCallHandler.call()` or `InboundCallHandler.callSuspending()`. */
+  private fun irCallFunction(
+    inboundCallHandler: IrClass,
+    callSuspending: Boolean,
+  ): IrSimpleFunction {
+    // override fun call(inboundCall: InboundCall): Array<String> {
+    // }
+    val inboundBridgeCall = when {
+      callSuspending -> ziplineApis.inboundCallHandlerCallSuspending
+      else -> ziplineApis.inboundCallHandlerCall
+    }
+    return inboundCallHandler.addFunction {
+      initDefaults(original)
+      name = inboundBridgeCall.owner.name
+      returnType = ziplineApis.stringArrayType
+      isSuspend = callSuspending
+    }.apply {
+      addDispatchReceiver {
+        initDefaults(original)
+        type = inboundCallHandler.defaultType
+      }
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("inboundCall")
+        type = ziplineApis.inboundCall.defaultType
+      }
+      overriddenSymbols = listOf(inboundBridgeCall)
+    }
+  }
+
+  /**
+   * The body of either `InboundCallHandler.call()` or `InboundCallHandler.callSuspending()`.
+   *
+   * ```
+   * when {
+   *   inboundCall.funName == "function1" -> ...
+   *   inboundCall.funName == "function2" -> ...
+   *   ...
+   *   else -> ...
+   * }
+   * ```
+   */
+  private fun IrBlockBodyBuilder.irCallFunctionBody(
+    bridgedInterface: BridgedInterface,
+    callFunction: IrSimpleFunction,
+    serviceProperty: IrProperty,
+  ): IrExpression {
+    val result = mutableListOf<IrBranch>()
+    val inboundBridgeThis = callFunction.dispatchReceiverParameter!!
+
+    // Each bridged function gets its own branch in the when() expression.
+    for (bridgedFunction in bridgedInterface.bridgedFunctions) {
+      if (callFunction.isSuspend != bridgedFunction.isSuspend) continue
+
+      result += irBranch(
+        condition = irEquals(
+          arg1 = irFunName(callFunction),
+          arg2 = irString(bridgedFunction.owner.name.identifier)
+        ),
+        result = irBlock {
+          +irCallEncodeResult(
+            bridgedInterface = bridgedInterface,
+            callFunction = callFunction,
+            resultExpression = irCallServiceFunction(
+              bridgedInterface = bridgedInterface,
+              callFunction = callFunction,
+              inboundCallHandlerThis = inboundBridgeThis,
+              serviceProperty = serviceProperty,
+              bridgedFunction = bridgedFunction
+            )
+          )
+        }
+      )
+    }
+
+    // Add an else clause that calls unexpectedFunction().
+    result += irElseBranch(irCallUnexpectedFunction(callFunction))
+
+    return irWhen(
+      type = ziplineApis.stringArrayType,
+      branches = result
+    )
+  }
+
+  /** `inboundCall.funName` */
+  private fun IrBuilderWithScope.irFunName(
+    callFunction: IrSimpleFunction,
+  ): IrExpression {
+    return irCall(
+      callee = ziplineApis.inboundCall.getPropertyGetter("funName")!!,
+      type = pluginContext.symbols.string.defaultType,
+    ).apply {
+      dispatchReceiver = irGetInboundCallParameter(
+        callFunction = callFunction,
+      )
+    }
+  }
+
+  /** `service.function1(...)` */
+  private fun IrBuilderWithScope.irCallServiceFunction(
+    bridgedInterface: BridgedInterface,
+    callFunction: IrSimpleFunction,
+    inboundCallHandlerThis: IrValueParameter,
+    serviceProperty: IrProperty,
+    bridgedFunction: IrSimpleFunctionSymbol,
+  ): IrExpression {
+    val getServiceCall = irService(inboundCallHandlerThis, serviceProperty)
+    val returnType = bridgedFunction.owner.returnType
+
+    return irCall(
+      type = bridgedInterface.resolveTypeParameters(returnType),
+      callee = bridgedFunction,
+      valueArgumentsCount = bridgedFunction.owner.valueParameters.size,
+    ).apply {
+      dispatchReceiver = getServiceCall
+
+      for (p in bridgedFunction.owner.valueParameters.indices) {
+        putValueArgument(
+          p,
+          irCallDecodeParameter(
+            bridgedInterface = bridgedInterface,
+            callFunction = callFunction,
+            valueParameter = bridgedFunction.owner.valueParameters[p]
+          ),
+        )
+      }
+    }
+  }
+
+  /** `inboundBridge.service` */
+  private fun IrBuilderWithScope.irService(
+    inboundCallHandlerThis: IrValueParameter,
+    serviceProperty: IrProperty,
+  ): IrExpression {
+    return irCall(
+      callee = serviceProperty.getter!!,
+    ).apply {
+      dispatchReceiver = irGet(inboundCallHandlerThis)
+    }
+  }
+
+  /** `inboundCall.parameter(...)` */
+  private fun IrBuilderWithScope.irCallDecodeParameter(
+    bridgedInterface: BridgedInterface,
+    callFunction: IrSimpleFunction,
+    valueParameter: IrValueParameter,
+  ): IrExpression {
+    val valueParameterType = bridgedInterface.resolveTypeParameters(valueParameter.type)
+    return irCall(
+      type = valueParameterType,
+      callee = ziplineApis.inboundCallParameter,
+    ).apply {
+      dispatchReceiver = irGetInboundCallParameter(callFunction)
+      putTypeArgument(0, valueParameterType)
+      putValueArgument(
+        0,
+        bridgedInterface.serializerExpression(
+          this@irCallDecodeParameter,
+          valueParameterType,
+          callFunction.dispatchReceiverParameter!!
+        )
+      )
+    }
+  }
+
+  /** `inboundCall` */
+  private fun IrBuilderWithScope.irGetInboundCallParameter(
+    callFunction: IrSimpleFunction
+  ): IrGetValue {
+    return irGet(
+      type = ziplineApis.inboundCall.defaultType,
+      variable = callFunction.valueParameters[0].symbol,
+    )
+  }
+
+  /** `inboundCall.result(...)` */
+  private fun IrBuilderWithScope.irCallEncodeResult(
+    bridgedInterface: BridgedInterface,
+    callFunction: IrSimpleFunction,
+    resultExpression: IrExpression
+  ): IrExpression {
+    return irCall(
+      type = ziplineApis.stringArrayType,
+      callee = ziplineApis.inboundCallResult,
+    ).apply {
+      dispatchReceiver = irGetInboundCallParameter(callFunction)
+      putTypeArgument(0, resultExpression.type)
+      putValueArgument(
+        0,
+        bridgedInterface.serializerExpression(
+          this@irCallEncodeResult,
+          resultExpression.type,
+          callFunction.dispatchReceiverParameter!!
+        )
+      )
+      putValueArgument(1, resultExpression)
+    }
+  }
+
+  /** `inboundCall.unexpectedFunction()` */
+  private fun IrBuilderWithScope.irCallUnexpectedFunction(
+    callFunction: IrSimpleFunction,
+  ): IrExpression {
+    return irCall(
+      type = ziplineApis.stringArrayType,
+      callee = ziplineApis.inboundCallUnexpectedFunction,
+    ).apply {
+      dispatchReceiver = irGetInboundCallParameter(callFunction)
+    }
+  }
+
+  /** Override `ZiplineServiceAdapter.outboundService()`. */
+  private fun irOutboundServiceFunction(
+    bridgedInterface: BridgedInterface,
+    adapterClass: IrClass,
+    outboundServiceClass: IrClass,
+  ): IrSimpleFunction {
+    // override fun outboundService(context: OutboundBridge.Context): SampleService
+    val outboundServiceFunction = adapterClass.addFunction {
+      initDefaults(original)
+      name = ziplineApis.ziplineServiceAdapterOutboundService.owner.name
+      returnType = bridgedInterface.type
+    }.apply {
+      addDispatchReceiver {
+        initDefaults(original)
+        type = adapterClass.defaultType
+      }
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("context")
+        type = ziplineApis.outboundBridgeContext.defaultType
+      }
+      overriddenSymbols = listOf(ziplineApis.ziplineServiceAdapterOutboundService)
+    }
+    outboundServiceFunction.irFunctionBody(
+      context = pluginContext,
+      scopeOwnerSymbol = outboundServiceFunction.symbol,
+    ) {
+      +irReturn(
+        irCall(
+          callee = outboundServiceClass.constructors.single().symbol,
+          type = outboundServiceClass.defaultType
+        ).apply {
+          putValueArgument(0, irGet(outboundServiceFunction.valueParameters[0]))
+        }
+      )
+    }
+    return outboundServiceFunction
+  }
+
+  // private class GeneratedOutboundService(
+  //   private val context: OutboundBridge.Context
+  // ) : SampleService {
+  //   private val serializer_0 = context.serializersModule.serializer<SampleRequest>()
+  //   private val serializer_1 = context.serializersModule.serializer<SampleResponse>()
+  //
+  //   override fun ping(request: SampleRequest): SampleResponse { ... }
+  //   override fun close() { ... }
+  // }
+  private fun irOutboundServiceClass(
+    bridgedInterface: BridgedInterface,
+    adapterClass: IrClass,
+  ): IrClass {
+    val outboundServiceClass = irFactory.buildClass {
+      initDefaults(original)
+      name = Name.identifier("GeneratedOutboundService")
+      visibility = DescriptorVisibilities.PRIVATE
+    }.apply {
+      parent = adapterClass
+      superTypes = listOf(bridgedInterface.type)
+      createImplicitParameterDeclarationWithWrappedDescriptor()
+    }
+
+    val constructor = outboundServiceClass.addConstructor {
+      initDefaults(original)
+    }.apply {
+      addValueParameter {
+        initDefaults(adapterClass)
+        name = Name.identifier("context")
+        type = ziplineApis.outboundBridgeContext.defaultType
+      }
+    }
+    constructor.irConstructorBody(pluginContext) { statements ->
+      statements += irDelegatingConstructorCall(
+        context = pluginContext,
+        symbol = ziplineApis.any.constructors.single(),
+      )
+      statements += irInstanceInitializerCall(
+        context = pluginContext,
+        classSymbol = outboundServiceClass.symbol,
+      )
+    }
+
+    val contextProperty = irOutboundContextProperty(
+      outboundServiceClass,
+      constructor.valueParameters[0]
+    )
+    outboundServiceClass.declarations += contextProperty
+
+    bridgedInterface.declareSerializerProperties(
+      outboundServiceClass,
+      constructor.valueParameters[0]
+    )
+
+    for (bridgedFunction in bridgedInterface.bridgedFunctions) {
+      outboundServiceClass.irBridgedFunction(
+        bridgedInterface = bridgedInterface,
+        outboundContextProperty = contextProperty,
+        bridgedFunction = bridgedFunction.owner,
+      )
+    }
+
+    outboundServiceClass.addFakeOverrides(pluginContext.irBuiltIns, listOf())
+
+    return outboundServiceClass
+  }
+
+  // override val context: OutboundBridge.Context = context
+  private fun irOutboundContextProperty(
+    inboundCallHandlerClass: IrClass,
+    irContextParameter: IrValueParameter
+  ): IrProperty {
+    return irVal(
+      pluginContext = pluginContext,
+      propertyType = ziplineApis.outboundBridgeContext.defaultType,
+      declaringClass = inboundCallHandlerClass,
+      propertyName = Name.identifier("context")
+    ) {
+      irExprBody(irGet(irContextParameter))
+    }
+  }
+
+  private fun IrClass.irBridgedFunction(
+    bridgedInterface: BridgedInterface,
+    outboundContextProperty: IrProperty,
+    bridgedFunction: IrSimpleFunction,
+  ): IrSimpleFunction {
+    val functionReturnType = bridgedInterface.resolveTypeParameters(bridgedFunction.returnType)
+    val result = addFunction {
+      initDefaults(original)
+      name = bridgedFunction.name
+      isSuspend = bridgedFunction.isSuspend
+      returnType = functionReturnType
+    }.apply {
+      overriddenSymbols = listOf(bridgedFunction.symbol)
+      addDispatchReceiver {
+        initDefaults(original)
+        type = defaultType
+      }
+    }
+
+    for (valueParameter in bridgedFunction.valueParameters) {
+      result.addValueParameter {
+        initDefaults(original)
+        name = valueParameter.name
+        type = bridgedInterface.resolveTypeParameters(valueParameter.type)
+      }
+    }
+
+    result.irFunctionBody(
+      context = pluginContext,
+      scopeOwnerSymbol = result.symbol
+    ) {
+      val newCall = irCall(ziplineApis.outboundBridgeContextNewCall).apply {
+        dispatchReceiver = irCall(
+          callee = outboundContextProperty.getter!!
+        ).apply {
+          dispatchReceiver = irGet(result.dispatchReceiverParameter!!)
+        }
+        putValueArgument(0, irString(bridgedFunction.name.identifier))
+        putValueArgument(1, irInt(bridgedFunction.valueParameters.size))
+      }
+
+      val outboundCallLocal = irTemporary(
+        value = newCall,
+        nameHint = "outboundCall",
+        isMutable = false
+      ).apply {
+        origin = IrDeclarationOrigin.DEFINED
+      }
+
+      // outboundCall.parameter<SampleRequest>(serializer_0, request)
+      for (valueParameter in result.valueParameters) {
+        val parameterType = bridgedInterface.resolveTypeParameters(valueParameter.type)
+        +irCall(callee = ziplineApis.outboundCallParameter).apply {
+          dispatchReceiver = irGet(outboundCallLocal)
+          putTypeArgument(0, parameterType)
+          putValueArgument(
+            0,
+            bridgedInterface.serializerExpression(
+              this@irFunctionBody,
+              parameterType,
+              result.dispatchReceiverParameter!!
+            )
+          )
+          putValueArgument(
+            1,
+            irGet(
+              type = valueParameter.type,
+              variable = valueParameter.symbol,
+            )
+          )
+        }
+      }
+
+      // One of:
+      //   return outboundCall.<SampleResponse>invoke(serializer_2)
+      //   return outboundCall.<SampleResponse>invokeSuspending(serializer_2)
+      val invoke = when {
+        bridgedFunction.isSuspend -> ziplineApis.outboundCallInvokeSuspending
+        else -> ziplineApis.outboundCallInvoke
+      }
+      +irReturn(
+        value = irCall(callee = invoke).apply {
+          dispatchReceiver = irGet(outboundCallLocal)
+          type = functionReturnType
+          putTypeArgument(0, result.returnType)
+          putValueArgument(
+            0,
+            bridgedInterface.serializerExpression(
+              this@irFunctionBody,
+              functionReturnType,
+              result.dispatchReceiverParameter!!
+            )
+          )
+        },
+        returnTargetSymbol = result.symbol,
+        type = pluginContext.irBuiltIns.nothingType,
+      )
+    }
+
+    return result
+  }
+}

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AddAdapterArgumentRewriter.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AddAdapterArgumentRewriter.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.kotlin
+
+import org.jetbrains.kotlin.backend.common.ScopeWithIr
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.irCall
+import org.jetbrains.kotlin.ir.util.patchDeclarationParents
+
+/**
+ * Rewrites calls to `Zipline.getService()` and `Zipline.setService()` to also pass an additional
+ * argument, the generated `ZiplineServiceAdapter`.
+ *
+ * This call:
+ *
+ * ```
+ * val helloService: SampleService = zipline.getService(
+ *   "helloService"
+ * )
+ * ```
+ *
+ * is rewritten to:
+ *
+ * ```
+ * val helloService: SampleService = zipline.getService(
+ *   "helloService",
+ *   SampleService.Companion.Adapter
+ * )
+ * ```
+ *
+ * This also rewrites calls on `Endpoint`.
+ */
+internal class AddAdapterArgumentRewriter(
+  private val pluginContext: IrPluginContext,
+  private val ziplineApis: ZiplineApis,
+  private val scope: ScopeWithIr,
+  private val declarationParent: IrDeclarationParent,
+  private val original: IrCall,
+  private val rewrittenFunction: IrSimpleFunctionSymbol,
+) {
+  /** The user-defined interface type, like `SampleService` above. */
+  private val bridgedInterfaceType: IrType = original.getTypeArgument(0)!!
+
+  private val bridgedInterface = BridgedInterface.create(
+    pluginContext,
+    ziplineApis,
+    original,
+    "Zipline.${original.symbol.owner.name.identifier}()",
+    bridgedInterfaceType
+  )
+
+  fun rewrite(): IrCall {
+    // Make sure there's an adapter for this class so we have something to reference.
+    val adapterClass = AdapterGenerator(
+      pluginContext,
+      ziplineApis,
+      bridgedInterface.typeIrClass
+    ).generateAdapterIfAbsent()
+
+    return irCall(original, rewrittenFunction).apply {
+      val irBlockBodyBuilder = irBlockBodyBuilder(pluginContext, scope, original)
+      putValueArgument(valueArgumentsCount - 1, irBlockBodyBuilder.irGetObject(adapterClass.symbol))
+      patchDeclarationParents(declarationParent)
+    }
+  }
+}

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -62,6 +62,8 @@ internal class BridgedInterface(
   /** Maps types to the property holding the corresponding serializer. */
   private val typeToSerializerProperty = mutableMapOf<IrType, IrProperty>()
 
+  val typeIrClass = classSymbol.owner
+
   val bridgedFunctions: List<IrSimpleFunctionSymbol>
     // TODO(jwilson): find a better way to skip equals()/hashCode()/toString()
     get() = classSymbol.functions.toList()
@@ -156,7 +158,7 @@ internal class BridgedInterface(
   /** Call this on any declaration returned by [classSymbol] to fill in the generic parameters. */
   fun resolveTypeParameters(type: IrType): IrType {
     val simpleType = this.type as? IrSimpleType ?: return type
-    val parameters = classSymbol.owner.typeParameters
+    val parameters = typeIrClass.typeParameters
     val arguments = simpleType.arguments.map { it as IrType }
     return type.substitute(parameters, arguments)
   }

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -39,6 +39,8 @@ internal class ZiplineApis(
   private val serializersModuleFqName = serializationModulesFqName.child("SerializersModule")
   private val ziplineFqName = packageFqName.child("Zipline")
   val ziplineReferenceFqName = packageFqName.child("ZiplineReference")
+  val ziplineServiceFqName = packageFqName.child("ZiplineService")
+  private val ziplineServiceAdapterFqName = bridgeFqName.child("ZiplineServiceAdapter")
   private val endpointFqName = bridgeFqName.child("Endpoint")
 
   val any: IrClassSymbol
@@ -164,6 +166,27 @@ internal class ZiplineApis(
   val outboundBridgeCreate: IrSimpleFunctionSymbol
     get() = outboundBridge.functions.single { it.owner.name.identifier == "create" }
 
+  val ziplineService: IrClassSymbol
+    get() = pluginContext.referenceClass(ziplineServiceFqName)!!
+
+  val ziplineServiceAdapter: IrClassSymbol
+    get() = pluginContext.referenceClass(ziplineServiceAdapterFqName)!!
+
+  val ziplineServiceAdapterSerialName: IrPropertySymbol
+    get() = pluginContext.referenceProperties(
+      ziplineServiceAdapterFqName.child("serialName")
+    ).single()
+
+  val ziplineServiceAdapterInboundCallHandler: IrSimpleFunctionSymbol
+    get() = ziplineServiceAdapter.functions.single {
+      it.owner.name.identifier == "inboundCallHandler"
+    }
+
+  val ziplineServiceAdapterOutboundService: IrSimpleFunctionSymbol
+    get() = ziplineServiceAdapter.functions.single {
+      it.owner.name.identifier == "outboundService"
+    }
+
   private val referenceFqName = FqName("app.cash.zipline.ZiplineReference")
   private val referenceGetFqName = referenceFqName.child("get")
   private val inboundReferenceFqName = FqName("app.cash.zipline.InboundZiplineReference")
@@ -173,6 +196,14 @@ internal class ZiplineApis(
     rewritePair(ziplineFqName.child("get")),
     rewritePair(endpointFqName.child("get")),
     referenceGetRewritePair(),
+  ).toMap()
+
+  /** Keys are functions like `Zipline.getService()` and values are their rewrite targets. */
+  val getOrSetServiceRewriteFunctions: Map<IrFunctionSymbol, IrSimpleFunctionSymbol> = listOf(
+    rewritePair(ziplineFqName.child("getService")),
+    rewritePair(endpointFqName.child("getService")),
+    rewritePair(ziplineFqName.child("setService")),
+    rewritePair(endpointFqName.child("setService")),
   ).toMap()
 
   /** Keys are functions like `Zipline.set()` and values are their rewrite targets. */

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -15,12 +15,15 @@
  */
 package app.cash.zipline.kotlin
 
+import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
+import org.jetbrains.kotlin.backend.common.ir.createImplicitParameterDeclarationWithWrappedDescriptor
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocationWithRange
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
@@ -33,6 +36,8 @@ import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.builders.declarations.IrClassBuilder
 import org.jetbrains.kotlin.ir.builders.declarations.IrFunctionBuilder
 import org.jetbrains.kotlin.ir.builders.declarations.IrValueParameterBuilder
+import org.jetbrains.kotlin.ir.builders.declarations.addConstructor
+import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irReturn
@@ -59,7 +64,9 @@ import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrPropertySymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
+import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -285,3 +292,58 @@ fun irVal(
   return result
 }
 
+fun irBlockBodyBuilder(
+  irPluginContext: IrGeneratorContext,
+  scopeWithIr: ScopeWithIr,
+  original: IrElement
+): IrBlockBodyBuilder {
+  return IrBlockBodyBuilder(
+    irPluginContext,
+    scopeWithIr.scope,
+    original.startOffset,
+    original.endOffset
+  )
+}
+
+/** This creates `companion object` if it doesn't exist already. */
+fun IrClass.getOrCreateCompanion(
+  irPluginContext: IrPluginContext,
+): IrClass {
+  val existing = declarations.firstOrNull {
+    it is IrClass && it.name.identifier == "Companion"
+  }
+  if (existing != null) return existing as IrClass
+
+  val irFactory = irPluginContext.irFactory
+  val anyType = irPluginContext.referenceClass(irPluginContext.irBuiltIns.anyType.classFqName!!)!!
+  val companionClass = irFactory.buildClass {
+    initDefaults(this@getOrCreateCompanion)
+    name = Name.identifier("Companion")
+    visibility = DescriptorVisibilities.PUBLIC
+    kind = ClassKind.OBJECT
+    isCompanion = true
+  }.apply {
+    parent = this@getOrCreateCompanion
+    superTypes = listOf(irPluginContext.irBuiltIns.anyType)
+    createImplicitParameterDeclarationWithWrappedDescriptor()
+  }
+
+  companionClass.addConstructor {
+    initDefaults(this@getOrCreateCompanion)
+    visibility = DescriptorVisibilities.PRIVATE
+  }.apply {
+    irConstructorBody(irPluginContext) { statements ->
+      statements += irDelegatingConstructorCall(
+        context = irPluginContext,
+        symbol = anyType.constructors.single()
+      )
+      statements += irInstanceInitializerCall(
+        context = irPluginContext,
+        classSymbol = companionClass.symbol,
+      )
+    }
+  }
+
+  declarations.add(companionClass)
+  return companionClass
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineReference.kt
@@ -47,7 +47,7 @@ internal class InboundZiplineReference<T : Any>(
     check(this.endpoint == null && this.name == null) { "already connected" }
     this.name = name
     this.endpoint = endpoint
-    val context = InboundBridge.Context(endpoint.serializersModule, endpoint)
+    val context = endpoint.newInboundContext()
     val result = inboundBridge.create(context)
     endpoint.inboundHandlers[name] = result
     return result
@@ -61,7 +61,7 @@ internal class InboundZiplineReference<T : Any>(
     val endpoint = this.endpoint
     val name = this.name
     if (endpoint != null && name != null) {
-      val removed = endpoint.inboundHandlers.remove(name)
+      val removed = endpoint.remove(name)
       this.endpoint = null
       this.name = null
       require(removed != null) { "unable to find $name: was it removed twice?" }
@@ -81,11 +81,7 @@ internal class OutboundZiplineReference<T : Any> : ZiplineReference<T>() {
 
   override fun get(outboundBridge: OutboundBridge<T>): T {
     val endpoint = this.endpoint ?: throw IllegalStateException("not connected")
-    val context = OutboundBridge.Context(
-      instanceName = this.name!!,
-      serializersModule = endpoint.serializersModule,
-      endpoint = endpoint
-    )
+    val context = endpoint.newOutboundContext(this.name!!)
     return outboundBridge.create(context)
   }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineService.kt
@@ -15,22 +15,14 @@
  */
 package app.cash.zipline
 
-import kotlinx.serialization.modules.SerializersModule
-
-expect class Zipline {
-  val serializersModule: SerializersModule
-
-  /** Name of services that have been published with [set]. */
-  val serviceNames: Set<String>
-
-  /** Names of services that can be consumed with [get]. */
-  val clientNames: Set<String>
-
-  fun <T : Any> get(name: String): T
-
-  fun <T : Any> set(name: String, instance: T)
-
-  fun <T : ZiplineService> getService(name: String): T
-
-  fun <T : ZiplineService> setService(name: String, instance: T)
+/**
+ * Implemented by all interfaces that can safely be passed from the host platform to Kotlin/JS or
+ * vice versa.
+ *
+ * When an instance of a service is passed between platforms, the receiving platform **must** call
+ * [close] when it is done. This releases the handle on the inbound side, and prevents a resource
+ * leak. It is an error to call any method on a service after it is closed.
+ */
+interface ZiplineService {
+  fun close()
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import app.cash.zipline.ZiplineService
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Adapts [ZiplineService] implementations to receive incoming and send outgoing calls. Most
+ * implementations are generated.
+ */
+@PublishedApi
+internal abstract class ZiplineServiceAdapter<T : ZiplineService> {
+  abstract val serialName: String
+
+  abstract fun inboundCallHandler(
+    service: T,
+    context: InboundBridge.Context
+  ): InboundCallHandler
+
+  abstract fun outboundService(
+    context: OutboundBridge.Context
+  ): T
+
+  fun serializer(endpoint: Endpoint) : KSerializer<T> {
+    return object : KSerializer<T> {
+      override val descriptor = PrimitiveSerialDescriptor(serialName, PrimitiveKind.STRING)
+
+      override fun serialize(encoder: Encoder, value: T) {
+        val name = endpoint.generateName()
+        endpoint.setService(name, value, this@ZiplineServiceAdapter)
+        encoder.encodeString(name)
+      }
+
+      override fun deserialize(decoder: Decoder): T {
+        val name = decoder.decodeString()
+        return outboundService(endpoint.newOutboundContext(name))
+      }
+    }
+  }
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -119,7 +119,7 @@ internal class OutboundCall(
   ) : SuspendCallback {
     override fun call(response: Array<String>) {
       // Suspend callbacks are one-shot. When triggered, remove them immediately.
-      endpoint.inboundHandlers.remove(callbackName)
+      endpoint.remove(callbackName)
       val result = response.decodeResult(serializer)
       context.endpoint.incompleteContinuations -= continuation
       continuation.resumeWith(result)

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -15,8 +15,10 @@
  */
 package app.cash.zipline
 
+import app.cash.zipline.internal.CURRENT_MODULE_ID
 import app.cash.zipline.internal.Console
 import app.cash.zipline.internal.CoroutineEventLoop
+import app.cash.zipline.internal.DEFINE_JS
 import app.cash.zipline.internal.EventLoop
 import app.cash.zipline.internal.HostConsole
 import app.cash.zipline.internal.JsPlatform
@@ -24,9 +26,8 @@ import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.internal.bridge.InboundBridge
 import app.cash.zipline.internal.bridge.OutboundBridge
+import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import app.cash.zipline.internal.consoleName
-import app.cash.zipline.internal.CURRENT_MODULE_ID
-import app.cash.zipline.internal.DEFINE_JS
 import app.cash.zipline.internal.eventLoopName
 import app.cash.zipline.internal.jsPlatformName
 import kotlin.coroutines.resumeWithException
@@ -112,20 +113,44 @@ actual class Zipline private constructor(
     error("unexpected call to Zipline.get: is the Zipline plugin configured?")
   }
 
+  actual fun <T : ZiplineService> getService(name: String): T {
+    error("unexpected call to Zipline.getService: is the Zipline plugin configured?")
+  }
+
   @PublishedApi
   internal fun <T : Any> get(name: String, bridge: OutboundBridge<T>): T {
     check(scope.isActive) { "closed" }
     return endpoint.get(name, bridge)
   }
 
+  @PublishedApi
+  internal fun <T : ZiplineService> getService(name: String, adapter: ZiplineServiceAdapter<T>): T {
+    check(scope.isActive) { "closed" }
+    return endpoint.getService(name, adapter)
+  }
+
   actual fun <T : Any> set(name: String, instance: T) {
     error("unexpected call to Zipline.set: is the Zipline plugin configured?")
+  }
+
+  actual fun <T : ZiplineService> setService(name: String, instance: T) {
+    error("unexpected call to Zipline.setService: is the Zipline plugin configured?")
   }
 
   @PublishedApi
   internal fun <T : Any> set(name: String, bridge: InboundBridge<T>) {
     check(scope.isActive) { "closed" }
     endpoint.set(name, bridge)
+  }
+
+  @PublishedApi
+  internal fun <T : ZiplineService> setService(
+    name: String,
+    service: T,
+    adapter: ZiplineServiceAdapter<T>,
+  ) {
+    check(scope.isActive) { "closed" }
+    endpoint.setService(name, service, adapter)
   }
 
   /**

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.internal.bridge.InboundBridge
+import app.cash.zipline.internal.bridge.InboundCall
+import app.cash.zipline.internal.bridge.InboundCallHandler
+import app.cash.zipline.internal.bridge.OutboundBridge
+import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.serializer
+
+@Serializable
+data class SampleRequest(
+  val message: String
+)
+
+@Serializable
+data class SampleResponse(
+  val message: String
+)
+
+/**
+ * Note that this interface is unused. It only serves as a sample for what the code generators
+ * should consume and produce.
+ */
+interface SampleService : ZiplineService {
+  fun ping(request: SampleRequest): SampleResponse
+  override fun close()
+
+  companion object {
+    /**
+     * We expect this manually-written adapter to be consistent with the generated one. This exists
+     * mostly to model what the expected generated code should look like when making changes to
+     * `AdapterGenerator`.
+     */
+    internal object ManualAdapter : ZiplineServiceAdapter<SampleService>() {
+      override val serialName: String = "SampleService"
+
+      override fun inboundCallHandler(
+        service: SampleService,
+        context: InboundBridge.Context
+      ): InboundCallHandler = GeneratedInboundCallHandler(service, context)
+
+      override fun outboundService(
+        context: OutboundBridge.Context
+      ): SampleService = GeneratedOutboundService(context)
+
+      private class GeneratedInboundCallHandler(
+        private val service: SampleService,
+        override val context: InboundBridge.Context,
+      ) : InboundCallHandler {
+        private val requestSerializer = context.serializersModule.serializer<SampleRequest>()
+        private val responseSerializer = context.serializersModule.serializer<SampleResponse>()
+
+        override fun call(inboundCall: InboundCall): Array<String> {
+          return when (inboundCall.funName) {
+            "ping" -> {
+              inboundCall.result(
+                responseSerializer,
+                service.ping(
+                  inboundCall.parameter(requestSerializer)
+                )
+              )
+            }
+            "close" -> {
+              inboundCall.result(
+                Unit.serializer(),
+                service.close()
+              )
+            }
+            else -> {
+              inboundCall.unexpectedFunction()
+            }
+          }
+        }
+
+        override suspend fun callSuspending(inboundCall: InboundCall): Array<String> {
+          return when (inboundCall.funName) {
+            else -> {
+              inboundCall.unexpectedFunction()
+            }
+          }
+        }
+      }
+
+      private class GeneratedOutboundService(
+        private val context: OutboundBridge.Context
+      ) : SampleService {
+        private val requestSerializer = context.serializersModule.serializer<SampleRequest>()
+        private val responseSerializer = context.serializersModule.serializer<SampleResponse>()
+
+        override fun ping(request: SampleRequest): SampleResponse {
+          val call = context.newCall("ping", 1)
+          call.parameter(requestSerializer, request)
+          return call.invoke(responseSerializer)
+        }
+
+        override fun close() {
+          val call = context.newCall("close", 0)
+          return call.invoke(Unit.serializer())
+        }
+      }
+    }
+  }
+}

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.EchoRequest
+import app.cash.zipline.testing.EchoResponse
+import app.cash.zipline.testing.EchoZiplineService
+import app.cash.zipline.testing.newEndpointPair
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+
+internal class ZiplineServiceTest {
+  @Test
+  fun requestAndResponse() = runBlocking {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    val events = ArrayDeque<String>()
+    val responses = ArrayDeque<String>()
+    val service = object : EchoZiplineService {
+      override fun echo(request: EchoRequest): EchoResponse {
+        events += "request message='${request.message}'"
+        return EchoResponse(responses.removeFirst())
+      }
+
+      override fun close() {
+        events += "close"
+      }
+    }
+
+    endpointA.setService<EchoZiplineService>("helloService", service)
+    assertEquals(setOf("helloService"), endpointA.serviceNames)
+
+    val client = endpointB.getService<EchoZiplineService>("helloService")
+    assertEquals(setOf("helloService"), endpointB.clientNames)
+
+    responses += "this is a curt response"
+    val response = client.echo(EchoRequest("this is a happy request"))
+    assertEquals("this is a curt response", response.message)
+    assertEquals("request message='this is a happy request'", events.removeFirst())
+
+    client.close()
+    assertEquals("close", events.removeFirst())
+    assertEquals(setOf(), endpointB.clientNames)
+    assertEquals(setOf(), endpointA.serviceNames)
+
+    assertNull(events.removeFirstOrNull())
+  }
+}

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -22,6 +22,7 @@ import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.internal.bridge.InboundBridge
 import app.cash.zipline.internal.bridge.OutboundBridge
+import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import app.cash.zipline.internal.bridge.inboundChannelName
 import app.cash.zipline.internal.bridge.outboundChannelName
 import app.cash.zipline.internal.consoleName
@@ -108,6 +109,15 @@ actual class Zipline internal constructor() {
     error("unexpected call to Zipline.get: is the Zipline plugin configured?")
   }
 
+  actual fun <T : ZiplineService> getService(name: String): T {
+    error("unexpected call to Zipline.getService: is the Zipline plugin configured?")
+  }
+
+  @PublishedApi
+  internal fun <T : ZiplineService> getService(name: String, adapter: ZiplineServiceAdapter<T>): T {
+    return endpoint.getService(name, adapter)
+  }
+
   @PublishedApi
   internal fun <T : Any> get(name: String, outboundBridge: OutboundBridge<T>): T {
     return endpoint.get(name, outboundBridge)
@@ -115,6 +125,19 @@ actual class Zipline internal constructor() {
 
   actual fun <T : Any> set(name: String, instance: T) {
     error("unexpected call to Zipline.set: is the Zipline plugin configured?")
+  }
+
+  actual fun <T : ZiplineService> setService(name: String, instance: T) {
+    error("unexpected call to Zipline.setService: is the Zipline plugin configured?")
+  }
+
+  @PublishedApi
+  internal fun <T : ZiplineService> setService(
+    name: String,
+    service: T,
+    adapter: ZiplineServiceAdapter<T>
+  ) {
+    endpoint.setService(name, service, adapter)
   }
 
   @PublishedApi

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/EchoZiplineService.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/EchoZiplineService.kt
@@ -13,24 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline
+package app.cash.zipline.testing
 
-import kotlinx.serialization.modules.SerializersModule
+import app.cash.zipline.ZiplineService
 
-expect class Zipline {
-  val serializersModule: SerializersModule
-
-  /** Name of services that have been published with [set]. */
-  val serviceNames: Set<String>
-
-  /** Names of services that can be consumed with [get]. */
-  val clientNames: Set<String>
-
-  fun <T : Any> get(name: String): T
-
-  fun <T : Any> set(name: String, instance: T)
-
-  fun <T : ZiplineService> getService(name: String): T
-
-  fun <T : ZiplineService> setService(name: String, instance: T)
+interface EchoZiplineService : ZiplineService {
+  fun echo(request: EchoRequest): EchoResponse
+  override fun close()
 }


### PR DESCRIPTION
This introduces ZiplineService (public API) and ZiplineServiceAdapter (internal)
that should soon replace other classes including InboundBridge, OutboundBridge,
and ZiplineReference.

The biggest benefit of this change is that it should make it possible to not
need the clumsy ZiplineReference box when passing interfaces across the bridge.

A side-effect of this change is that API-dependent code is now generated
alongside the interface and not the use-sites. This should fix our problems
with incremental builds. (Without this, any time an interface method is changed
but the calls to Zipline.get() or Zipline.set() don't change, a rebuild is
not triggered and things fail at runtime.)

https://github.com/cashapp/zipline/issues/383

In follow-up PRs I'd like to tear down the above features obsoleted by this
change. I'm holding off on doing that here to simplify the transition. As a
consequence, this PR introduces some duplicate code.