### PR TITLE
Support serializing ZiplineServices

### DIFF
--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -93,7 +93,7 @@ internal class AdapterGenerator(
   private fun getOrCreateAdapterClass(
     companion: IrClass
   ): IrClass {
-    // object Adapter : ZiplineServiceAdapter<SampleService>() {
+    // object Adapter : ZiplineServiceAdapter<SampleService>(), KSerializer<SampleService> {
     //   ...
     // }
     val existing = companion.declarations.firstOrNull {
@@ -108,7 +108,10 @@ internal class AdapterGenerator(
       visibility = DescriptorVisibilities.PUBLIC
     }.apply {
       parent = companion
-      superTypes = listOf(ziplineApis.ziplineServiceAdapter.typeWith(original.defaultType))
+      superTypes = listOf(
+        ziplineApis.ziplineServiceAdapter.typeWith(original.defaultType),
+        ziplineApis.kSerializer.typeWith(original.defaultType),
+      )
       createImplicitParameterDeclarationWithWrappedDescriptor()
     }
 

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -146,6 +146,9 @@ internal class ZiplineApis(
       outboundBridgeContextFqName.child("endpoint")
     ).single()
 
+  val ziplineService: IrClassSymbol
+    get() = pluginContext.referenceClass(ziplineServiceFqName)!!
+
   val ziplineServiceAdapter: IrClassSymbol
     get() = pluginContext.referenceClass(ziplineServiceAdapterFqName)!!
 

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -56,28 +56,20 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrDelegatingConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnTargetSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
-import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrPropertySymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
-import org.jetbrains.kotlin.ir.types.IrStarProjection
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.IrTypeArgument
-import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.types.Variance
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 internal val IrSimpleFunction.signature: String
   get() = buildString {

--- a/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -24,6 +24,7 @@ import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import kotlin.test.assertEquals
+import kotlinx.serialization.KSerializer
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.junit.Ignore
 import org.junit.Test
@@ -52,6 +53,7 @@ class ZiplineKotlinPluginTest {
       "app.cash.zipline.testing.SampleService\$Companion\$Adapter"
     )
     assertThat(adapterClass).isNotNull()
+    assertThat(adapterClass.interfaces).asList().containsExactly(KSerializer::class.java)
   }
 
   @Test

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -58,6 +58,7 @@ class Endpoint internal constructor(
 
   private fun computeSerializersModule(): SerializersModule {
     return SerializersModule {
+      contextual(SerializableEndpoint::class, SerializableEndpointSerializer(this@Endpoint))
       contextual(Throwable::class, ThrowableSerializer)
       contextual(FlowReference::class) {
         FlowReferenceSerializer(ziplineReferenceSerializer(ziplineServiceAdapter()), it[0])

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/serializableEndpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/serializableEndpoint.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import app.cash.zipline.ZiplineService
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * This is used with [ZiplineServiceAdapter] to pass services between runtimes by reference and not
+ * by value. This calls [Endpoint.bind] when serializing, and deserializers call [Endpoint.take].
+ */
+interface SerializableEndpoint
+
+internal class DeserializedEndpoint(
+  var name: String,
+  var endpoint: Endpoint,
+) : SerializableEndpoint
+
+internal class SerializedEndpoint<T : ZiplineService>(
+  val service: T,
+  val adapter: ZiplineServiceAdapter<T>,
+) : SerializableEndpoint {
+  fun bindToEndpoint(endpoint: Endpoint, name: String) {
+    endpoint.bind(name, service, adapter)
+  }
+}
+
+internal class SerializableEndpointSerializer(
+  val endpoint: Endpoint,
+) : KSerializer<SerializableEndpoint> {
+  override val descriptor = PrimitiveSerialDescriptor("SerializableEndpoint", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: SerializableEndpoint) {
+    require(value is SerializedEndpoint<*>)
+    val name = endpoint.generateName()
+    value.bindToEndpoint(endpoint, name)
+    encoder.encodeString(name)
+  }
+
+  override fun deserialize(decoder: Decoder): SerializableEndpoint {
+    val name = decoder.decodeString()
+    return DeserializedEndpoint(name, endpoint)
+  }
+}

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -20,6 +20,7 @@ import app.cash.zipline.internal.bridge.InboundCall
 import app.cash.zipline.internal.bridge.InboundCallHandler
 import app.cash.zipline.internal.bridge.OutboundBridge
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.serializer
@@ -47,7 +48,8 @@ interface SampleService : ZiplineService {
      * mostly to model what the expected generated code should look like when making changes to
      * `AdapterGenerator`.
      */
-    internal object ManualAdapter : ZiplineServiceAdapter<SampleService>() {
+    internal object ManualAdapter
+      : ZiplineServiceAdapter<SampleService>(), KSerializer<SampleService> {
       override val serialName: String = "SampleService"
 
       override fun inboundCallHandler(


### PR DESCRIPTION
Currently this only works if the service is a parameter or return
type of another ZiplineService.

I tried quite hard to make it work everywhere using `@Serializable`
but that required some pretty ugly compromises. In particular we'd
need to either register services explicitly, or lean on implementation
details of kotlinx.serialization and convert ZiplineService from an
interface to an abstract class.