### PR TITLE
Make CallChannel do more with encoded parameters

### DIFF
--- a/zipline/native/Context.cpp
+++ b/zipline/native/Context.cpp
@@ -84,7 +84,6 @@ Context::Context(JNIEnv* env)
       lengthAtom(JS_NewAtom(jsContext, "length")),
       serviceNamesArrayAtom(JS_NewAtom(jsContext, "serviceNamesArray")),
       invokeAtom(JS_NewAtom(jsContext, "invoke")),
-      invokeSuspendingAtom(JS_NewAtom(jsContext, "invokeSuspending")),
       disconnectAtom(JS_NewAtom(jsContext, "disconnect")),
       booleanClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("java/lang/Boolean")))),
       integerClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("java/lang/Integer")))),
@@ -136,7 +135,6 @@ Context::~Context() {
   JS_FreeAtom(jsContext, lengthAtom);
   JS_FreeAtom(jsContext, serviceNamesArrayAtom);
   JS_FreeAtom(jsContext, invokeAtom);
-  JS_FreeAtom(jsContext, invokeSuspendingAtom);
   JS_FreeAtom(jsContext, disconnectAtom);
   JS_FreeContext(jsContext);
   JS_FreeRuntime(jsRuntime);

--- a/zipline/native/Context.cpp
+++ b/zipline/native/Context.cpp
@@ -83,7 +83,7 @@ Context::Context(JNIEnv* env)
       outboundCallChannelClassId(0),
       lengthAtom(JS_NewAtom(jsContext, "length")),
       serviceNamesArrayAtom(JS_NewAtom(jsContext, "serviceNamesArray")),
-      invokeAtom(JS_NewAtom(jsContext, "invoke")),
+      callAtom(JS_NewAtom(jsContext, "call")),
       disconnectAtom(JS_NewAtom(jsContext, "disconnect")),
       booleanClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("java/lang/Boolean")))),
       integerClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("java/lang/Integer")))),
@@ -134,7 +134,7 @@ Context::~Context() {
   env->DeleteGlobalRef(booleanClass);
   JS_FreeAtom(jsContext, lengthAtom);
   JS_FreeAtom(jsContext, serviceNamesArrayAtom);
-  JS_FreeAtom(jsContext, invokeAtom);
+  JS_FreeAtom(jsContext, callAtom);
   JS_FreeAtom(jsContext, disconnectAtom);
   JS_FreeContext(jsContext);
   JS_FreeRuntime(jsRuntime);

--- a/zipline/native/Context.h
+++ b/zipline/native/Context.h
@@ -64,7 +64,6 @@ public:
   JSAtom lengthAtom;
   JSAtom serviceNamesArrayAtom;
   JSAtom invokeAtom;
-  JSAtom invokeSuspendingAtom;
   JSAtom disconnectAtom;
   jclass booleanClass;
   jclass integerClass;

--- a/zipline/native/Context.h
+++ b/zipline/native/Context.h
@@ -63,7 +63,7 @@ public:
   JSClassID outboundCallChannelClassId;
   JSAtom lengthAtom;
   JSAtom serviceNamesArrayAtom;
-  JSAtom invokeAtom;
+  JSAtom callAtom;
   JSAtom disconnectAtom;
   jclass booleanClass;
   jclass integerClass;

--- a/zipline/native/InboundCallChannel.cpp
+++ b/zipline/native/InboundCallChannel.cpp
@@ -52,15 +52,15 @@ jobjectArray InboundCallChannel::serviceNamesArray(Context *context, JNIEnv* env
   return javaResult;
 }
 
-jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env,
-                                        jobjectArray encodedArguments) const {
+jobjectArray InboundCallChannel::call(Context *context, JNIEnv* env,
+                                      jobjectArray encodedArguments) const {
   JSContext *jsContext = context->jsContext;
   JSValue global = JS_GetGlobalObject(jsContext);
   JSValue thisPointer = JS_GetProperty(jsContext, global, nameAtom);
   JSValueConst arguments[1];
   arguments[0] = context->toJsStringArray(env, encodedArguments);
 
-  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeAtom, 1, arguments);
+  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->callAtom, 1, arguments);
   jobjectArray javaResult;
   auto tag = JS_VALUE_GET_NORM_TAG(jsResult);
   if (tag == JS_TAG_EXCEPTION) {

--- a/zipline/native/InboundCallChannel.cpp
+++ b/zipline/native/InboundCallChannel.cpp
@@ -80,32 +80,6 @@ jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env,
   return javaResult;
 }
 
-void InboundCallChannel::invokeSuspending(Context *context, JNIEnv* env,
-                                          jobjectArray encodedArguments,
-                                          jstring callbackName) const {
-  JSContext *jsContext = context->jsContext;
-  JSValue global = JS_GetGlobalObject(jsContext);
-  JSValue thisPointer = JS_GetProperty(jsContext, global, nameAtom);
-  JSValueConst arguments[2];
-  arguments[0] = context->toJsStringArray(env, encodedArguments);
-  arguments[1] = context->toJsString(env, callbackName);
-
-  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeSuspendingAtom, 2, arguments);
-  auto tag = JS_VALUE_GET_NORM_TAG(jsResult);
-  if (tag == JS_TAG_EXCEPTION) {
-    context->throwJsException(env, jsResult);
-  } else if (tag == JS_TAG_UNDEFINED) {
-    // Expected. Do nothing.
-  } else {
-    assert(false); // Unexpected tag.
-  }
-
-  JS_FreeValue(jsContext, arguments[0]);
-  JS_FreeValue(jsContext, arguments[1]);
-  JS_FreeValue(jsContext, thisPointer);
-  JS_FreeValue(jsContext, global);
-}
-
 jboolean InboundCallChannel::disconnect(Context *context, JNIEnv* env, jstring instanceName) const {
   JSContext *jsContext = context->jsContext;
   JSValue global = JS_GetGlobalObject(jsContext);

--- a/zipline/native/InboundCallChannel.cpp
+++ b/zipline/native/InboundCallChannel.cpp
@@ -52,17 +52,15 @@ jobjectArray InboundCallChannel::serviceNamesArray(Context *context, JNIEnv* env
   return javaResult;
 }
 
-jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env, jstring instanceName,
-                                   jstring funName, jobjectArray encodedArguments) const {
+jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env,
+                                        jobjectArray encodedArguments) const {
   JSContext *jsContext = context->jsContext;
   JSValue global = JS_GetGlobalObject(jsContext);
   JSValue thisPointer = JS_GetProperty(jsContext, global, nameAtom);
-  JSValueConst arguments[3];
-  arguments[0] = context->toJsString(env, instanceName);
-  arguments[1] = context->toJsString(env, funName);
-  arguments[2] = context->toJsStringArray(env, encodedArguments);
+  JSValueConst arguments[1];
+  arguments[0] = context->toJsStringArray(env, encodedArguments);
 
-  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeAtom, 3, arguments);
+  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeAtom, 1, arguments);
   jobjectArray javaResult;
   auto tag = JS_VALUE_GET_NORM_TAG(jsResult);
   if (tag == JS_TAG_EXCEPTION) {
@@ -75,8 +73,6 @@ jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env, jstring i
   }
 
   JS_FreeValue(jsContext, arguments[0]);
-  JS_FreeValue(jsContext, arguments[1]);
-  JS_FreeValue(jsContext, arguments[2]);
   JS_FreeValue(jsContext, jsResult);
   JS_FreeValue(jsContext, thisPointer);
   JS_FreeValue(jsContext, global);
@@ -84,19 +80,17 @@ jobjectArray InboundCallChannel::invoke(Context *context, JNIEnv* env, jstring i
   return javaResult;
 }
 
