### PR TITLE
Get the JS engine to do JSON decoding

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
@@ -16,6 +16,8 @@
 package app.cash.zipline.internal.bridge
 
 import app.cash.zipline.ZiplineService
+import app.cash.zipline.internal.decodeFromStringFast
+import app.cash.zipline.internal.encodeToStringFast
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.ContextualSerializer
@@ -62,7 +64,7 @@ internal class FlowSerializer<T>(
       override suspend fun collectJson(collector: FlowZiplineCollector) {
         try {
           this@toZiplineService.collect {
-            val value = json.encodeToString(itemSerializer, it)
+            val value = json.encodeToStringFast(itemSerializer, it)
             collector.emit(value)
           }
         } finally {
@@ -85,7 +87,7 @@ internal class FlowSerializer<T>(
       try {
         val collector = object : FlowZiplineCollector {
           override suspend fun emit(value: String) {
-            val item = json.decodeFromString(itemSerializer, value)
+            val item = json.decodeFromStringFast(itemSerializer, value)
             this@channelFlow.send(item)
           }
         }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -16,6 +16,8 @@
 package app.cash.zipline.internal.bridge
 
 import app.cash.zipline.ZiplineApiMismatchException
+import app.cash.zipline.internal.decodeFromStringFast
+import app.cash.zipline.internal.encodeToStringFast
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
@@ -63,7 +65,7 @@ internal class InboundCall(
     while (i < arguments.size) {
       when (arguments[i]) {
         LABEL_VALUE -> {
-          val result = context.json.decodeFromString(serializer, arguments[i + 1])
+          val result = context.json.decodeFromStringFast(serializer, arguments[i + 1])
           i += 2
           return result
         }
@@ -81,7 +83,7 @@ internal class InboundCall(
 
   fun <R> result(serializer: KSerializer<R>, value: R): Array<String> {
     return when {
-      value != null -> arrayOf(LABEL_VALUE, context.json.encodeToString(serializer, value))
+      value != null -> arrayOf(LABEL_VALUE, context.json.encodeToStringFast(serializer, value))
       else -> arrayOf(LABEL_NULL, "")
     }
   }
@@ -98,6 +100,6 @@ internal class InboundCall(
   )
 
   fun resultException(e: Throwable): Array<String> {
-    return arrayOf(LABEL_EXCEPTION, context.json.encodeToString(ThrowableSerializer, e))
+    return arrayOf(LABEL_EXCEPTION, context.json.encodeToStringFast(ThrowableSerializer, e))
   }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -15,6 +15,8 @@
  */
 package app.cash.zipline.internal.bridge
 
+import app.cash.zipline.internal.decodeFromStringFast
+import app.cash.zipline.internal.encodeToStringFast
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.launch
@@ -73,7 +75,7 @@ internal class OutboundCall(
       arguments += ""
     } else {
       arguments += LABEL_VALUE
-      arguments += context.json.encodeToString(serializer, value)
+      arguments += context.json.encodeToStringFast(serializer, value)
     }
   }
 
@@ -129,10 +131,10 @@ internal class OutboundCall(
           return Result.success(null as R)
         }
         LABEL_VALUE -> {
-          return Result.success(context.json.decodeFromString(serializer, this[1]))
+          return Result.success(context.json.decodeFromStringFast(serializer, this[1]))
         }
         LABEL_EXCEPTION -> {
-          return Result.failure(context.json.decodeFromString(ThrowableSerializer, this[1]))
+          return Result.failure(context.json.decodeFromStringFast(ThrowableSerializer, this[1]))
         }
         else -> i += 2
       }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/jsonCommon.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/jsonCommon.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+/*
+ * In QuickJS (version 2021-03-27) it's faster to ask the JavaScript engine to parse JSON to a
+ * dynamic value (ie. JSON.parse()) and bind that to a Kotlin Objects, than to parse and bind all
+ * in Kotlin/JS. In one sample this optimization reduced overall execution time by 35%.
+ */
+
+expect fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T
+
+expect fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T =
+  decodeFromString(deserializer, string)
+
+actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String =
+  encodeToString(serializer, value)

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/internal/jsonJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/internal/jsonJs.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromDynamic
+import kotlinx.serialization.json.encodeToDynamic
+
+@OptIn(ExperimentalSerializationApi::class)
+actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T =
+  decodeFromDynamic(deserializer, JSON.parse(string))
+
+@OptIn(ExperimentalSerializationApi::class)
+actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String =
+  JSON.stringify(encodeToDynamic(serializer, value))


### PR DESCRIPTION
This saved 35% of overall execution time in one benchmark.