### PR TITLE
Inline abiFilters

### DIFF
--- a/buildSrc/src/main/kotlin/Ext.kt
+++ b/buildSrc/src/main/kotlin/Ext.kt
@@ -1,5 +1,4 @@
 object Ext {
   val composeVersion = "1.1.0-rc02"
-  val ndkAbiFilters = listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
   val kotlinPluginId = "app.cash.zipline.kotlin"
 }

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -184,7 +184,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     ndk {
-      abiFilters += Ext.ndkAbiFilters
+      abiFilters += listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
     }
 
     externalNativeBuild {


### PR DESCRIPTION
As the goal is to remove `buildSrc`, I'm just inlining `ndkAbiFilters` as I haven't really thought about where we'd put it (I don't think having it in `libs.versions.toml` would make sense or is even possible) and I don't currently see the value in figuring out where to put it atm.