-void InboundCallChannel::invokeSuspending(Context *context, JNIEnv* env, jstring instanceName,
-                                     jstring funName, jobjectArray encodedArguments,
-                                     jstring callbackName) const {
+void InboundCallChannel::invokeSuspending(Context *context, JNIEnv* env,
+                                          jobjectArray encodedArguments,
+                                          jstring callbackName) const {
   JSContext *jsContext = context->jsContext;
   JSValue global = JS_GetGlobalObject(jsContext);
   JSValue thisPointer = JS_GetProperty(jsContext, global, nameAtom);
-  JSValueConst arguments[4];
-  arguments[0] = context->toJsString(env, instanceName);
-  arguments[1] = context->toJsString(env, funName);
-  arguments[2] = context->toJsStringArray(env, encodedArguments);
-  arguments[3] = context->toJsString(env, callbackName);
+  JSValueConst arguments[2];
+  arguments[0] = context->toJsStringArray(env, encodedArguments);
+  arguments[1] = context->toJsString(env, callbackName);
 
-  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeSuspendingAtom, 4, arguments);
+  JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->invokeSuspendingAtom, 2, arguments);
   auto tag = JS_VALUE_GET_NORM_TAG(jsResult);
   if (tag == JS_TAG_EXCEPTION) {
     context->throwJsException(env, jsResult);
@@ -108,8 +102,6 @@ void InboundCallChannel::invokeSuspending(Context *context, JNIEnv* env, jstring
 
   JS_FreeValue(jsContext, arguments[0]);
   JS_FreeValue(jsContext, arguments[1]);
-  JS_FreeValue(jsContext, arguments[2]);
-  JS_FreeValue(jsContext, arguments[3]);
   JS_FreeValue(jsContext, thisPointer);
   JS_FreeValue(jsContext, global);
 }

--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -30,7 +30,6 @@ public:
 
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
   jobjectArray invoke(Context *context, JNIEnv* env, jobjectArray encodedArguments) const;
-  void invokeSuspending(Context *context, JNIEnv* env, jobjectArray encodedArguments, jstring callbackName) const;
   jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
   JSContext *jsContext;

--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -29,8 +29,8 @@ public:
   ~InboundCallChannel();
 
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
-  jobjectArray invoke(Context *context, JNIEnv* env, jstring instanceName, jstring funName, jobjectArray encodedArguments) const;
-  void invokeSuspending(Context *context, JNIEnv* env, jstring instanceName, jstring funName, jobjectArray encodedArguments, jstring callbackName) const;
+  jobjectArray invoke(Context *context, JNIEnv* env, jobjectArray encodedArguments) const;
+  void invokeSuspending(Context *context, JNIEnv* env, jobjectArray encodedArguments, jstring callbackName) const;
   jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
   JSContext *jsContext;

--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -29,7 +29,7 @@ public:
   ~InboundCallChannel();
 
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
-  jobjectArray invoke(Context *context, JNIEnv* env, jobjectArray encodedArguments) const;
+  jobjectArray call(Context *context, JNIEnv* env, jobjectArray encodedArguments) const;
   jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
   JSContext *jsContext;

--- a/zipline/native/OutboundCallChannel.cpp
+++ b/zipline/native/OutboundCallChannel.cpp
@@ -25,10 +25,10 @@ OutboundCallChannel::OutboundCallChannel(Context* c, JNIEnv* env, const char* na
       javaThis(env->NewGlobalRef(object)),
       callChannelClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("app/cash/zipline/internal/bridge/CallChannel")))),
       serviceNamesArrayMethod(env->GetMethodID(callChannelClass, "serviceNamesArray", "()[Ljava/lang/String;")),
