### PR TITLE
Implement support for canceling suspend calls

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -52,13 +52,18 @@ internal interface CallChannel {
     encodedArguments: Array<String>,
   ): Array<String>
 
-  /** Like [invoke], but the response is delivered to the [SuspendCallback] named [callbackName]. */
+  /**
+   * Like [invoke], but the response is delivered to the [SuspendCallback] named
+   * [suspendCallbackName].
+   *
+   * This call is cancelable until it returns. Use a [CancelCallback] to cancel this call.
+   */
   @JsName("invokeSuspending")
   fun invokeSuspending(
     instanceName: String,
     funName: String,
     encodedArguments: Array<String>,
-    callbackName: String,
+    suspendCallbackName: String,
   )
 
   /**

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CancelCallback.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CancelCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Block, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ package app.cash.zipline.internal.bridge
 import app.cash.zipline.ZiplineService
 
 /**
- * A bridged interface to return results from suspending calls.  This is used internally by Zipline
- * to complete suspending calls from the receiving endpoint to the calling endpoint.
+ * A bridged interface to cancel suspending calls. This is used internally by Zipline to send
+ * a cancellation signal from the calling endpoint to the receiving endpoint.
  *
- * It is not necessary for the receiving endpoint to [ZiplineService.close] this; that's handled
- * automatically by the calling service.
+ * It is not necessary for the calling endpoint to [ZiplineService.close] this; that's handled
+ * automatically by the receiving service.
  */
 @PublishedApi
-internal interface SuspendCallback : ZiplineService {
-  fun call(response: Array<String>)
+internal interface CancelCallback : ZiplineService {
+  fun cancel()
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -47,10 +47,10 @@ internal fun newEndpointPair(
         instanceName: String,
         funName: String,
         encodedArguments: Array<String>,
-        callbackName: String
+        suspendCallbackName: String
       ) {
         return b.inboundChannel.invokeSuspending(
-          instanceName, funName, encodedArguments, callbackName
+          instanceName, funName, encodedArguments, suspendCallbackName
         )
       }
 

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -75,10 +75,15 @@ actual class Zipline private constructor(
         instanceName: String,
         funName: String,
         encodedArguments: Array<String>,
-        callbackName: String
+        suspendCallbackName: String
       ) {
         check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.invokeSuspending(instanceName, funName, encodedArguments, callbackName)
+        return jsInboundBridge.invokeSuspending(
+          instanceName,
+          funName,
+          encodedArguments,
+          suspendCallbackName
+        )
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
@@ -42,10 +42,10 @@ class LoggingCallChannel : CallChannel {
     instanceName: String,
     funName: String,
     encodedArguments: Array<String>,
-    callbackName: String
+    suspendCallbackName: String
   ) {
     log += "invokeSuspending($instanceName, $funName, " +
-      "[${encodedArguments.joinToString(", ")}], $callbackName)"
+      "[${encodedArguments.joinToString(", ")}], $suspendCallbackName)"
   }
 
   override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
@@ -115,7 +115,7 @@ class QuickJsInboundChannelTest {
       instanceName = "theInstanceName",
       funName = "theFunName",
       encodedArguments = arrayOf("firstArg", "secondArg"),
-      callbackName = "theCallbackName",
+      suspendCallbackName = "theCallbackName",
     )
     val result = inboundChannel.invoke("", "", arrayOf())
     assertContentEquals(

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -46,9 +46,9 @@ internal class JniCallChannel(
     instanceName: String,
     funName: String,
     encodedArguments: Array<String>,
-    callbackName: String
+    suspendCallbackName: String
   ) = invokeSuspending(
-    quickJs.context, instance, instanceName, funName, encodedArguments, callbackName
+    quickJs.context, instance, instanceName, funName, encodedArguments, suspendCallbackName
   )
 
   private external fun invokeSuspending(


### PR DESCRIPTION
The endpoint executing the suspending call now creates
a service to receive async cancelation signals. When
such signals are received it cancels its internal scope.