### PR TITLE
Embedded resources should use hex representation for file name

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -112,7 +112,7 @@ class ZiplineLoader(
 
     /** Attempt to load from, in prioritized order: embedded, cache, network */
     suspend fun load() {
-      val embeddedPath = embeddedDirectory / module.sha256
+      val embeddedPath = embeddedDirectory / module.sha256.hex()
       val ziplineFileBytes = if (embeddedFileSystem.exists(embeddedPath)) {
         embeddedFileSystem.read(embeddedPath, BufferedSource::readByteString)
       } else {

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -146,10 +146,10 @@ class ZiplineLoaderTest {
   fun loaderUsesResourcesBeforeCacheButManifestOverNetwork(): Unit = runBlocking(dispatcher) {
     // seed the resources FS with zipline files
     embeddedFileSystem.createDirectories(embeddedDirectory)
-    embeddedFileSystem.write(embeddedDirectory / alphaBytecode(quickJs).sha256()) {
+    embeddedFileSystem.write(embeddedDirectory / alphaBytecode(quickJs).sha256().hex()) {
       write(alphaBytecode(quickJs))
     }
-    embeddedFileSystem.write(embeddedDirectory / bravoBytecode(quickJs).sha256()) {
+    embeddedFileSystem.write(embeddedDirectory / bravoBytecode(quickJs).sha256().hex()) {
       write(bravoBytecode(quickJs))
     }
 
@@ -176,10 +176,10 @@ class ZiplineLoaderTest {
     embeddedFileSystem.write(embeddedDirectory / PREBUILT_MANIFEST_FILE_NAME) {
       write(Json.encodeToString(manifest(quickJs)).encodeUtf8())
     }
-    embeddedFileSystem.write(embeddedDirectory / alphaBytecode(quickJs).sha256()) {
+    embeddedFileSystem.write(embeddedDirectory / alphaBytecode(quickJs).sha256().hex()) {
       write(alphaBytecode(quickJs))
     }
-    embeddedFileSystem.write(embeddedDirectory / bravoBytecode(quickJs).sha256()) {
+    embeddedFileSystem.write(embeddedDirectory / bravoBytecode(quickJs).sha256().hex()) {
       write(bravoBytecode(quickJs))
     }
 


### PR DESCRIPTION
Previously the SHA256 was being used in byte form. If the hash started with 0x5C this was interpreted as a backslash which made the relative path resolution fail as that is the representation for a Windows-style root.

~There are no tests for this type... but clearly we need some.~ Ah, they're JVM-only!