### PR TITLE
Run publish job on MacOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
           script: ./gradlew connectedCheck
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs:
       - build
       - android-emulator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
           script: ./gradlew connectedCheck
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs:
       - build
       - android-emulator


### PR DESCRIPTION
We need to get iOS/tvOS/MacOS artifacts from Kotlin/Native which can only be built on a Mac.