### PR TITLE
Don't accept a CoroutineScope in ZiplineLoader.load

### DIFF
--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -22,11 +22,12 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import okio.Buffer
+import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 
@@ -54,14 +55,12 @@ class ZiplineLoaderTest {
   @Test
   fun `happy path`() {
     httpClient.filePathToByteString = mapOf(
-      alphaFilePath to alphaBytecode(quickJs).toByteString(),
-      bravoFilePath to bravoBytecode(quickJs).toByteString()
+      alphaFilePath to alphaBytecode(quickJs),
+      bravoFilePath to bravoBytecode(quickJs)
     )
     val zipline = Zipline.create(dispatcher)
     dispatcher.runBlockingTest {
-      coroutineScope {
-        loader.load(this@coroutineScope, zipline, manifest(quickJs))
-      }
+      loader.load(zipline, manifest(quickJs))
     }
     assertEquals(
       zipline.quickJs.evaluate("globalThis.log", "assert.js"),
@@ -76,14 +75,12 @@ class ZiplineLoaderTest {
   fun `load manifest from url`() {
     httpClient.filePathToByteString = mapOf(
       manifestPath to Json.encodeToString(manifest(quickJs)).encodeUtf8(),
-      alphaFilePath to alphaBytecode(quickJs).toByteString(),
-      bravoFilePath to bravoBytecode(quickJs).toByteString()
+      alphaFilePath to alphaBytecode(quickJs),
+      bravoFilePath to bravoBytecode(quickJs)
     )
     val zipline = Zipline.create(dispatcher)
     dispatcher.runBlockingTest {
-      coroutineScope {
-        loader.load(this@coroutineScope, zipline, manifestPath)
-      }
+      loader.load(zipline, manifestPath)
     }
     assertEquals(
       zipline.quickJs.evaluate("globalThis.log", "assert.js"),
@@ -98,29 +95,42 @@ class ZiplineLoaderTest {
     private val alphaJs = """
       |globalThis.log = globalThis.log || "";
       |globalThis.log += "alpha loaded\n"
-    """.trimMargin()
-    private fun alphaBytecode(quickJs: QuickJs) = quickJs.compile(alphaJs, "alpha.js")
+      |""".trimMargin()
+    private fun alphaBytecode(quickJs: QuickJs) = ziplineFile(quickJs, alphaJs, "alpha.js")
     private const val alphaFilePath = "/alpha.zipline"
+
     private val bravoJs = """
       |globalThis.log = globalThis.log || "";
       |globalThis.log += "bravo loaded\n"
-    """.trimMargin()
-    private fun bravoBytecode(quickJs: QuickJs) = quickJs.compile(bravoJs, "bravo.js")
+      |""".trimMargin()
+    private fun bravoBytecode(quickJs: QuickJs) = ziplineFile(quickJs, bravoJs, "bravo.js")
     private const val bravoFilePath = "/bravo.zipline"
+
     private const val manifestPath = "/manifest.zipline.json"
     private fun manifest(quickJs: QuickJs) = ZiplineManifest.create(
       modules = mapOf(
         "bravo" to ZiplineModule(
           url = bravoFilePath,
-          sha256 = bravoBytecode(quickJs).toByteString().sha256(),
+          sha256 = bravoBytecode(quickJs).sha256(),
           dependsOnIds = listOf("alpha"),
         ),
         "alpha" to ZiplineModule(
           url = alphaFilePath,
-          sha256 = alphaBytecode(quickJs).toByteString().sha256(),
+          sha256 = alphaBytecode(quickJs).sha256(),
           dependsOnIds = listOf(),
         ),
       )
     )
+
+    private fun ziplineFile(quickJs: QuickJs, javaScript: String, fileName: String): ByteString {
+      val ziplineFile = ZiplineFile(
+        CURRENT_ZIPLINE_VERSION,
+        quickJs.compile(javaScript, fileName).toByteString()
+      )
+
+      val buffer = Buffer()
+      ziplineFile.writeTo(buffer)
+      return buffer.readByteString()
+    }
   }
 }


### PR DESCRIPTION
It doesn't make sense for this function to spawn jobs that are
still running when the function returns. Instead do the scoping
internally.