### PR TITLE
Rename `arguments` to `encodedArguments`

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -57,15 +57,15 @@ internal interface InboundCallHandler {
 internal class InboundCall(
   private val context: InboundBridge.Context,
   val funName: String,
-  val arguments: Array<String>,
+  val encodedArguments: Array<String>,
 ) {
   private var i = 0
 
   fun <T> parameter(serializer: KSerializer<T>): T {
-    while (i < arguments.size) {
-      when (arguments[i]) {
+    while (i < encodedArguments.size) {
+      when (encodedArguments[i]) {
         LABEL_VALUE -> {
-          val result = context.json.decodeFromStringFast(serializer, arguments[i + 1])
+          val result = context.json.decodeFromStringFast(serializer, encodedArguments[i + 1])
           i += 2
           return result
         }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -65,17 +65,17 @@ internal class OutboundCall(
   private val funName: String,
   private val parameterCount: Int,
 ) {
-  private val arguments = ArrayList<String>(parameterCount * 2)
+  private val encodedArguments = ArrayList<String>(parameterCount * 2)
   private var callCount = 0
 
   fun <T> parameter(serializer: KSerializer<T>, value: T) {
     require(callCount++ < parameterCount)
     if (value == null) {
-      arguments += LABEL_NULL
-      arguments += ""
+      encodedArguments += LABEL_NULL
+      encodedArguments += ""
     } else {
-      arguments += LABEL_VALUE
-      arguments += context.json.encodeToStringFast(serializer, value)
+      encodedArguments += LABEL_VALUE
+      encodedArguments += context.json.encodeToStringFast(serializer, value)
     }
   }
 
@@ -84,7 +84,7 @@ internal class OutboundCall(
     val encodedResult = endpoint.outboundChannel.invoke(
       instanceName,
       funName,
-      arguments.toTypedArray()
+      encodedArguments.toTypedArray()
     )
 
     return encodedResult.decodeResult(serializer).getOrThrow()
@@ -102,7 +102,7 @@ internal class OutboundCall(
         endpoint.outboundChannel.invokeSuspending(
           instanceName,
           funName,
-          arguments.toTypedArray(),
+          encodedArguments.toTypedArray(),
           callbackName
         )
       }


### PR DESCRIPTION
Disambiguate between the encoded and unecoded arguments via the variable names.