### PR TITLE
Migrate composeVersion to version catalog

### DIFF
--- a/buildSrc/src/main/kotlin/Ext.kt
+++ b/buildSrc/src/main/kotlin/Ext.kt
@@ -1,5 +1,4 @@
 object Ext {
-  val composeVersion = "1.1.0-rc02"
   val ndkAbiFilters = listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
   val kotlinPluginId = "app.cash.zipline.kotlin"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidx-compose = "1.1.0-rc01"
+androidx-compose = "1.1.0-rc02"
 compileSdk = "31"
 graalvm = "22.0.0.2"
 kotlin = "1.6.10"

--- a/samples/emoji-search/android/build.gradle.kts
+++ b/samples/emoji-search/android/build.gradle.kts
@@ -25,7 +25,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Ext.composeVersion
+    kotlinCompilerExtensionVersion = libs.versions.androidx.compose.get()
   }
 
   packagingOptions {


### PR DESCRIPTION
The compose version `libs.versions.toml` is actually `1.1.0-rc01`, so we're downgrading the sample by a minor version.