### PR TITLE
Add more events to EventListener

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
@@ -15,8 +15,72 @@
  */
 package app.cash.zipline
 
+/**
+ * Listener for metrics and debugging.
+ *
+ * All event methods must execute fast, without external locking, cannot throw exceptions, attempt
+ * to mutate the event parameters, or be re-entrant back into the client. Any IO - writing to files
+ * or network should be done asynchronously.
+ */
 abstract class EventListener {
-  open fun instanceLeaked(name: String, stacktrace: Exception?) {
+  /** Invoked when something calls [Zipline.bind], or a service is sent via an API. */
+  open fun bindService(name: String, service: ZiplineService) {
+  }
+
+  /** Invoked when something calls [Zipline.take], or a service is received via an API. */
+  open fun takeService(name: String, service: ZiplineService) {
+  }
+
+  /**
+   * Invoked when a service function is called. This may be invoked for either suspending or
+   * non-suspending functions.
+   *
+   * @return any object. This value will be passed back to [callEnd] or [callFailed] when the call
+   *     is completed. The base function always returns null.
+   */
+  open fun callStart(
+    name: String,
+    service: ZiplineService,
+    functionName: String,
+    args: List<Any?>,
+  ): Any? {
+    return null
+  }
+
+  /**
+   * Invoked when a service function call completes successfully.
+   *
+   * @param callStartResult the value returned by [callStart] for the start of this call. This is
+   *     null unless [callStart] is overridden to return something else.
+   */
+  open fun callEnd(
+    name: String,
+    functionName: String,
+    service: ZiplineService,
+    args: List<Any?>,
+    result: Any?,
+    callStartResult: Any?
+  ) {
+  }
+
+  /**
+   * Invoked when a service function call fails with an exception.
+   *
+   * @param callStartResult the value returned by [callStart] for the start of this call. This is
+   *     null unless [callStart] is overridden to return something else.
+   */
+  open fun callFailed(
+    name: String,
+    functionName: String,
+    service: ZiplineService,
+    args: List<Any?>,
+    exception: Throwable?,
+    callStartResult: Any?
+  ) {
+  }
+
+  /** Invoked when a service is garbage collected without being closed. */
+  open fun serviceLeaked(name: String) {
   }
 
   companion object {

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
@@ -52,7 +52,7 @@ private class ZiplineServiceReference(
   fun afterGc() {
     allReferencesSet.remove(this)
     if (!context.closed) {
-      eventListener.instanceLeaked(name, null)
+      eventListener.serviceLeaked(name)
     }
   }
 }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/LeakedServicesTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/LeakedServicesTest.kt
@@ -17,7 +17,6 @@ package app.cash.zipline
 
 import app.cash.zipline.testing.EchoService
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -28,8 +27,8 @@ import org.junit.Test
 class LeakedServicesTest {
   private val events = Channel<String>(capacity = Int.MAX_VALUE)
   private val eventListener = object : EventListener() {
-    override fun instanceLeaked(name: String, stacktrace: Exception?) {
-      val sent = events.trySend("instanceLeaked($name, $stacktrace)")
+    override fun serviceLeaked(name: String) {
+      val sent = events.trySend("serviceLeaked($name)")
       check(sent.isSuccess)
     }
   }
@@ -52,7 +51,7 @@ class LeakedServicesTest {
     allocateAndLeakService()
     awaitGarbageCollection()
     triggerLeakDetection()
-    assertThat(events.receive()).isEqualTo("instanceLeaked(helloService, null)")
+    assertThat(events.receive()).isEqualTo("serviceLeaked(helloService)")
   }
 
   /** Just attempting to take a service causes Zipline to process leaked services. */


### PR DESCRIPTION
I haven't called out whether the host is the caller or the receiver
of the call. Is this useful?

I also haven't made suspending functions special. My assumption is
the implementation will do fancy things to make the suspend callback
look like a single regular function call.

Lastly I think we always implement this interface on the host platform
but call it from either platform. That'll require some asymmetry.