-      invokeMethod(env->GetMethodID(callChannelClass, "invoke", "([Ljava/lang/String;)[Ljava/lang/String;")),
+      callMethod(env->GetMethodID(callChannelClass, "call", "([Ljava/lang/String;)[Ljava/lang/String;")),
       disconnectMethod(env->GetMethodID(callChannelClass, "disconnect", "(Ljava/lang/String;)Z")) {
   functions.push_back(JS_CFUNC_DEF("serviceNamesArray", 0, OutboundCallChannel::serviceNamesArray));
-  functions.push_back(JS_CFUNC_DEF("invoke", 1, OutboundCallChannel::invoke));
+  functions.push_back(JS_CFUNC_DEF("call", 1, OutboundCallChannel::call));
   functions.push_back(JS_CFUNC_DEF("disconnect", 1, OutboundCallChannel::disconnect));
   if (!env->ExceptionCheck()) {
     JS_SetPropertyFunctionList(context->jsContext, jsOutboundCallChannel, functions.data(), functions.size());
@@ -67,7 +67,7 @@ OutboundCallChannel::serviceNamesArray(JSContext* ctx, JSValueConst this_val, in
 }
 
 JSValue
-OutboundCallChannel::invoke(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+OutboundCallChannel::call(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
   auto context = reinterpret_cast<const Context*>(JS_GetRuntimeOpaque(JS_GetRuntime(ctx)));
   if (!context) {
     return JS_ThrowReferenceError(ctx, "QuickJs closed");
@@ -85,7 +85,7 @@ OutboundCallChannel::invoke(JSContext* ctx, JSValueConst this_val, int argc, JSV
   args[0].l = context->toJavaStringArray(env, argv[0]);
 
   jobjectArray javaResult = static_cast<jobjectArray>(env->CallObjectMethodA(
-      channel->javaThis, channel->invokeMethod, args));
+      channel->javaThis, channel->callMethod, args));
   JSValue jsResult;
   if (!env->ExceptionCheck()) {
     jsResult = context->toJsStringArray(env, javaResult);

--- a/zipline/native/OutboundCallChannel.cpp
+++ b/zipline/native/OutboundCallChannel.cpp
@@ -25,8 +25,8 @@ OutboundCallChannel::OutboundCallChannel(Context* c, JNIEnv* env, const char* na
       javaThis(env->NewGlobalRef(object)),
       callChannelClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("app/cash/zipline/internal/bridge/CallChannel")))),
       serviceNamesArrayMethod(env->GetMethodID(callChannelClass, "serviceNamesArray", "()[Ljava/lang/String;")),
-      invokeMethod(env->GetMethodID(callChannelClass, "invoke", "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)[Ljava/lang/String;")),
-      invokeSuspendingMethod(env->GetMethodID(callChannelClass, "invokeSuspending", "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V")),
+      invokeMethod(env->GetMethodID(callChannelClass, "invoke", "([Ljava/lang/String;)[Ljava/lang/String;")),
+      invokeSuspendingMethod(env->GetMethodID(callChannelClass, "invokeSuspending", "([Ljava/lang/String;Ljava/lang/String;)V")),
       disconnectMethod(env->GetMethodID(callChannelClass, "disconnect", "(Ljava/lang/String;)Z")) {
   functions.push_back(JS_CFUNC_DEF("serviceNamesArray", 0, OutboundCallChannel::serviceNamesArray));
   functions.push_back(JS_CFUNC_DEF("invoke", 3, OutboundCallChannel::invoke));
@@ -79,14 +79,12 @@ OutboundCallChannel::invoke(JSContext* ctx, JSValueConst this_val, int argc, JSV
     return JS_ThrowReferenceError(ctx, "Not an OutboundCallChannel");
   }
 
-  assert(argc == 3);
+  assert(argc == 1);
 
   auto env = context->getEnv();
   env->PushLocalFrame(argc + 1);
-  jvalue args[3];
-  args[0].l = context->toJavaString(env, argv[0]);
-  args[1].l = context->toJavaString(env, argv[1]);
-  args[2].l = context->toJavaStringArray(env, argv[2]);
+  jvalue args[1];
+  args[0].l = context->toJavaStringArray(env, argv[0]);
 
   jobjectArray javaResult = static_cast<jobjectArray>(env->CallObjectMethodA(
       channel->javaThis, channel->invokeMethod, args));
@@ -111,15 +109,13 @@ OutboundCallChannel::invokeSuspending(JSContext* ctx, JSValueConst this_val, int
     return JS_ThrowReferenceError(ctx, "Not an OutboundCallChannel");
   }
 
-  assert(argc == 4);
+  assert(argc == 2);
 
   auto env = context->getEnv();
   env->PushLocalFrame(argc + 1);
-  jvalue args[4];
-  args[0].l = context->toJavaString(env, argv[0]);
+  jvalue args[2];
+  args[0].l = context->toJavaStringArray(env, argv[0]);
   args[1].l = context->toJavaString(env, argv[1]);
-  args[2].l = context->toJavaStringArray(env, argv[2]);
-  args[3].l = context->toJavaString(env, argv[3]);
 
   env->CallVoidMethodA(channel->javaThis, channel->invokeSuspendingMethod, args);
   JSValue jsResult;

--- a/zipline/native/OutboundCallChannel.h
+++ b/zipline/native/OutboundCallChannel.h
@@ -31,7 +31,6 @@ public:
 
   static JSValue serviceNamesArray(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
   static JSValue invoke(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
-  static JSValue invokeSuspending(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
   static JSValue disconnect(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
 
 private:
@@ -41,7 +40,6 @@ private:
   jclass callChannelClass;
   jmethodID serviceNamesArrayMethod;
   jmethodID invokeMethod;
-  jmethodID invokeSuspendingMethod;
   jmethodID disconnectMethod;
   std::vector<JSCFunctionListEntry> functions;
 };

--- a/zipline/native/OutboundCallChannel.h
+++ b/zipline/native/OutboundCallChannel.h
@@ -30,7 +30,7 @@ public:
   ~OutboundCallChannel();
 
   static JSValue serviceNamesArray(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
-  static JSValue invoke(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
+  static JSValue call(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
   static JSValue disconnect(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
 
 private:
@@ -39,7 +39,7 @@ private:
   jobject javaThis;
   jclass callChannelClass;
   jmethodID serviceNamesArrayMethod;
-  jmethodID invokeMethod;
+  jmethodID callMethod;
   jmethodID disconnectMethod;
   std::vector<JSCFunctionListEntry> functions;
 };

--- a/zipline/native/quickjs-jni.cpp
+++ b/zipline/native/quickjs-jni.cpp
@@ -170,8 +170,7 @@ Java_app_cash_zipline_JniCallChannel_serviceNamesArray(JNIEnv* env, jobject thiz
 
 extern "C" JNIEXPORT jobjectArray JNICALL
 Java_app_cash_zipline_JniCallChannel_invoke(JNIEnv* env, jobject thiz, jlong _context,
-                                            jlong instance, jstring instanceName, jstring funName,
-                                            jobjectArray encodedArguments) {
+                                            jlong instance, jobjectArray encodedArguments) {
   Context* context = reinterpret_cast<Context*>(_context);
   if (!context) {
     throwJavaException(env, "java/lang/IllegalStateException", "QuickJs instance was closed");
@@ -184,13 +183,12 @@ Java_app_cash_zipline_JniCallChannel_invoke(JNIEnv* env, jobject thiz, jlong _co
     return nullptr;
   }
 
-  return channel->invoke(context, env, instanceName, funName, encodedArguments);
+  return channel->invoke(context, env, encodedArguments);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_app_cash_zipline_JniCallChannel_invokeSuspending(JNIEnv* env, jobject thiz, jlong _context,
-                                                      jlong instance, jstring instanceName,
-                                                      jstring funName, jobjectArray encodedArguments,
+                                                      jlong instance, jobjectArray encodedArguments,
                                                       jstring callbackName) {
   Context* context = reinterpret_cast<Context*>(_context);
   if (!context) {
@@ -204,7 +202,7 @@ Java_app_cash_zipline_JniCallChannel_invokeSuspending(JNIEnv* env, jobject thiz,
     return;
   }
 
-  channel->invokeSuspending(context, env, instanceName, funName, encodedArguments, callbackName);
+  channel->invokeSuspending(context, env, encodedArguments, callbackName);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL

--- a/zipline/native/quickjs-jni.cpp
+++ b/zipline/native/quickjs-jni.cpp
@@ -169,8 +169,8 @@ Java_app_cash_zipline_JniCallChannel_serviceNamesArray(JNIEnv* env, jobject thiz
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL
-Java_app_cash_zipline_JniCallChannel_invoke(JNIEnv* env, jobject thiz, jlong _context,
-                                            jlong instance, jobjectArray encodedArguments) {
+Java_app_cash_zipline_JniCallChannel_call(JNIEnv* env, jobject thiz, jlong _context,
+                                          jlong instance, jobjectArray encodedArguments) {
   Context* context = reinterpret_cast<Context*>(_context);
   if (!context) {
     throwJavaException(env, "java/lang/IllegalStateException", "QuickJs instance was closed");
@@ -183,7 +183,7 @@ Java_app_cash_zipline_JniCallChannel_invoke(JNIEnv* env, jobject thiz, jlong _co
     return nullptr;
   }
 
-  return channel->invoke(context, env, encodedArguments);
+  return channel->call(context, env, encodedArguments);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL

--- a/zipline/native/quickjs-jni.cpp
+++ b/zipline/native/quickjs-jni.cpp
@@ -186,25 +186,6 @@ Java_app_cash_zipline_JniCallChannel_invoke(JNIEnv* env, jobject thiz, jlong _co
   return channel->invoke(context, env, encodedArguments);
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_app_cash_zipline_JniCallChannel_invokeSuspending(JNIEnv* env, jobject thiz, jlong _context,
-                                                      jlong instance, jobjectArray encodedArguments,
-                                                      jstring callbackName) {
-  Context* context = reinterpret_cast<Context*>(_context);
-  if (!context) {
-    throwJavaException(env, "java/lang/IllegalStateException", "QuickJs instance was closed");
-    return;
-  }
-
-  const InboundCallChannel* channel = reinterpret_cast<const InboundCallChannel*>(instance);
-  if (!channel) {
-    throwJavaException(env, "java/lang/IllegalStateException", "Invalid JavaScript object");
-    return;
-  }
-
-  channel->invokeSuspending(context, env, encodedArguments, callbackName);
-}
-
 extern "C" JNIEXPORT jboolean JNICALL
 Java_app_cash_zipline_JniCallChannel_disconnect(JNIEnv* env, jobject thiz, jlong _context,
                                                 jlong instance, jstring instanceName) {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -27,7 +27,7 @@ internal const val outboundChannelName = "app_cash_zipline_outboundChannel"
 
 @PublishedApi
 internal interface CallChannel {
-  /** Returns names can receive calls to [invoke] and [invokeSuspending]. */
+  /** Returns names of services that can receive calls to [invoke]. */
   @JsName("serviceNamesArray")
   fun serviceNamesArray(): Array<String>
 
@@ -38,6 +38,7 @@ internal interface CallChannel {
    *
    *  * Label `s`: the following value is the service name
    *  * Label `f`: the following value is the function name
+   *  * Label `c`: the following value is the callback name
    *  * Label `v`: the following value is a non-null parameter value.
    *  * Label `n`: the following value is an empty string and the parameter value is null.
    *
@@ -46,18 +47,13 @@ internal interface CallChannel {
    *  * Label `v`: the following value is a non-null normal result value.
    *  * Label `n`: the following value is an empty string and the result value is null.
    *  * Label `t`: the following value is a non-null thrown exception value.
+   *
+   * If this function is suspending, the callback name is not empty. This function returns an empty
+   * array and the response is delivered to the [SuspendCallback]. Suspending calls may be canceled
+   * before it returns by using the [CancelCallback].
    */
   @JsName("invoke")
   fun invoke(encodedArguments: Array<String>): Array<String>
-
-  /**
-   * Like [invoke], but the response is delivered to the [SuspendCallback] named
-   * [suspendCallbackName].
-   *
-   * This call is cancelable until it returns. Use a [CancelCallback] to cancel this call.
-   */
-  @JsName("invokeSuspending")
-  fun invokeSuspending(encodedArguments: Array<String>, suspendCallbackName: String)
 
   /**
    * Remove [instanceName] from the receiver. After making this call it is an error to make calls
@@ -74,6 +70,7 @@ internal const val LABEL_NULL = "n"
 internal const val LABEL_EXCEPTION = "t"
 internal const val LABEL_SERVICE_NAME = "s"
 internal const val LABEL_FUN_NAME = "f"
+internal const val LABEL_CALLBACK_NAME = "c"
 
 internal object ThrowableSerializer : KSerializer<Throwable> {
   override val descriptor = PrimitiveSerialDescriptor("ZiplineThrowable", PrimitiveKind.STRING)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -27,18 +27,19 @@ internal const val outboundChannelName = "app_cash_zipline_outboundChannel"
 
 @PublishedApi
 internal interface CallChannel {
-  /** Returns names of services that can receive calls to [invoke]. */
+  /** Returns names of services that can receive calls to [call]. */
   @JsName("serviceNamesArray")
   fun serviceNamesArray(): Array<String>
 
   /**
-   * Internal function used to bridge method calls from Java or Android to JavaScript.
+   * Internal function used to bridge method calls from either Kotlin/JVM or Kotlin/Native to
+   * Kotlin/JS.
    *
    * The structure of [encodedArguments] is a series of alternating label/value pairs.
    *
    *  * Label `s`: the following value is the service name
    *  * Label `f`: the following value is the function name
-   *  * Label `c`: the following value is the callback name
+   *  * Label `c`: the following value is the callback name, or an empty string.
    *  * Label `v`: the following value is a non-null parameter value.
    *  * Label `n`: the following value is an empty string and the parameter value is null.
    *
@@ -52,8 +53,8 @@ internal interface CallChannel {
    * array and the response is delivered to the [SuspendCallback]. Suspending calls may be canceled
    * before it returns by using the [CancelCallback].
    */
-  @JsName("invoke")
-  fun invoke(encodedArguments: Array<String>): Array<String>
+  @JsName("call")
+  fun call(encodedArguments: Array<String>): Array<String>
 
   /**
    * Remove [instanceName] from the receiver. After making this call it is an error to make calls

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -36,6 +36,8 @@ internal interface CallChannel {
    *
    * The structure of [encodedArguments] is a series of alternating label/value pairs.
    *
+   *  * Label `s`: the following value is the service name
+   *  * Label `f`: the following value is the function name
    *  * Label `v`: the following value is a non-null parameter value.
    *  * Label `n`: the following value is an empty string and the parameter value is null.
    *
@@ -46,11 +48,7 @@ internal interface CallChannel {
    *  * Label `t`: the following value is a non-null thrown exception value.
    */
   @JsName("invoke")
-  fun invoke(
-    instanceName: String,
-    funName: String,
-    encodedArguments: Array<String>,
-  ): Array<String>
+  fun invoke(encodedArguments: Array<String>): Array<String>
 
   /**
    * Like [invoke], but the response is delivered to the [SuspendCallback] named
@@ -59,12 +57,7 @@ internal interface CallChannel {
    * This call is cancelable until it returns. Use a [CancelCallback] to cancel this call.
    */
   @JsName("invokeSuspending")
-  fun invokeSuspending(
-    instanceName: String,
-    funName: String,
-    encodedArguments: Array<String>,
-    suspendCallbackName: String,
-  )
+  fun invokeSuspending(encodedArguments: Array<String>, suspendCallbackName: String)
 
   /**
    * Remove [instanceName] from the receiver. After making this call it is an error to make calls
@@ -79,6 +72,8 @@ internal interface CallChannel {
 internal const val LABEL_VALUE = "v"
 internal const val LABEL_NULL = "n"
 internal const val LABEL_EXCEPTION = "t"
+internal const val LABEL_SERVICE_NAME = "s"
+internal const val LABEL_FUN_NAME = "f"
 
 internal object ThrowableSerializer : KSerializer<Throwable> {
   override val descriptor = PrimitiveSerialDescriptor("ZiplineThrowable", PrimitiveKind.STRING)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -60,18 +60,18 @@ class Endpoint internal constructor(
       return serviceNames.toTypedArray()
     }
 
-    override fun invoke(encodedArguments: Array<String>): Array<String> {
+    override fun call(encodedArguments: Array<String>): Array<String> {
       val inboundCall = InboundCall(encodedArguments)
       val handler = takeHandler(inboundCall.serviceName, inboundCall.funName)
       inboundCall.context = handler.context
 
       return when {
-        inboundCall.callbackName.isNotEmpty() -> invokeSuspending(inboundCall, handler)
-        else -> invoke(inboundCall, handler)
+        inboundCall.callbackName.isNotEmpty() -> callSuspending(inboundCall, handler)
+        else -> call(inboundCall, handler)
       }
     }
 
-    private fun invoke(call: InboundCall, handler: InboundCallHandler): Array<String> {
+    private fun call(call: InboundCall, handler: InboundCallHandler): Array<String> {
       return try {
         handler.call(call)
       } catch (e: Throwable) {
@@ -79,7 +79,7 @@ class Endpoint internal constructor(
       }
     }
 
-    private fun invokeSuspending(call: InboundCall, handler: InboundCallHandler): Array<String> {
+    private fun callSuspending(call: InboundCall, handler: InboundCallHandler): Array<String> {
       val suspendCallbackName = call.callbackName
       val job = scope.launch {
         val result = try {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -60,13 +60,10 @@ class Endpoint internal constructor(
       return serviceNames.toTypedArray()
     }
 
-    override fun invoke(
-      instanceName: String,
-      funName: String,
-      encodedArguments: Array<String>
-    ): Array<String> {
-      val handler = takeHandler(instanceName, funName)
-      val inboundCall = InboundCall(handler.context, funName, encodedArguments)
+    override fun invoke(encodedArguments: Array<String>): Array<String> {
+      val inboundCall = InboundCall(encodedArguments)
+      val handler = takeHandler(inboundCall.instanceName, inboundCall.funName)
+      inboundCall.context = handler.context
       return try {
         handler.call(inboundCall)
       } catch (e: Throwable) {
@@ -74,15 +71,11 @@ class Endpoint internal constructor(
       }
     }
 
-    override fun invokeSuspending(
-      instanceName: String,
-      funName: String,
-      encodedArguments: Array<String>,
-      suspendCallbackName: String
-    ) {
-      val handler = takeHandler(instanceName, funName)
+    override fun invokeSuspending(encodedArguments: Array<String>, suspendCallbackName: String) {
+      val inboundCall = InboundCall(encodedArguments)
+      val handler = takeHandler(inboundCall.instanceName, inboundCall.funName)
+      inboundCall.context = handler.context
       val job = scope.launch {
-        val inboundCall = InboundCall(handler.context, funName, encodedArguments)
         val result = try {
           handler.callSuspending(inboundCall)
         } catch (e: Exception) {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -61,9 +61,9 @@ internal class InboundCall(
   val encodedArguments: Array<String>,
 ) {
   internal lateinit var context: InboundBridge.Context
-  internal val serviceName: String
-  internal val funName: String
-  internal val callbackName: String
+  val serviceName: String
+  val funName: String
+  val callbackName: String
 
   private val arguments = ArrayList<Any?>(encodedArguments.size / 2)
   private var callStartResult: Any? = null

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -61,29 +61,33 @@ internal class InboundCall(
   val encodedArguments: Array<String>,
 ) {
   internal lateinit var context: InboundBridge.Context
-  internal val instanceName: String
+  internal val serviceName: String
   internal val funName: String
+  internal val callbackName: String
 
   private val arguments = ArrayList<Any?>(encodedArguments.size / 2)
   private var callStartResult: Any? = null
   private var i = 0
 
   init {
-    var skippedArguments = false
-    var instanceName: String? = null
+    var serviceName: String? = null
     var funName: String? = null
+    var callbackName: String? = null
+    var skippedArguments = false
     while (i < encodedArguments.size) {
       when (encodedArguments[i]) {
-        LABEL_SERVICE_NAME -> instanceName = encodedArguments[i + 1]
+        LABEL_SERVICE_NAME -> serviceName = encodedArguments[i + 1]
         LABEL_FUN_NAME -> funName = encodedArguments[i + 1]
+        LABEL_CALLBACK_NAME -> callbackName = encodedArguments[i + 1]
         else -> skippedArguments = true
       }
       i += 2
-      if (instanceName != null && funName != null) break
+      if (serviceName != null && funName != null && callbackName != null) break
     }
 
-    this.instanceName = instanceName!!
+    this.serviceName = serviceName!!
     this.funName = funName!!
+    this.callbackName = callbackName!!
     if (skippedArguments) i = 0
   }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -95,7 +95,7 @@ internal class OutboundCall(
   fun <R> invoke(service: ZiplineService, serializer: KSerializer<R>): R {
     require(callCount++ == parameterCount)
     val callStartResult = endpoint.eventListener.callStart(instanceName, service, funName, arguments)
-    val encodedResult = endpoint.outboundChannel.invoke(encodedArguments.toTypedArray())
+    val encodedResult = endpoint.outboundChannel.call(encodedArguments.toTypedArray())
 
     val result = encodedResult.decodeResult(serializer)
     endpoint.eventListener.callEnd(instanceName, service, funName, arguments, result, callStartResult)
@@ -131,7 +131,7 @@ internal class OutboundCall(
           cancelCallback.cancel()
         }
 
-        endpoint.outboundChannel.invoke(encodedArguments.toTypedArray())
+        endpoint.outboundChannel.call(encodedArguments.toTypedArray())
       }
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/outbound.kt
@@ -68,7 +68,7 @@ internal class OutboundCall(
   private val parameterCount: Int,
 ) {
   private val arguments = ArrayList<Any?>(parameterCount)
-  private val encodedArguments = ArrayList<String>(4 + (parameterCount * 2))
+  private val encodedArguments = ArrayList<String>(6 + (parameterCount * 2))
   private var callCount = 0
 
   init {
@@ -76,6 +76,8 @@ internal class OutboundCall(
     encodedArguments += instanceName
     encodedArguments += LABEL_FUN_NAME
     encodedArguments += funName
+    encodedArguments += LABEL_CALLBACK_NAME
+    encodedArguments += ""
   }
 
   fun <T> parameter(serializer: KSerializer<T>, value: T) {
@@ -101,33 +103,35 @@ internal class OutboundCall(
   }
 
   @PublishedApi
-  internal suspend fun <R> invokeSuspending(service: ZiplineService, serializer: KSerializer<R>): R {
+  internal suspend fun <R> invokeSuspending(
+    service: ZiplineService,
+    serializer: KSerializer<R>,
+  ): R {
     require(callCount++ == parameterCount)
     val callStartResult = endpoint.eventListener.callStart(instanceName, service, funName, arguments)
     return suspendCancellableCoroutine { continuation ->
       context.endpoint.incompleteContinuations += continuation
       context.endpoint.scope.launch {
-        val suspendCallbackName = endpoint.generateName(prefix = ziplineInternalPrefix)
+        val callbackName = endpoint.generateName(prefix = ziplineInternalPrefix)
+        encodedArguments[encodedArguments.indexOf(LABEL_CALLBACK_NAME) + 1] = callbackName
+
         val suspendCallback = RealSuspendCallback(
           service = service,
-          suspendCallbackName = suspendCallbackName,
+          suspendCallbackName = callbackName,
           continuation = continuation,
           serializer = serializer,
           callStartResult = callStartResult,
         )
-        endpoint.bind<SuspendCallback>(suspendCallbackName, suspendCallback)
+        endpoint.bind<SuspendCallback>(callbackName, suspendCallback)
 
         continuation.invokeOnCancellation {
           if (suspendCallback.completed) return@invokeOnCancellation
-          val cancelCallbackName = endpoint.cancelCallbackName(suspendCallbackName)
+          val cancelCallbackName = endpoint.cancelCallbackName(callbackName)
           val cancelCallback = endpoint.take<CancelCallback>(cancelCallbackName)
           cancelCallback.cancel()
         }
 
-        endpoint.outboundChannel.invokeSuspending(
-          encodedArguments.toTypedArray(),
-          suspendCallbackName
-        )
+        endpoint.outboundChannel.invoke(encodedArguments.toTypedArray())
       }
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -35,17 +35,8 @@ internal fun newEndpointPair(
         return b.inboundChannel.serviceNamesArray()
       }
 
-      override fun invoke(
-        encodedArguments: Array<String>
-      ): Array<String> {
+      override fun invoke(encodedArguments: Array<String>): Array<String> {
         return b.inboundChannel.invoke(encodedArguments)
-      }
-
-      override fun invokeSuspending(
-        encodedArguments: Array<String>,
-        suspendCallbackName: String
-      ) {
-        return b.inboundChannel.invokeSuspending(encodedArguments, suspendCallbackName)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -35,8 +35,8 @@ internal fun newEndpointPair(
         return b.inboundChannel.serviceNamesArray()
       }
 
-      override fun invoke(encodedArguments: Array<String>): Array<String> {
-        return b.inboundChannel.invoke(encodedArguments)
+      override fun call(encodedArguments: Array<String>): Array<String> {
+        return b.inboundChannel.call(encodedArguments)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -36,22 +36,16 @@ internal fun newEndpointPair(
       }
 
       override fun invoke(
-        instanceName: String,
-        funName: String,
         encodedArguments: Array<String>
       ): Array<String> {
-        return b.inboundChannel.invoke(instanceName, funName, encodedArguments)
+        return b.inboundChannel.invoke(encodedArguments)
       }
 
       override fun invokeSuspending(
-        instanceName: String,
-        funName: String,
         encodedArguments: Array<String>,
         suspendCallbackName: String
       ) {
-        return b.inboundChannel.invokeSuspending(
-          instanceName, funName, encodedArguments, suspendCallbackName
-        )
+        return b.inboundChannel.invokeSuspending(encodedArguments, suspendCallbackName)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -62,9 +62,9 @@ actual class Zipline private constructor(
         return jsInboundBridge.serviceNamesArray()
       }
 
-      override fun invoke(encodedArguments: Array<String>): Array<String> {
+      override fun call(encodedArguments: Array<String>): Array<String> {
         check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.invoke(encodedArguments)
+        return jsInboundBridge.call(encodedArguments)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -22,8 +22,8 @@ import app.cash.zipline.internal.DEFINE_JS
 import app.cash.zipline.internal.EventListenerService
 import app.cash.zipline.internal.EventLoop
 import app.cash.zipline.internal.HostConsole
-import app.cash.zipline.internal.JsPlatform
 import app.cash.zipline.internal.HostEventListenerService
+import app.cash.zipline.internal.JsPlatform
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
@@ -62,28 +62,17 @@ actual class Zipline private constructor(
         return jsInboundBridge.serviceNamesArray()
       }
 
-      override fun invoke(
-        instanceName: String,
-        funName: String,
-        encodedArguments: Array<String>
-      ): Array<String> {
+      override fun invoke(encodedArguments: Array<String>): Array<String> {
         check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.invoke(instanceName, funName, encodedArguments)
+        return jsInboundBridge.invoke(encodedArguments)
       }
 
       override fun invokeSuspending(
-        instanceName: String,
-        funName: String,
         encodedArguments: Array<String>,
         suspendCallbackName: String
       ) {
         check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.invokeSuspending(
-          instanceName,
-          funName,
-          encodedArguments,
-          suspendCallbackName
-        )
+        return jsInboundBridge.invokeSuspending(encodedArguments, suspendCallbackName)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -67,14 +67,6 @@ actual class Zipline private constructor(
         return jsInboundBridge.invoke(encodedArguments)
       }
 
-      override fun invokeSuspending(
-        encodedArguments: Array<String>,
-        suspendCallbackName: String
-      ) {
-        check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.invokeSuspending(encodedArguments, suspendCallbackName)
-      }
-
       override fun disconnect(instanceName: String): Boolean {
         return jsInboundBridge.disconnect(instanceName)
       }

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
@@ -30,22 +30,17 @@ class LoggingCallChannel : CallChannel {
   }
 
   override fun invoke(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>
   ): Array<String> {
-    log += "invoke($instanceName, $funName, [${encodedArguments.joinToString(", ")}])"
+    log += "invoke(${encodedArguments.joinToString(", ")})"
     return invokeResult.toTypedArray()
   }
 
   override fun invokeSuspending(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
     suspendCallbackName: String
   ) {
-    log += "invokeSuspending($instanceName, $funName, " +
-      "[${encodedArguments.joinToString(", ")}], $suspendCallbackName)"
+    log += "invokeSuspending(${encodedArguments.joinToString(", ")}, $suspendCallbackName)"
   }
 
   override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
@@ -20,7 +20,7 @@ import app.cash.zipline.internal.bridge.CallChannel
 class LoggingCallChannel : CallChannel {
   val log = mutableListOf<String>()
   val serviceNamesResult = mutableListOf<String>()
-  val invokeResult = mutableListOf<String>()
+  val callResult = mutableListOf<String>()
   var disconnectThrow = false
   var disconnectResult = true
 
@@ -29,11 +29,9 @@ class LoggingCallChannel : CallChannel {
     return serviceNamesResult.toTypedArray()
   }
 
-  override fun invoke(
-    encodedArguments: Array<String>
-  ): Array<String> {
-    log += "invoke(${encodedArguments.joinToString(", ")})"
-    return invokeResult.toTypedArray()
+  override fun call(encodedArguments: Array<String>): Array<String> {
+    log += "call(${encodedArguments.joinToString(", ")})"
+    return callResult.toTypedArray()
   }
 
   override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
@@ -36,13 +36,6 @@ class LoggingCallChannel : CallChannel {
     return invokeResult.toTypedArray()
   }
 
-  override fun invokeSuspending(
-    encodedArguments: Array<String>,
-    suspendCallbackName: String
-  ) {
-    log += "invokeSuspending(${encodedArguments.joinToString(", ")}, $suspendCallbackName)"
-  }
-
   override fun disconnect(instanceName: String): Boolean {
     log += "disconnect($instanceName)"
     if (disconnectThrow) throw UnsupportedOperationException("boom!")

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
@@ -81,42 +81,6 @@ class QuickJsInboundChannelTest {
   }
 
   @Test
-  fun invokeSuspendingHappyPath() {
-    quickJs.evaluate("""
-      var callLog = [];
-      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
-        return callLog.pop();
-      };
-      globalThis.$inboundChannelName.invokeSuspending = function(encodedArguments, callbackName) {
-        var call = [
-          'received call to invokeSuspending()',
-          callbackName
-        ];
-        call.push(...encodedArguments);
-        call.push('and the call was successful!');
-        callLog.push(call);
-      };
-    """.trimIndent())
-
-    val inboundChannel = quickJs.getInboundChannel()
-    inboundChannel.invokeSuspending(
-      encodedArguments = arrayOf("firstArg", "secondArg"),
-      suspendCallbackName = "theCallbackName",
-    )
-    val result = inboundChannel.invoke(arrayOf())
-    assertContentEquals(
-      arrayOf(
-        "received call to invokeSuspending()",
-        "theCallbackName",
-        "firstArg",
-        "secondArg",
-        "and the call was successful!",
-      ),
-      result,
-    )
-  }
-
-  @Test
   fun serviceNamesArrayHappyPath() {
     quickJs.evaluate("""
       var callLog = [];

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
@@ -43,9 +43,7 @@ class QuickJsInboundChannelTest {
       globalThis.$inboundChannelName = {};
       globalThis.$inboundChannelName.serviceNamesArray = function() {
       };
-      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
-      };
-      globalThis.$inboundChannelName.invokeSuspending = function(encodedArguments, callbackName) {
+      globalThis.$inboundChannelName.call = function(encodedArguments) {
       };
       globalThis.$inboundChannelName.disconnect = function(instanceName) {
       };
@@ -53,11 +51,11 @@ class QuickJsInboundChannelTest {
   }
 
   @Test
-  fun invokeHappyPath() {
+  fun callHappyPath() {
     quickJs.evaluate("""
-      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
+      globalThis.$inboundChannelName.call = function(encodedArguments) {
         var result = [
-          'received call to invoke()'
+          'received call()'
         ];
         result.push(...encodedArguments);
         result.push('and the call was successful!');
@@ -66,12 +64,12 @@ class QuickJsInboundChannelTest {
     """.trimIndent())
 
     val inboundChannel = quickJs.getInboundChannel()
-    val result = inboundChannel.invoke(
+    val result = inboundChannel.call(
       encodedArguments = arrayOf("firstArg", "secondArg"),
     )
     assertContentEquals(
       arrayOf(
-        "received call to invoke()",
+        "received call()",
         "firstArg",
         "secondArg",
         "and the call was successful!",
@@ -104,7 +102,7 @@ class QuickJsInboundChannelTest {
   fun disconnectHappyPath() {
     quickJs.evaluate("""
       var callLog = [];
-      globalThis.$inboundChannelName.invoke = function(instanceName, funName, encodedArguments) {
+      globalThis.$inboundChannelName.call = function(instanceName, funName, encodedArguments) {
         return callLog.pop();
       };
       globalThis.$inboundChannelName.disconnect = function(instanceName) {
@@ -115,7 +113,7 @@ class QuickJsInboundChannelTest {
 
     val inboundChannel = quickJs.getInboundChannel()
     assertTrue(inboundChannel.disconnect("service one"))
-    val result = inboundChannel.invoke(arrayOf())
+    val result = inboundChannel.call(arrayOf())
     assertContentEquals(
       arrayOf(
         "disconnect",

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsInboundChannelTest.kt
@@ -43,11 +43,9 @@ class QuickJsInboundChannelTest {
       globalThis.$inboundChannelName = {};
       globalThis.$inboundChannelName.serviceNamesArray = function() {
       };
-      globalThis.$inboundChannelName.invoke = function(instanceName, funName, encodedArguments) {
+      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
       };
-      globalThis.$inboundChannelName.invokeSuspending = function(
-        instanceName, funName, encodedArguments, callbackName
-      ) {
+      globalThis.$inboundChannelName.invokeSuspending = function(encodedArguments, callbackName) {
       };
       globalThis.$inboundChannelName.disconnect = function(instanceName) {
       };
@@ -57,11 +55,9 @@ class QuickJsInboundChannelTest {
   @Test
   fun invokeHappyPath() {
     quickJs.evaluate("""
-      globalThis.$inboundChannelName.invoke = function(instanceName, funName, encodedArguments) {
+      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
         var result = [
-          'received call to invoke()',
-          instanceName,
-          funName
+          'received call to invoke()'
         ];
         result.push(...encodedArguments);
         result.push('and the call was successful!');
@@ -71,15 +67,11 @@ class QuickJsInboundChannelTest {
 
     val inboundChannel = quickJs.getInboundChannel()
     val result = inboundChannel.invoke(
-      instanceName = "theInstanceName",
-      funName = "theFunName",
       encodedArguments = arrayOf("firstArg", "secondArg"),
     )
     assertContentEquals(
       arrayOf(
         "received call to invoke()",
-        "theInstanceName",
-        "theFunName",
         "firstArg",
         "secondArg",
         "and the call was successful!",
@@ -92,16 +84,12 @@ class QuickJsInboundChannelTest {
   fun invokeSuspendingHappyPath() {
     quickJs.evaluate("""
       var callLog = [];
-      globalThis.$inboundChannelName.invoke = function(instanceName, funName, encodedArguments) {
+      globalThis.$inboundChannelName.invoke = function(encodedArguments) {
         return callLog.pop();
       };
-      globalThis.$inboundChannelName.invokeSuspending = function(
-        instanceName, funName, encodedArguments, callbackName
-      ) {
+      globalThis.$inboundChannelName.invokeSuspending = function(encodedArguments, callbackName) {
         var call = [
           'received call to invokeSuspending()',
-          instanceName,
-          funName,
           callbackName
         ];
         call.push(...encodedArguments);
@@ -112,17 +100,13 @@ class QuickJsInboundChannelTest {
 
     val inboundChannel = quickJs.getInboundChannel()
     inboundChannel.invokeSuspending(
-      instanceName = "theInstanceName",
-      funName = "theFunName",
       encodedArguments = arrayOf("firstArg", "secondArg"),
       suspendCallbackName = "theCallbackName",
     )
-    val result = inboundChannel.invoke("", "", arrayOf())
+    val result = inboundChannel.invoke(arrayOf())
     assertContentEquals(
       arrayOf(
         "received call to invokeSuspending()",
-        "theInstanceName",
-        "theFunName",
         "theCallbackName",
         "firstArg",
         "secondArg",
@@ -167,7 +151,7 @@ class QuickJsInboundChannelTest {
 
     val inboundChannel = quickJs.getInboundChannel()
     assertTrue(inboundChannel.disconnect("service one"))
-    val result = inboundChannel.invoke("", "", arrayOf())
+    val result = inboundChannel.invoke(arrayOf())
     assertContentEquals(
       arrayOf(
         "disconnect",

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
@@ -47,7 +47,7 @@ class QuickJsOutboundChannelTest {
     callChannel.invokeResult += "result two"
     val invokeResult = quickJs.evaluate("""
       globalThis.${outboundChannelName}.invoke(
-        'theInstanceName', 'theFunName', ['firstArg', 'secondArg']
+        ['firstArg', 'secondArg']
       );
     """.trimIndent()) as Array<Any>
     assertContentEquals(
@@ -59,7 +59,7 @@ class QuickJsOutboundChannelTest {
     )
     assertEquals(
       listOf(
-        "invoke(theInstanceName, theFunName, [firstArg, secondArg])",
+        "invoke(firstArg, secondArg)",
       ),
       callChannel.log,
     )
@@ -69,12 +69,12 @@ class QuickJsOutboundChannelTest {
   fun invokeSuspendingHappyPath() {
     quickJs.evaluate("""
       globalThis.${outboundChannelName}.invokeSuspending(
-        'theInstanceName', 'theFunName', ['firstArg', 'secondArg'], 'theCallbackName'
+        ['firstArg', 'secondArg'], 'theCallbackName'
       );
     """.trimIndent())
     assertEquals(
       listOf(
-        "invokeSuspending(theInstanceName, theFunName, [firstArg, secondArg], theCallbackName)",
+        "invokeSuspending(firstArg, secondArg, theCallbackName)",
       ),
       callChannel.log,
     )

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
@@ -42,11 +42,11 @@ class QuickJsOutboundChannelTest {
   }
 
   @Test
-  fun invokeHappyPath() {
-    callChannel.invokeResult += "result one"
-    callChannel.invokeResult += "result two"
-    val invokeResult = quickJs.evaluate("""
-      globalThis.${outboundChannelName}.invoke(
+  fun callHappyPath() {
+    callChannel.callResult += "result one"
+    callChannel.callResult += "result two"
+    val callResult = quickJs.evaluate("""
+      globalThis.${outboundChannelName}.call(
         ['firstArg', 'secondArg']
       );
     """.trimIndent()) as Array<Any>
@@ -55,11 +55,11 @@ class QuickJsOutboundChannelTest {
         "result one",
         "result two",
       ),
-      invokeResult,
+      callResult,
     )
     assertEquals(
       listOf(
-        "invoke(firstArg, secondArg)",
+        "call(firstArg, secondArg)",
       ),
       callChannel.log,
     )

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
@@ -66,21 +66,6 @@ class QuickJsOutboundChannelTest {
   }
 
   @Test
-  fun invokeSuspendingHappyPath() {
-    quickJs.evaluate("""
-      globalThis.${outboundChannelName}.invokeSuspending(
-        ['firstArg', 'secondArg'], 'theCallbackName'
-      );
-    """.trimIndent())
-    assertEquals(
-      listOf(
-        "invokeSuspending(firstArg, secondArg, theCallbackName)",
-      ),
-      callChannel.log,
-    )
-  }
-
-  @Test
   fun serviceNamesArrayHappyPath() {
     callChannel.serviceNamesResult += "service one"
     callChannel.serviceNamesResult += "service two"

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -28,11 +28,10 @@ internal class JniCallChannel(
     instance: Long
   ): Array<String>
 
-  override fun invoke(
-    encodedArguments: Array<String>
-  ) = invoke(quickJs.context, instance, encodedArguments)
+  override fun call(encodedArguments: Array<String>) =
+    call(quickJs.context, instance, encodedArguments)
 
-  private external fun invoke(
+  private external fun call(
     context: Long,
     instance: Long,
     encodedArguments: Array<String>,

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -29,33 +29,23 @@ internal class JniCallChannel(
   ): Array<String>
 
   override fun invoke(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>
-  ) = invoke(quickJs.context, instance, instanceName, funName, encodedArguments)
+  ) = invoke(quickJs.context, instance, encodedArguments)
 
   private external fun invoke(
     context: Long,
     instance: Long,
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
   ): Array<String>
 
   override fun invokeSuspending(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
     suspendCallbackName: String
-  ) = invokeSuspending(
-    quickJs.context, instance, instanceName, funName, encodedArguments, suspendCallbackName
-  )
+  ) = invokeSuspending(quickJs.context, instance, encodedArguments, suspendCallbackName)
 
   private external fun invokeSuspending(
     context: Long,
     instance: Long,
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
     callbackName: String,
   )

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -38,18 +38,6 @@ internal class JniCallChannel(
     encodedArguments: Array<String>,
   ): Array<String>
 
-  override fun invokeSuspending(
-    encodedArguments: Array<String>,
-    suspendCallbackName: String
-  ) = invokeSuspending(quickJs.context, instance, encodedArguments, suspendCallbackName)
-
-  private external fun invokeSuspending(
-    context: Long,
-    instance: Long,
-    encodedArguments: Array<String>,
-    callbackName: String,
-  )
-
   override fun disconnect(instanceName: String): Boolean =
     disconnect(quickJs.context, instance, instanceName)
 

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsInboundChannelJvmTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsInboundChannelJvmTest.kt
@@ -41,11 +41,7 @@ class QuickJsInboundChannelJvmTest {
       globalThis.$inboundChannelName = {};
       globalThis.$inboundChannelName.serviceNamesArray = function() {
       };
-      globalThis.$inboundChannelName.invoke = function(instanceName, funName, encodedArguments) {
-      };
-      globalThis.$inboundChannelName.invokeSuspending = function(
-        instanceName, funName, encodedArguments, callbackName
-      ) {
+      globalThis.$inboundChannelName.call = function(instanceName, funName, encodedArguments) {
       };
       globalThis.$inboundChannelName.disconnect = function(instanceName) {
       };

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
@@ -61,15 +61,13 @@ internal object GlobalBridge : JsPlatform, CallChannel {
 
   override fun serviceNamesArray() = inboundChannel.serviceNamesArray()
 
-  override fun invoke(instanceName: String, funName: String, encodedArguments: Array<String>) =
-    inboundChannel.invoke(instanceName, funName, encodedArguments)
+  override fun invoke(encodedArguments: Array<String>) =
+    inboundChannel.invoke(encodedArguments)
 
   override fun invokeSuspending(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
     callbackName: String
-  ) = inboundChannel.invokeSuspending(instanceName, funName, encodedArguments, callbackName)
+  ) = inboundChannel.invokeSuspending(encodedArguments, callbackName)
 
   override fun disconnect(instanceName: String) =
     inboundChannel.disconnect(instanceName)

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
@@ -64,11 +64,6 @@ internal object GlobalBridge : JsPlatform, CallChannel {
   override fun invoke(encodedArguments: Array<String>) =
     inboundChannel.invoke(encodedArguments)
 
-  override fun invokeSuspending(
-    encodedArguments: Array<String>,
-    callbackName: String
-  ) = inboundChannel.invokeSuspending(encodedArguments, callbackName)
-
   override fun disconnect(instanceName: String) =
     inboundChannel.disconnect(instanceName)
 

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
@@ -61,8 +61,8 @@ internal object GlobalBridge : JsPlatform, CallChannel {
 
   override fun serviceNamesArray() = inboundChannel.serviceNamesArray()
 
-  override fun invoke(encodedArguments: Array<String>) =
-    inboundChannel.invoke(encodedArguments)
+  override fun call(encodedArguments: Array<String>) =
+    inboundChannel.call(encodedArguments)
 
   override fun disconnect(instanceName: String) =
     inboundChannel.disconnect(instanceName)

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -58,13 +58,6 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
         return jsOutboundChannel.invoke(encodedArguments)
       }
 
-      override fun invokeSuspending(
-        encodedArguments: Array<String>,
-        callbackName: String
-      ) {
-        return jsOutboundChannel.invokeSuspending(encodedArguments, callbackName)
-      }
-
       override fun disconnect(instanceName: String): Boolean {
         return jsOutboundChannel.disconnect(instanceName)
       }

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -52,10 +52,8 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
         return jsOutboundChannel.serviceNamesArray()
       }
 
-      override fun invoke(
-        encodedArguments: Array<String>
-      ): Array<String> {
-        return jsOutboundChannel.invoke(encodedArguments)
+      override fun call(encodedArguments: Array<String>): Array<String> {
+        return jsOutboundChannel.call(encodedArguments)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -53,29 +53,16 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
       }
 
       override fun invoke(
-        instanceName: String,
-        funName: String,
         encodedArguments: Array<String>
       ): Array<String> {
-        return jsOutboundChannel.invoke(
-          instanceName,
-          funName,
-          encodedArguments
-        )
+        return jsOutboundChannel.invoke(encodedArguments)
       }
 
       override fun invokeSuspending(
-        instanceName: String,
-        funName: String,
         encodedArguments: Array<String>,
         callbackName: String
       ) {
-        return jsOutboundChannel.invokeSuspending(
-          instanceName,
-          funName,
-          encodedArguments,
-          callbackName
-        )
+        return jsOutboundChannel.invokeSuspending(encodedArguments, callbackName)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/nativeInterop/cinterop/quickjs.def
+++ b/zipline/src/nativeInterop/cinterop/quickjs.def
@@ -43,12 +43,7 @@ static inline JSCFunctionListEntry JsServiceNamesFunction(void *func) {
 }
 
 static inline JSCFunctionListEntry JsInvokeFunction(void *func) {
-  JSCFunctionListEntry entry = JS_CFUNC_DEF("invoke", 3, func);
-  return entry;
-}
-
-static inline JSCFunctionListEntry JsInvokeSuspendingFunction(void *func) {
-  JSCFunctionListEntry entry = JS_CFUNC_DEF("invokeSuspending", 4, func);
+  JSCFunctionListEntry entry = JS_CFUNC_DEF("invoke", 1, func);
   return entry;
 }
 

--- a/zipline/src/nativeInterop/cinterop/quickjs.def
+++ b/zipline/src/nativeInterop/cinterop/quickjs.def
@@ -42,8 +42,8 @@ static inline JSCFunctionListEntry JsServiceNamesFunction(void *func) {
   return entry;
 }
 
-static inline JSCFunctionListEntry JsInvokeFunction(void *func) {
-  JSCFunctionListEntry entry = JS_CFUNC_DEF("invoke", 1, func);
+static inline JSCFunctionListEntry JsCallFunction(void *func) {
+  JSCFunctionListEntry entry = JS_CFUNC_DEF("call", 1, func);
   return entry;
 }
 

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -74,31 +74,6 @@ internal class InboundCallChannel(
     return kotlinResult
   }
 
-  override fun invokeSuspending(
-    encodedArguments: Array<String>,
-    callbackName: String,
-  ) {
-    quickJs.checkNotClosed()
-
-    val globalThis = JS_GetGlobalObject(context)
-    val inboundChannel = JS_GetPropertyStr(context, globalThis, inboundChannelName)
-    val property = JS_NewAtom(context, "invokeSuspending")
-    val arg0 = with(quickJs) { encodedArguments.toJsValue() }
-    val arg1 = JS_NewString(context, callbackName)
-
-    val jsResult = memScoped {
-      val args = allocArrayOf(arg0, arg1)
-      JS_Invoke(context, inboundChannel, property, 2, args)
-    }
-
-    JS_FreeValue(context, jsResult)
-    JS_FreeValue(context, arg1)
-    JS_FreeValue(context, arg0)
-    JS_FreeAtom(context, property)
-    JS_FreeValue(context, inboundChannel)
-    JS_FreeValue(context, globalThis)
-  }
-
   override fun disconnect(instanceName: String): Boolean {
     quickJs.checkNotClosed()
 

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -49,14 +49,12 @@ internal class InboundCallChannel(
     return kotlinResult
   }
 
-  override fun invoke(
-    encodedArguments: Array<String>,
-  ): Array<String> {
+  override fun call(encodedArguments: Array<String>): Array<String> {
     quickJs.checkNotClosed()
 
     val globalThis = JS_GetGlobalObject(context)
     val inboundChannel = JS_GetPropertyStr(context, globalThis, inboundChannelName)
-    val property = JS_NewAtom(context, "invoke")
+    val property = JS_NewAtom(context, "call")
     val arg0 = with(quickJs) { encodedArguments.toJsValue() }
 
     val jsResult = memScoped {

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -50,8 +50,6 @@ internal class InboundCallChannel(
   }
 
   override fun invoke(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
   ): Array<String> {
     quickJs.checkNotClosed()
@@ -59,19 +57,15 @@ internal class InboundCallChannel(
     val globalThis = JS_GetGlobalObject(context)
     val inboundChannel = JS_GetPropertyStr(context, globalThis, inboundChannelName)
     val property = JS_NewAtom(context, "invoke")
-    val arg0 = JS_NewString(context, instanceName)
-    val arg1 = JS_NewString(context, funName)
-    val arg2 = with(quickJs) { encodedArguments.toJsValue() }
+    val arg0 = with(quickJs) { encodedArguments.toJsValue() }
 
     val jsResult = memScoped {
-      val args = allocArrayOf(arg0, arg1, arg2)
-      JS_Invoke(context, inboundChannel, property, 3, args)
+      val args = allocArrayOf(arg0)
+      JS_Invoke(context, inboundChannel, property, 1, args)
     }
     val kotlinResult = with(quickJs) { jsResult.toKotlinInstanceOrNull() } as Array<String>
 
     JS_FreeValue(context, jsResult)
-    JS_FreeValue(context, arg2)
-    JS_FreeValue(context, arg1)
     JS_FreeValue(context, arg0)
     JS_FreeAtom(context, property)
     JS_FreeValue(context, inboundChannel)
@@ -81,8 +75,6 @@ internal class InboundCallChannel(
   }
 
   override fun invokeSuspending(
-    instanceName: String,
-    funName: String,
     encodedArguments: Array<String>,
     callbackName: String,
   ) {
@@ -91,19 +83,15 @@ internal class InboundCallChannel(
     val globalThis = JS_GetGlobalObject(context)
     val inboundChannel = JS_GetPropertyStr(context, globalThis, inboundChannelName)
     val property = JS_NewAtom(context, "invokeSuspending")
-    val arg0 = JS_NewString(context, instanceName)
-    val arg1 = JS_NewString(context, funName)
-    val arg2 = with(quickJs) { encodedArguments.toJsValue() }
-    val arg3 = JS_NewString(context, callbackName)
+    val arg0 = with(quickJs) { encodedArguments.toJsValue() }
+    val arg1 = JS_NewString(context, callbackName)
 
     val jsResult = memScoped {
-      val args = allocArrayOf(arg0, arg1, arg2, arg3)
-      JS_Invoke(context, inboundChannel, property, 4, args)
+      val args = allocArrayOf(arg0, arg1)
+      JS_Invoke(context, inboundChannel, property, 2, args)
     }
 
     JS_FreeValue(context, jsResult)
-    JS_FreeValue(context, arg3)
-    JS_FreeValue(context, arg2)
     JS_FreeValue(context, arg1)
     JS_FreeValue(context, arg0)
     JS_FreeAtom(context, property)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -350,21 +350,17 @@ actual class QuickJs private constructor(
   }
 
   internal fun jsOutboundInvoke(argc: Int, argv: CArrayPointer<JSValue>): CValue<JSValue> {
-    assert(argc == 3)
-    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as String
-    val arg1 = JsValueArrayToInstanceRef(argv, 1).toKotlinInstanceOrNull() as String
-    val arg2 = JsValueArrayToInstanceRef(argv, 2).toKotlinInstanceOrNull() as Array<String>
-    val result = outboundChannel!!.invoke(arg0, arg1, arg2)
+    assert(argc == 1)
+    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as Array<String>
+    val result = outboundChannel!!.invoke(arg0)
     return result.toJsValue()
   }
 
   internal fun jsOutboundInvokeSuspending(argc: Int, argv: CArrayPointer<JSValue>): CValue<JSValue> {
-    assert(argc == 4)
-    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as String
+    assert(argc == 2)
+    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as Array<String>
     val arg1 = JsValueArrayToInstanceRef(argv, 1).toKotlinInstanceOrNull() as String
-    val arg2 = JsValueArrayToInstanceRef(argv, 2).toKotlinInstanceOrNull() as Array<String>
-    val arg3 = JsValueArrayToInstanceRef(argv, 3).toKotlinInstanceOrNull() as String
-    outboundChannel!!.invokeSuspending(arg0, arg1, arg2, arg3)
+    outboundChannel!!.invokeSuspending(arg0, arg1)
     return JsUndefined()
   }
 


### PR DESCRIPTION
This is a big refactoring to the internals of CallChannel:

 * Promote serviceName, funName, and callbackName as encoded data. The encoding is a bit clumsy but it means we need a lot less wiring.
 * Use one function for both regular and suspending invocations. The presence of a non-empty callback distinguishes the two cases.
 * Rename `invoke()` to `call()`.