### PR TITLE
Stop assuming the HTTP client has a base URL

### DIFF
--- a/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.launch
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path
@@ -43,14 +42,13 @@ class EmojiSearchZipline(
   private val client = OkHttpClient()
   private val hostApi = RealHostApi(client)
 
-  private val baseUrl = "http://10.0.2.2:8080/".toHttpUrl()
-  private val manifestPath = "/manifest.zipline.json"
+  private val manifestUrl = "http://10.0.2.2:8080/manifest.zipline.json"
   private val moduleName = "./zipline-root-presenters.js"
 
   private val driver = DriverFactory().createDriver()
   private val ziplineLoader = ZiplineLoader(
     dispatcher = dispatcher,
-    httpClient = OkHttpZiplineHttpClient(baseUrl, client),
+    httpClient = OkHttpZiplineHttpClient(client),
     embeddedDir = embeddedDir,
     embeddedFileSystem = FileSystem.RESOURCES, // TODO use assets
     cacheDbDriver = driver,
@@ -65,7 +63,7 @@ class EmojiSearchZipline(
     modelsStateFlow: MutableStateFlow<EmojiSearchViewModel>
   ) {
     val job = coroutineScope.launch(dispatcher) {
-      ziplineLoader.load(zipline, manifestPath)
+      ziplineLoader.load(zipline, manifestUrl)
       zipline.bind<HostApi>("hostApi", hostApi)
       zipline.quickJs.evaluate(
         "require('$moduleName').app.cash.zipline.samples.emojisearch.preparePresenters()"

--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -20,7 +20,6 @@ import app.cash.zipline.loader.DriverFactory
 import app.cash.zipline.loader.OkHttpZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -31,10 +30,10 @@ fun getTriviaService(zipline: Zipline): TriviaService {
 
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   val zipline = Zipline.create(dispatcher)
-  val baseUrl = "http://localhost:8080/".toHttpUrl()
+  val manifestUrl = "http://localhost:8080/manifest.zipline.json"
   val loader = ZiplineLoader(
     dispatcher = dispatcher,
-    httpClient = OkHttpZiplineHttpClient(baseUrl, OkHttpClient()),
+    httpClient = OkHttpZiplineHttpClient(OkHttpClient()),
     embeddedDir = "/".toPath(),
     embeddedFileSystem = FileSystem.RESOURCES,
     cacheDbDriver = DriverFactory().createDriver(),
@@ -43,7 +42,7 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
     cacheMaxSizeInBytes = 10 * 1024 * 1024,
     nowMs = System::currentTimeMillis,
   )
-  loader.load(zipline, baseUrl.resolve("/manifest.zipline.json").toString())
+  loader.load(zipline, manifestUrl)
   val moduleName = "./zipline-root-trivia-js.js"
   zipline.quickJs.evaluate(
     "require('$moduleName').app.cash.zipline.samples.trivia.launchZipline()",

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
@@ -23,7 +23,6 @@ import java.io.File
 import java.util.concurrent.Executors
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -43,14 +42,11 @@ class Download : Runnable {
   private val dispatcher = executorService.asCoroutineDispatcher()
   private val client = OkHttpClient()
 
-  // Dummy base url
-  private val baseUrl = "http://10.0.2.2:8080/".toHttpUrl()
-
   private fun download(manifestUrl: String, downloadDir: File) {
     println("Zipline Download [manifestUrl=$manifestUrl][downloadDir=$downloadDir]...")
     val ziplineDownloader = ZiplineDownloader(
       dispatcher = dispatcher,
-      httpClient = OkHttpZiplineHttpClient(baseUrl, client),
+      httpClient = OkHttpZiplineHttpClient(client),
       downloadDir = downloadDir.toOkioPath(),
       downloadFileSystem = FileSystem.SYSTEM,
     )

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
@@ -22,7 +22,6 @@ import java.io.File
 import java.util.concurrent.Executors
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -32,13 +31,10 @@ class ZiplineGradleDownloader {
   private val dispatcher = executorService.asCoroutineDispatcher()
   private val client = OkHttpClient()
 
-  // Dummy base url
-  private val baseUrl = "http://10.0.2.2:8080/".toHttpUrl()
-
   fun download(manifestUrl: String, downloadDir: File) {
     val ziplineDownloader = ZiplineDownloader(
       dispatcher = dispatcher,
-      httpClient = OkHttpZiplineHttpClient(baseUrl, client),
+      httpClient = OkHttpZiplineHttpClient(client),
       downloadDir = downloadDir.toOkioPath(),
       downloadFileSystem = FileSystem.SYSTEM,
     )

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineDownloader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineDownloader.kt
@@ -66,7 +66,7 @@ class ZiplineDownloader(
     val manifestByteString = concurrentDownloadsSemaphore.withPermit {
       httpClient.download(manifestUrl)
     }
-    val manifest = Json.decodeFromString<ZiplineManifest>(manifestByteString.utf8())
+    val manifest = Json.decodeFromString(ZiplineManifest.serializer(), manifestByteString.utf8())
     return httpClient.resolveUrls(manifest, manifestUrl)
   }
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineDownloader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineDownloader.kt
@@ -66,7 +66,8 @@ class ZiplineDownloader(
     val manifestByteString = concurrentDownloadsSemaphore.withPermit {
       httpClient.download(manifestUrl)
     }
-    return Json.decodeFromString(manifestByteString.utf8())
+    val manifest = Json.decodeFromString<ZiplineManifest>(manifestByteString.utf8())
+    return httpClient.resolveUrls(manifest, manifestUrl)
   }
 
   companion object {

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
@@ -19,4 +19,23 @@ import okio.ByteString
 
 interface ZiplineHttpClient {
   suspend fun download(url: String): ByteString
+
+  /** Returns the URL of [link] relative to [baseUrl]. */
+  fun resolve(baseUrl: String, link: String): String
+}
+
+/**
+ * Returns a manifest equivalent to [manifest], but with module URLs resolved against [baseUrl].
+ * This way consumers of the manifest don't need to know the URL that the manifest was downloaded
+ * from.
+ */
+internal fun ZiplineHttpClient.resolveUrls(
+  manifest: ZiplineManifest,
+  baseUrl: String
+): ZiplineManifest {
+  return manifest.copy(
+    modules = manifest.modules.mapValues { (_, module) ->
+      module.copy(url = resolve(baseUrl, module.url))
+    }
+  )
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -93,6 +93,7 @@ class ZiplineLoader(
       }
     }
 
-    return Json.decodeFromString(manifestByteString.utf8())
+    val manifest = Json.decodeFromString<ZiplineManifest>(manifestByteString.utf8())
+    return httpClient.resolveUrls(manifest, manifestUrl)
   }
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -93,7 +93,7 @@ class ZiplineLoader(
       }
     }
 
-    val manifest = Json.decodeFromString<ZiplineManifest>(manifestByteString.utf8())
+    val manifest = Json.decodeFromString(ZiplineManifest.serializer(), manifestByteString.utf8())
     return httpClient.resolveUrls(manifest, manifestUrl)
   }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
@@ -25,4 +25,9 @@ class FakeZiplineHttpClient: ZiplineHttpClient {
   override suspend fun download(url: String): ByteString {
     return filePathToByteString[url] ?: throw IOException("404: $url not found")
   }
+
+  /** Note: this naive resolve() that doesn't support `../` etc. */
+  override fun resolve(baseUrl: String, link: String): String {
+    return baseUrl.substringBeforeLast("/") + "/" + link
+  }
 }

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
@@ -29,15 +29,13 @@ import okhttp3.Response
 import okio.ByteString
 
 class OkHttpZiplineHttpClient(
-  private val baseUrl: HttpUrl,
   private val okHttpClient: OkHttpClient
 ) : ZiplineHttpClient {
   override suspend fun download(url: String): ByteString {
     return suspendCancellableCoroutine { continuation ->
-      val fullUrl = baseUrl.resolve(url)!!
       val call = okHttpClient.newCall(
         Request.Builder()
-          .url(fullUrl)
+          .url(url)
           .build()
       )
 

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -70,4 +71,7 @@ class OkHttpZiplineHttpClient(
       })
     }
   }
+
+  override fun resolve(baseUrl: String, link: String) =
+    baseUrl.toHttpUrl().resolve(link)!!.toString()
 }

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineDownloaderTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineDownloaderTest.kt
@@ -16,9 +16,9 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.QuickJs
-import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaFilePath
-import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoFilePath
-import app.cash.zipline.loader.TestFixturesJvm.Companion.manifestPath
+import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaUrl
+import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoUrl
+import app.cash.zipline.loader.TestFixturesJvm.Companion.manifestUrl
 import app.cash.zipline.loader.ZiplineDownloader.Companion.PREBUILT_MANIFEST_FILE_NAME
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -42,10 +42,6 @@ class ZiplineDownloaderTest {
   private lateinit var quickJs: QuickJs
   private lateinit var testFixturesJvm: TestFixturesJvm
   private lateinit var downloader: ZiplineDownloader
-
-  private fun alphaBytecode(quickJs: QuickJs) = testFixturesJvm.alphaByteString
-  private fun bravoBytecode(quickJs: QuickJs) = testFixturesJvm.bravoByteString
-  private fun manifest(quickJs: QuickJs) = testFixturesJvm.manifest
 
   @Before
   fun setUp() {
@@ -71,11 +67,11 @@ class ZiplineDownloaderTest {
     assertFalse(fileSystem.exists(downloadDir / testFixturesJvm.bravoSha256Hex))
 
     httpClient.filePathToByteString = mapOf(
-      manifestPath to testFixturesJvm.manifestByteString,
-      alphaFilePath to testFixturesJvm.alphaByteString,
-      bravoFilePath to testFixturesJvm.bravoByteString
+      manifestUrl to testFixturesJvm.manifestWithRelativeUrlsByteString,
+      alphaUrl to testFixturesJvm.alphaByteString,
+      bravoUrl to testFixturesJvm.bravoByteString
     )
-    downloader.download(manifestPath)
+    downloader.download(manifestUrl)
 
     // check that files have been downloaded to downloadDir as expected
     assertTrue(fileSystem.exists(downloadDir / PREBUILT_MANIFEST_FILE_NAME))

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/interceptors/DownloadOnlyInterceptorTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/interceptors/DownloadOnlyInterceptorTest.kt
@@ -19,8 +19,8 @@ package app.cash.zipline.loader.interceptors
 import app.cash.zipline.QuickJs
 import app.cash.zipline.loader.FakeZiplineHttpClient
 import app.cash.zipline.loader.TestFixturesJvm
-import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaFilePath
-import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoFilePath
+import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaUrl
+import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoUrl
 import app.cash.zipline.loader.ZiplineModuleLoader
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import kotlin.test.assertEquals
@@ -70,8 +70,8 @@ class DownloadOnlyInterceptorTest {
   @Test
   fun getFileFromNetworkSaveToFs(): Unit = runBlocking {
     httpClient.filePathToByteString = mapOf(
-      alphaFilePath to testFixturesJvm.alphaByteString,
-      bravoFilePath to testFixturesJvm.bravoByteString,
+      alphaUrl to testFixturesJvm.alphaByteString,
+      bravoUrl to testFixturesJvm.bravoByteString,
     )
 
     moduleLoader.load(testFixturesJvm.manifest)

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/interceptors/ProductionInterceptorTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/interceptors/ProductionInterceptorTest.kt
@@ -23,8 +23,8 @@ import app.cash.zipline.loader.FakeZiplineHttpClient
 import app.cash.zipline.loader.TestFixturesJvm
 import app.cash.zipline.loader.ZiplineCache
 import app.cash.zipline.loader.ZiplineModuleLoader
-import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaFilePath
-import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoFilePath
+import app.cash.zipline.loader.TestFixturesJvm.Companion.alphaUrl
+import app.cash.zipline.loader.TestFixturesJvm.Companion.bravoUrl
 import app.cash.zipline.loader.createZiplineCache
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import kotlin.test.assertEquals
@@ -144,8 +144,8 @@ class ProductionInterceptorTest {
     assertNull(cache.read(testFixturesJvm.bravoSha256))
 
     httpClient.filePathToByteString = mapOf(
-      alphaFilePath to testFixturesJvm.alphaByteString,
-      bravoFilePath to testFixturesJvm.bravoByteString,
+      alphaUrl to testFixturesJvm.alphaByteString,
+      bravoUrl to testFixturesJvm.bravoByteString,
     )
 
     moduleLoader.load(testFixturesJvm.manifest)


### PR DESCRIPTION
Instead do URL resolution inside the manifest that we've just
downloaded. That way manifests written to disk always have
absolute URLs in them.