### PR TITLE
Fix bugs in serializing sealed classes in flows

### DIFF
--- a/samples/emoji-search/presenters/build.gradle.kts
+++ b/samples/emoji-search/presenters/build.gradle.kts
@@ -27,6 +27,12 @@ kotlin {
   }
 }
 
+// TODO(jwilson): remove this once the Kotlin/JS devserver doesn't crash on boot.
+// https://stackoverflow.com/questions/69537840/kotlin-js-gradle-plugin-unable-to-load-webpack-cli-serve-command
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
+  rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().versions.webpackCli.version = "4.9.0"
+}
+
 dependencies {
   add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(":zipline-kotlin-plugin"))
 }

--- a/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -39,10 +39,10 @@ class EmojiSearchZipline {
   ) {
     val job = coroutineScope.launch(dispatcher) {
       val presentersJs = hostApi.httpCall("http://10.0.2.2:8080/presenters.js", mapOf())
-      zipline.quickJs.evaluate(presentersJs, "presenters.js")
+      zipline.loadJsModule(presentersJs, "presenters")
       zipline.set<HostApi>("hostApi", hostApi)
       zipline.quickJs.evaluate(
-        "presenters.app.cash.zipline.samples.emojisearch.preparePresenters()"
+        "require('presenters').app.cash.zipline.samples.emojisearch.preparePresenters()"
       )
       val presenter = zipline.get<EmojiSearchPresenter>("emojiSearchPresenter")
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/FlowReference.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/FlowReference.kt
@@ -37,7 +37,7 @@ class FlowReference<T> @PublishedApi internal constructor(
       try {
         val collector: FlowCollector<String> = object : FlowCollector<String> {
           override suspend fun emit(value: String) {
-            val item = Json.decodeFromString(itemSerializer, value)
+            val item = json.decodeFromString(itemSerializer, value)
             this@channelFlow.send(item)
           }
         }
@@ -82,7 +82,7 @@ private class RealReferenceFlow<T>(
     try {
       val collector = collectorReference.get()
       flow.collect {
-        val value = Json.encodeToString(serializer, it)
+        val value = json.encodeToString(serializer, it)
         collector.emit(value)
       }
     } finally {
@@ -132,4 +132,8 @@ private class DeferredSerializer<T>(
     val delegate = this.delegate ?: throw IllegalStateException("not connected")
     delegate.serialize(encoder, value)
   }
+}
+
+private val json = Json {
+  useArrayPolymorphism = true
 }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/SealedClassSerializersTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/SealedClassSerializersTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.SealedClassMessageService
+import app.cash.zipline.testing.SealedMessage.BlueMessage
+import app.cash.zipline.testing.SealedMessage.RedMessage
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SealedClassSerializersTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher)
+
+  @Before fun setUp(): Unit = runBlocking(dispatcher) {
+    zipline.loadTestingJs()
+  }
+
+  @After fun tearDown(): Unit = runBlocking(dispatcher) {
+    zipline.close()
+  }
+
+  @Test fun sealedClassesEncodeAndDecode(): Unit = runBlocking(dispatcher) {
+    val service = zipline.get<SealedClassMessageService>("sealedClassMessageService")
+    zipline.quickJs.evaluate(
+      "testing.app.cash.zipline.testing.prepareSealedClassMessageService()"
+    )
+
+    assertThat(service.colorSwap(RedMessage("hello!")))
+      .isEqualTo(BlueMessage("hello!"))
+  }
+
+  /**
+   * We recently had a bug where JSON use inside of flows didn't use `useArrayPolymorphism = true`,
+   * which prevented us from decoding what was encoded.
+   */
+  @Test fun sealedClassesFlow(): Unit = runBlocking(dispatcher) {
+    val service = zipline.get<SealedClassMessageService>("sealedClassMessageService")
+    zipline.quickJs.evaluate(
+      "testing.app.cash.zipline.testing.prepareSealedClassMessageService()"
+    )
+
+    val sealedMessageFlow = flow {
+      emit(RedMessage("a"))
+      emit(BlueMessage("b"))
+      emit(RedMessage("c"))
+    }
+    val swappedFlowReference = service.colorSwapFlow(sealedMessageFlow.asFlowReference())
+    val swappedFlow = swappedFlowReference.get()
+
+    assertThat(swappedFlow.toList()).containsExactly(
+      BlueMessage("a"),
+      RedMessage("b"),
+      BlueMessage("c"),
+    )
+  }
+}

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/sealedClassSerializers.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/sealedClassSerializers.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import app.cash.zipline.FlowReference
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+
+@Serializable
+sealed class SealedMessage {
+  @Serializable
+  data class RedMessage(val message: String) : SealedMessage()
+
+  @Serializable
+  data class BlueMessage(val message: String) : SealedMessage()
+}
+
+interface SealedClassMessageService {
+  fun colorSwap(request: SealedMessage): SealedMessage
+  fun colorSwapFlow(request: FlowReference<SealedMessage>): FlowReference<SealedMessage>
+}

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/sealedClassSerializersJs.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/sealedClassSerializersJs.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import app.cash.zipline.FlowReference
+import app.cash.zipline.Zipline
+import app.cash.zipline.asFlowReference
+import app.cash.zipline.testing.SealedMessage.BlueMessage
+import app.cash.zipline.testing.SealedMessage.RedMessage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+
+class JsSealedClassMessageService : SealedClassMessageService {
+  override fun colorSwap(request: SealedMessage): SealedMessage {
+    return when (request) {
+      is BlueMessage -> RedMessage(request.message)
+      is RedMessage -> BlueMessage(request.message)
+    }
+  }
+
+  override fun colorSwapFlow(request: FlowReference<SealedMessage>): FlowReference<SealedMessage> {
+    val requestFlow = request.get()
+    val flow: Flow<SealedMessage> = flow {
+      requestFlow.collect { message ->
+        emit(colorSwap(message))
+      }
+    }
+    return flow.asFlowReference()
+  }
+}
+
+private val zipline by lazy { Zipline.get() }
+
+@JsExport
+fun prepareSealedClassMessageService() {
+  zipline.set<SealedClassMessageService>(
+    "sealedClassMessageService",
+    JsSealedClassMessageService()
+  )
+}


### PR DESCRIPTION
We had a bug where we weren't configuring kotlinx.serialization's
polymorphic mode, but only inside flows.