### PR TITLE
Report function signature on unexpected function

### DIFF
--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -399,8 +399,8 @@ internal class AdapterGenerator(
    *
    * ```
    * when {
-   *   inboundCall.funName == "function1" -> ...
-   *   inboundCall.funName == "function2" -> ...
+   *   inboundCall.funName == "fun function1(com.example.RequestType1): com.example.ResponseType1" -> ...
+   *   inboundCall.funName == "fun function2(com.example.RequestType2): com.example.ResponseType2" -> ...
    *   ...
    *   else -> ...
    * }
@@ -421,7 +421,7 @@ internal class AdapterGenerator(
       result += irBranch(
         condition = irEquals(
           arg1 = irFunName(callFunction),
-          arg2 = irString(bridgedFunction.owner.name.identifier)
+          arg2 = irString(bridgedFunction.owner.signature)
         ),
         result = irBlock {
           +irCallEncodeResult(
@@ -737,7 +737,7 @@ internal class AdapterGenerator(
         ).apply {
           dispatchReceiver = irGet(result.dispatchReceiverParameter!!)
         }
-        putValueArgument(0, irString(bridgedFunction.name.identifier))
+        putValueArgument(0, irString(bridgedFunction.signature))
         putValueArgument(1, irInt(bridgedFunction.valueParameters.size))
       }
 

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/InboundBridgeRewriter.kt
@@ -86,7 +86,7 @@ import org.jetbrains.kotlin.name.Name
  *         override val context: Context = context
  *         override fun call(inboundCall: InboundCall): Array<String> {
  *           return when {
- *             inboundCall.funName == "echo" -> {
+ *             inboundCall.funName == "fun echo(com.example.EchoRequest): com.example.EchoResponse" -> {
  *               inboundCall.result(
  *                 serializer_1,
  *                 s.echo(
@@ -423,8 +423,8 @@ internal class InboundBridgeRewriter(
    *
    * ```
    * when {
-   *   inboundCall.funName == "function1" -> ...
-   *   inboundCall.funName == "function2" -> ...
+   *   inboundCall.funName == "fun function1(com.example.RequestType1): com.example.ResponseType1" -> ...
+   *   inboundCall.funName == "fun function2(com.example.RequestType2): com.example.ResponseType2" -> ...
    *   ...
    *   else -> ...
    * }
@@ -444,7 +444,7 @@ internal class InboundBridgeRewriter(
       result += irBranch(
         condition = irEquals(
           arg1 = irFunName(callFunction),
-          arg2 = irString(bridgedFunction.owner.name.identifier)
+          arg2 = irString(bridgedFunction.owner.signature)
         ),
         result = irBlock {
           +irCallEncodeResult(

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/OutboundBridgeRewriter.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/OutboundBridgeRewriter.kt
@@ -70,7 +70,7 @@ import org.jetbrains.kotlin.name.Name
  *       val serializer_1 = context.serializersModule.serializer<EchoResponse>()
  *       return object : EchoService {
  *         override fun echo(request: EchoRequest): EchoResponse {
- *           val outboundCall = context.newCall("echo", 1)
+ *           val outboundCall = context.newCall("fun echo(com.example.EchoService): com.example.EchoRequest", 1)
  *           outboundCall.parameter<EchoRequest>(serializer_0, request)
  *           return outboundCall.invoke(serializer_1)
  *         }
@@ -294,7 +294,7 @@ internal class OutboundBridgeRewriter(
     ) {
       val newCall = irCall(ziplineApis.outboundBridgeContextNewCall).apply {
         dispatchReceiver = irGet(createFunction.valueParameters[0])
-        putValueArgument(0, irString(bridgedFunction.name.identifier))
+        putValueArgument(0, irString(bridgedFunction.signature))
         putValueArgument(1, irInt(bridgedFunction.valueParameters.size))
       }
 

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -87,28 +87,6 @@ internal val IrSimpleFunction.signature: String
     append("fun ${name.identifier}(${valueParameters.joinToString { (it.type as IrSimpleType).asString() }}): ${(returnType as IrSimpleType).asString()}")
   }
 
-/** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
-fun IrSimpleType.asString(): String =
-  classifier.asString() +
-    (arguments.ifNotEmpty {
-      joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }
-    } ?: "") +
-    (if (hasQuestionMark) "?" else "")
-
-/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
-private fun IrTypeArgument.asString(): String = when (this) {
-  is IrStarProjection -> "*"
-  is IrTypeProjection -> variance.label + (if (variance != Variance.INVARIANT) " " else "") + (type as IrSimpleType).asString()
-  else -> error("Unexpected kind of IrTypeArgument: " + javaClass.simpleName)
-}
-
-/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
-private fun IrClassifierSymbol.asString() = when (this) {
-  is IrTypeParameterSymbol -> this.owner.name.asString()
-  is IrClassSymbol -> this.owner.fqNameWhenAvailable!!.asString()
-  else -> error("Unexpected kind of IrClassifierSymbol: " + javaClass.typeName)
-}
-
 internal fun FqName.child(name: String) = child(Name.identifier(name))
 
 /** Thrown on invalid or unexpected input code. */

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -56,19 +56,53 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrDelegatingConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnTargetSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrPropertySymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrStarProjection
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+
+internal val IrSimpleFunction.signature: String
+  get() = "fun ${name.identifier}(${valueParameters.joinToString { (it.type as IrSimpleType).asString() }}): ${(returnType as IrSimpleType).asString()}"
+
+/** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+fun IrSimpleType.asString(): String =
+  classifier.asString() +
+    (if (hasQuestionMark) "?" else "") +
+    (arguments.ifNotEmpty {
+      joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }
+    } ?: "")
+
+/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+private fun IrTypeArgument.asString(): String = when (this) {
+  is IrStarProjection -> "*"
+  is IrTypeProjection -> variance.label + (if (variance != Variance.INVARIANT) " " else "") + (type as IrSimpleType).asString()
+  else -> error("Unexpected kind of IrTypeArgument: " + javaClass.simpleName)
+}
+
+/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+private fun IrClassifierSymbol.asString() = when (this) {
+  is IrTypeParameterSymbol -> this.owner.name.asString()
+  is IrClassSymbol -> this.owner.fqNameWhenAvailable!!.asString()
+  else -> error("Unexpected kind of IrClassifierSymbol: " + javaClass.typeName)
+}
 
 internal fun FqName.child(name: String) = child(Name.identifier(name))
 

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -90,10 +90,10 @@ internal val IrSimpleFunction.signature: String
 /** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
 fun IrSimpleType.asString(): String =
   classifier.asString() +
-    (if (hasQuestionMark) "?" else "") +
     (arguments.ifNotEmpty {
       joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }
-    } ?: "")
+    } ?: "") +
+    (if (hasQuestionMark) "?" else "")
 
 /** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
 private fun IrTypeArgument.asString(): String = when (this) {

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -80,7 +80,12 @@ import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 internal val IrSimpleFunction.signature: String
-  get() = "fun ${name.identifier}(${valueParameters.joinToString { (it.type as IrSimpleType).asString() }}): ${(returnType as IrSimpleType).asString()}"
+  get() = buildString {
+    if (isSuspend) {
+      append("suspend ")
+    }
+    append("fun ${name.identifier}(${valueParameters.joinToString { (it.type as IrSimpleType).asString() }}): ${(returnType as IrSimpleType).asString()}")
+  }
 
 /** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
 fun IrSimpleType.asString(): String =

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package app.cash.zipline.kotlin
+
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrStarProjection
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+
+/** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+fun IrSimpleType.asString(): String =
+  classifier.asString() +
+    (arguments.ifNotEmpty {
+      joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }
+    } ?: "") +
+    (if (hasQuestionMark) "?" else "")
+
+/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+private fun IrTypeArgument.asString(): String = when (this) {
+  is IrStarProjection -> "*"
+  is IrTypeProjection -> variance.label + (if (variance != Variance.INVARIANT) " " else "") + (type as IrSimpleType).asString()
+  else -> error("Unexpected kind of IrTypeArgument: " + javaClass.simpleName)
+}
+
+/** Copied from [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
+private fun IrClassifierSymbol.asString() = when (this) {
+  is IrTypeParameterSymbol -> this.owner.name.asString()
+  is IrClassSymbol -> this.owner.fqNameWhenAvailable!!.asString()
+  else -> error("Unexpected kind of IrClassifierSymbol: " + javaClass.typeName)
+}

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -76,7 +76,7 @@ public final class ZiplineTestInternals {
             = (KSerializer) serializer(context.getSerializersModule(), echoResponseKt);
         return new EchoService() {
           @Override public EchoResponse echo(EchoRequest request) {
-            OutboundCall outboundCall = context.newCall("echo", 1);
+            OutboundCall outboundCall = context.newCall("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse", 1);
             outboundCall.parameter(parameterSerializer, request);
             return outboundCall.invoke(resultSerializer);
           }
@@ -104,7 +104,7 @@ public final class ZiplineTestInternals {
           }
 
           @Override public String[] call(InboundCall inboundCall) {
-            if (inboundCall.getFunName().equals("echo")) {
+            if (inboundCall.getFunName().equals("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse")) {
               return inboundCall.result(resultSerializer, getService().echo(
                   inboundCall.parameter(parameterSerializer)));
             } else {
@@ -131,7 +131,7 @@ public final class ZiplineTestInternals {
             = (KSerializer) serializer(context.getSerializersModule(), listOfStringKt);
         return new GenericEchoService<String>() {
           @Override public List<String> genericEcho(String request) {
-            OutboundCall outboundCall = context.newCall("genericEcho", 1);
+            OutboundCall outboundCall = context.newCall("fun genericEcho(T): kotlin.collections.List<T>", 1);
             outboundCall.parameter(parameterSerializer, request);
             return outboundCall.invoke(resultSerializer);
           }
@@ -160,7 +160,7 @@ public final class ZiplineTestInternals {
           }
 
           @Override public String[] call(InboundCall inboundCall) {
-            if (inboundCall.getFunName().equals("genericEcho")) {
+            if (inboundCall.getFunName().equals("fun genericEcho(T): kotlin.collections.List<T>")) {
               return inboundCall.result(resultSerializer, getService().genericEcho(
                   inboundCall.parameter(parameterSerializer)));
             } else {
@@ -220,7 +220,7 @@ public final class ZiplineTestInternals {
 
       @Override
       public String[] call(InboundCall inboundCall) {
-        if (inboundCall.getFunName().equals("echo")) {
+        if (inboundCall.getFunName().equals("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse")) {
           return inboundCall.result(responseSerializer, service.echo(
             inboundCall.parameter(requestSerializer)));
         } else {
@@ -249,7 +249,7 @@ public final class ZiplineTestInternals {
       }
 
       @Override public EchoResponse echo(EchoRequest request) {
-        OutboundCall outboundCall = context.newCall("echo", 1);
+        OutboundCall outboundCall = context.newCall("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse", 1);
         outboundCall.parameter(requestSerializer, request);
         return outboundCall.invoke(responseSerializer);
       }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -118,7 +118,7 @@ class Endpoint internal constructor(
      */
     private fun takeHandler(instanceName: String, funName: String): InboundCallHandler {
       val result = when (funName) {
-        "close" -> inboundHandlers.remove(instanceName)
+        "fun close(): kotlin.Unit" -> inboundHandlers.remove(instanceName)
         else -> inboundHandlers[instanceName]
       }
       return result ?: error("no handler for $instanceName")

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -69,7 +69,7 @@ interface SampleService : ZiplineService {
 
         override fun call(inboundCall: InboundCall): Array<String> {
           return when (inboundCall.funName) {
-            "ping" -> {
+            "fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse" -> {
               inboundCall.result(
                 responseSerializer,
                 service.ping(
@@ -77,7 +77,7 @@ interface SampleService : ZiplineService {
                 )
               )
             }
-            "close" -> {
+            "fun close(): kotlin.Unit" -> {
               inboundCall.result(
                 Unit.serializer(),
                 service.close()
@@ -105,13 +105,13 @@ interface SampleService : ZiplineService {
         private val responseSerializer = context.serializersModule.serializer<SampleResponse>()
 
         override fun ping(request: SampleRequest): SampleResponse {
-          val call = context.newCall("ping", 1)
+          val call = context.newCall("fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse", 1)
           call.parameter(requestSerializer, request)
           return call.invoke(responseSerializer)
         }
 
         override fun close() {
-          val call = context.newCall("close", 0)
+          val call = context.newCall("fun close(): kotlin.Unit", 0)
           return call.invoke(Unit.serializer())
         }
       }

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
@@ -18,3 +18,7 @@ package app.cash.zipline.testing
 interface PotatoService {
   fun echo(): EchoResponse
 }
+
+interface SuspendingPotatoService {
+  suspend fun echo(): EchoResponse
+}

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+interface PotatoService {
+  fun echo(): EchoResponse
+}

--- a/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
+++ b/zipline/testing/src/jsMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
@@ -1,0 +1,41 @@
+package app.cash.zipline.testing
+
+import app.cash.zipline.Zipline
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+class JsSuspendingPotatoService(
+  private val greeting: String
+) : SuspendingPotatoService {
+  override suspend fun echo(): EchoResponse {
+    return EchoResponse("$greeting from suspending JavaScript, anonymous")
+  }
+}
+
+private val zipline by lazy { Zipline.get() }
+
+@JsExport
+fun prepareSuspendingPotatoJsBridges() {
+  zipline.set<SuspendingPotatoService>(
+    "jsSuspendingPotatoService",
+    JsSuspendingPotatoService("hello")
+  )
+}
+
+@JsExport
+fun callSuspendingPotatoService() {
+  val service = zipline.get<SuspendingPotatoService>("jvmSuspendingPotatoService")
+  GlobalScope.launch {
+    try {
+      suspendingPotatoResult = service.echo().message
+    } catch (e: Exception) {
+      suspendingPotatoException = e.stackTraceToString()
+    }
+  }
+}
+
+@JsExport
+var suspendingPotatoResult: String? = null
+
+@JsExport
+var suspendingPotatoException: String? = null


### PR DESCRIPTION
When faced with an unexpected function (e.g., via incompatible APIs) we currently just display the function name. This isn't super useful if the function name is the same but the parameter types or return type differs.

Through this change, we now display the whole function signature (except for the function location due to our use of duck typing), so instead of `echo` we'd have `fun echo(com.example.Request): com.example.Response`.

This is the first part of the solution to #402.