### PR TITLE
Change how inbound call handlers are generated

### DIFF
--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -220,20 +220,20 @@ internal class AdapterGenerator(
     // override fun inboundCallHandlers(
     //   service: SampleService,
     //   context: InboundBridge.Context,
-    // ): Map<String, InboundCallHandler2> { ... }
-    val mapOfStringInboundCallHandler2 = ziplineApis.map.typeWith(
+    // ): Map<String, InboundCallHandler> { ... }
+    val mapOfStringInboundCallHandler = ziplineApis.map.typeWith(
       pluginContext.symbols.string.defaultType,
-      ziplineApis.inboundCallHandler2.defaultType,
+      ziplineApis.inboundCallHandler.defaultType,
     )
-    val mutableMapOfStringInboundCallHandler2 = ziplineApis.mutableMap.typeWith(
+    val mutableMapOfStringInboundCallHandler = ziplineApis.mutableMap.typeWith(
       pluginContext.symbols.string.defaultType,
-      ziplineApis.inboundCallHandler2.defaultType,
+      ziplineApis.inboundCallHandler.defaultType,
     )
 
     val inboundCallHandlersFunction = adapterClass.addFunction {
       initDefaults(original)
       name = ziplineApis.ziplineServiceAdapterInboundCallHandlers.owner.name
-      returnType = mapOfStringInboundCallHandler2
+      returnType = mapOfStringInboundCallHandler
     }.apply {
       addDispatchReceiver {
         initDefaults(original)
@@ -264,8 +264,8 @@ internal class AdapterGenerator(
       val result = irTemporary(
         value = irCall(ziplineApis.mutableMapOfFunction).apply {
           putTypeArgument(0, pluginContext.symbols.string.defaultType)
-          putTypeArgument(1, ziplineApis.inboundCallHandler2.defaultType)
-          type = mutableMapOfStringInboundCallHandler2
+          putTypeArgument(1, ziplineApis.inboundCallHandler.defaultType)
+          type = mutableMapOfStringInboundCallHandler
         },
         nameHint = "result",
         isMutable = false
@@ -313,11 +313,11 @@ internal class AdapterGenerator(
     return inboundCallHandlersFunction
   }
 
-  // class RealInboundCallHandler2(
+  // class InboundCallHandler0(
   //   argSerializers: List<KSerializer<out Any?>>,
   //   resultSerializer: KSerializer<out Any?>,
   //   val service: SampleService,
-  // ) : InboundCallHandler2(argSerializers, resultSerializer) {
+  // ) : InboundCallHandler(argSerializers, resultSerializer) {
   //   ...
   // }
   private fun irInboundCallHandlerClass(
@@ -332,7 +332,7 @@ internal class AdapterGenerator(
       visibility = DescriptorVisibilities.PRIVATE
     }.apply {
       parent = adapterClass
-      superTypes = listOf(ziplineApis.inboundCallHandler2.defaultType)
+      superTypes = listOf(ziplineApis.inboundCallHandler.defaultType)
       createImplicitParameterDeclarationWithWrappedDescriptor()
     }
 
@@ -357,7 +357,7 @@ internal class AdapterGenerator(
       irConstructorBody(pluginContext) { statements ->
         statements += irDelegatingConstructorCall(
           context = pluginContext,
-          symbol = ziplineApis.inboundCallHandler2.constructors.single(),
+          symbol = ziplineApis.inboundCallHandler.constructors.single(),
           valueArgumentsCount = 2,
         ) {
           putValueArgument(0, irGet(valueParameters[0]))
@@ -419,8 +419,8 @@ internal class AdapterGenerator(
     // override fun call(args: List<*>): Any? {
     // }
     val inboundBridgeCall = when {
-      callSuspending -> ziplineApis.inboundCallHandler2CallSuspending
-      else -> ziplineApis.inboundCallHandler2Call
+      callSuspending -> ziplineApis.inboundCallHandlerCallSuspending
+      else -> ziplineApis.inboundCallHandlerCall
     }
     return inboundCallHandler.addFunction {
       initDefaults(original)

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -99,19 +99,6 @@ internal class ZiplineApis(
       bridgeFqName.child("ZiplineFunction").child("callSuspending")
     ).single()
 
-  val outboundCallInvoke: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(bridgeFqName.child("OutboundCall").child("invoke"))
-      .single()
-
-  val outboundCallInvokeSuspending: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(
-      bridgeFqName.child("OutboundCall").child("invokeSuspending")
-    ).single()
-
-  val outboundCallParameter: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(bridgeFqName.child("OutboundCall").child("parameter"))
-      .single()
-
   val outboundBridgeContextFqName = bridgeFqName.child("OutboundBridge").child("Context")
 
   val outboundBridgeContext: IrClassSymbol
@@ -122,14 +109,14 @@ internal class ZiplineApis(
       outboundBridgeContextFqName.child("closed")
     ).single()
 
-  val outboundBridgeContextNewCall: IrSimpleFunctionSymbol
+  val outboundBridgeContextCall: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
-      outboundBridgeContextFqName.child("newCall")
+      outboundBridgeContextFqName.child("call")
     ).single()
 
-  val outboundBridgeContextSerializersModule: IrPropertySymbol
-    get() = pluginContext.referenceProperties(
-      outboundBridgeContextFqName.child("serializersModule")
+  val outboundBridgeContextCallSuspending: IrSimpleFunctionSymbol
+    get() = pluginContext.referenceFunctions(
+      outboundBridgeContextFqName.child("callSuspending")
     ).single()
 
   val ziplineService: IrClassSymbol

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -105,17 +105,17 @@ internal class ZiplineApis(
       inboundBridgeContextFqName.child("serializersModule")
     ).single()
 
-  val inboundCallHandler2: IrClassSymbol
-    get() = pluginContext.referenceClass(bridgeFqName.child("InboundCallHandler2"))!!
+  val inboundCallHandler: IrClassSymbol
+    get() = pluginContext.referenceClass(bridgeFqName.child("InboundCallHandler"))!!
 
-  val inboundCallHandler2Call: IrSimpleFunctionSymbol
+  val inboundCallHandlerCall: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
-      bridgeFqName.child("InboundCallHandler2").child("call")
+      bridgeFqName.child("InboundCallHandler").child("call")
     ).single()
 
-  val inboundCallHandler2CallSuspending: IrSimpleFunctionSymbol
+  val inboundCallHandlerCallSuspending: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
-      bridgeFqName.child("InboundCallHandler2").child("callSuspending")
+      bridgeFqName.child("InboundCallHandler").child("callSuspending")
     ).single()
 
   val outboundCallInvoke: IrSimpleFunctionSymbol

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -53,6 +53,9 @@ internal class ZiplineApis(
   val kSerializer: IrClassSymbol
     get() = pluginContext.referenceClass(serializationFqName.child("KSerializer"))!!
 
+  val serializersModule: IrClassSymbol
+    get() = pluginContext.referenceClass(serializersModuleFqName)!!
+
   val map: IrClassSymbol
     get() = pluginContext.referenceClass(collectionsFqName.child("Map"))!!
 
@@ -105,17 +108,17 @@ internal class ZiplineApis(
       inboundBridgeContextFqName.child("serializersModule")
     ).single()
 
-  val inboundCallHandler: IrClassSymbol
-    get() = pluginContext.referenceClass(bridgeFqName.child("InboundCallHandler"))!!
+  val ziplineFunction: IrClassSymbol
+    get() = pluginContext.referenceClass(bridgeFqName.child("ZiplineFunction"))!!
 
-  val inboundCallHandlerCall: IrSimpleFunctionSymbol
+  val ziplineFunctionCall: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
-      bridgeFqName.child("InboundCallHandler").child("call")
+      bridgeFqName.child("ZiplineFunction").child("call")
     ).single()
 
-  val inboundCallHandlerCallSuspending: IrSimpleFunctionSymbol
+  val ziplineFunctionCallSuspending: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
-      bridgeFqName.child("InboundCallHandler").child("callSuspending")
+      bridgeFqName.child("ZiplineFunction").child("callSuspending")
     ).single()
 
   val outboundCallInvoke: IrSimpleFunctionSymbol
@@ -162,9 +165,9 @@ internal class ZiplineApis(
       ziplineServiceAdapterFqName.child("serialName")
     ).single()
 
-  val ziplineServiceAdapterInboundCallHandlers: IrSimpleFunctionSymbol
+  val ziplineServiceAdapterZiplineFunctions: IrSimpleFunctionSymbol
     get() = ziplineServiceAdapter.functions.single {
-      it.owner.name.identifier == "inboundCallHandlers"
+      it.owner.name.identifier == "ziplineFunctions"
     }
 
   val ziplineServiceAdapterOutboundService: IrSimpleFunctionSymbol

--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -65,9 +65,6 @@ internal class ZiplineApis(
   val listOfKSerializerStar: IrSimpleType
     get() = list.typeWith(kSerializer.starProjectedType)
 
-  val mutableMap: IrClassSymbol
-    get() = pluginContext.referenceClass(collectionsFqName.child("MutableMap"))!!
-
   val serializerFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(serializationFqName.child("serializer"))
       .single {
@@ -80,32 +77,13 @@ internal class ZiplineApis(
     get() = pluginContext.referenceFunctions(bridgeFqName.child("flowSerializer"))
       .single()
 
-  val mutableMapOfFunction: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(collectionsFqName.child("mutableMapOf"))
-      .single { it.owner.valueParameters.isEmpty() }
-
   val listOfFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(collectionsFqName.child("listOf"))
       .single { it.owner.valueParameters.firstOrNull()?.isVararg == true }
 
-  val mutableMapPutFunction: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(
-      collectionsFqName.child("MutableMap").child("put")
-    ).single()
-
   val listGetFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
       collectionsFqName.child("List").child("get")
-    ).single()
-
-  val inboundBridgeContextFqName = bridgeFqName.child("InboundBridge").child("Context")
-
-  val inboundBridgeContext: IrClassSymbol
-    get() = pluginContext.referenceClass(inboundBridgeContextFqName)!!
-
-  val inboundBridgeContextSerializersModule: IrPropertySymbol
-    get() = pluginContext.referenceProperties(
-      inboundBridgeContextFqName.child("serializersModule")
     ).single()
 
   val ziplineFunction: IrClassSymbol

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -16,10 +16,9 @@
 package app.cash.zipline.kotlin;
 
 import app.cash.zipline.internal.bridge.Endpoint;
-import app.cash.zipline.internal.bridge.InboundBridge;
-import app.cash.zipline.internal.bridge.InboundCallHandler;
 import app.cash.zipline.internal.bridge.OutboundBridge;
 import app.cash.zipline.internal.bridge.OutboundCall;
+import app.cash.zipline.internal.bridge.ZiplineFunction;
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter;
 import app.cash.zipline.testing.EchoRequest;
 import app.cash.zipline.testing.EchoResponse;
@@ -41,7 +40,7 @@ import kotlinx.coroutines.CoroutineScope;
 import kotlinx.coroutines.CoroutineScopeKt;
 import kotlinx.serialization.KSerializer;
 import kotlinx.serialization.SerializersKt;
-import org.jetbrains.annotations.NotNull;
+import kotlinx.serialization.modules.SerializersModule;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -94,16 +93,18 @@ public final class ZiplineTestInternals {
       return "EchoService";
     }
 
-    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
-        EchoService service, InboundBridge.Context context) {
+    @Override
+    public Map<String, ZiplineFunction<EchoService>> ziplineFunctions(
+        SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
+        = (KSerializer) SerializersKt.serializer(serializersModule, echoRequestKt);
       KSerializer<?> responseSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
-      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
+        = (KSerializer) SerializersKt.serializer(serializersModule, echoResponseKt);
+      Map<String, ZiplineFunction<EchoService>> result = new LinkedHashMap<>();
       result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
-          @Override public Object call(@NotNull List<?> args) {
+        new ZiplineFunction<EchoService>(Arrays.asList(requestSerializer), responseSerializer) {
+          @Override
+          public Object call(EchoService service, List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }
         });
@@ -147,16 +148,19 @@ public final class ZiplineTestInternals {
       return "GenericEchoService";
     }
 
-    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
-        GenericEchoService<String> service, InboundBridge.Context context) {
+    @Override
+    public Map<String, ZiplineFunction<GenericEchoService<String>>> ziplineFunctions(
+        SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), stringKt);
+        = (KSerializer) SerializersKt.serializer(serializersModule, stringKt);
       KSerializer<?> responseSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), listOfStringKt);
-      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
+        = (KSerializer) SerializersKt.serializer(serializersModule, listOfStringKt);
+      Map<String, ZiplineFunction<GenericEchoService<String>>> result = new LinkedHashMap<>();
       result.put("fun genericEcho(T): kotlin.collections.List<T>",
-        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
-          @Override public Object call(@NotNull List<?> args) {
+        new ZiplineFunction<GenericEchoService<String>>(
+            Arrays.asList(requestSerializer), responseSerializer) {
+          @Override
+          public Object call(GenericEchoService<String> service, List<?> args) {
             return service.genericEcho((String) args.get(0));
           }
         });
@@ -199,16 +203,19 @@ public final class ZiplineTestInternals {
       return "EchoZiplineService";
     }
 
-    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
-        EchoZiplineService service, InboundBridge.Context context) {
+    @Override
+    public Map<String, ZiplineFunction<EchoZiplineService>> ziplineFunctions(
+        SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
+        = (KSerializer) SerializersKt.serializer(serializersModule, echoRequestKt);
       KSerializer<?> responseSerializer
-        = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
-      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
+        = (KSerializer) SerializersKt.serializer(serializersModule, echoResponseKt);
+      Map<String, ZiplineFunction<EchoZiplineService>> result = new LinkedHashMap<>();
       result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
-          @Override public Object call(@NotNull List<?> args) {
+        new ZiplineFunction<EchoZiplineService>(
+            Arrays.asList(requestSerializer), responseSerializer) {
+          @Override
+          public Object call(EchoZiplineService service, List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }
         });

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -17,7 +17,7 @@ package app.cash.zipline.kotlin;
 
 import app.cash.zipline.internal.bridge.Endpoint;
 import app.cash.zipline.internal.bridge.InboundBridge;
-import app.cash.zipline.internal.bridge.InboundCallHandler2;
+import app.cash.zipline.internal.bridge.InboundCallHandler;
 import app.cash.zipline.internal.bridge.OutboundBridge;
 import app.cash.zipline.internal.bridge.OutboundCall;
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter;
@@ -94,15 +94,15 @@ public final class ZiplineTestInternals {
       return "EchoService";
     }
 
-    @Override public Map<String, InboundCallHandler2> inboundCallHandlers(
+    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
         EchoService service, InboundBridge.Context context) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
-      Map<String, InboundCallHandler2> result = new LinkedHashMap<>();
+      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
       result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-        new InboundCallHandler2(Arrays.asList(requestSerializer), responseSerializer) {
+        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
           @Override public Object call(@NotNull List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }
@@ -147,15 +147,15 @@ public final class ZiplineTestInternals {
       return "GenericEchoService";
     }
 
-    @Override public Map<String, InboundCallHandler2> inboundCallHandlers(
+    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
         GenericEchoService<String> service, InboundBridge.Context context) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), stringKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), listOfStringKt);
-      Map<String, InboundCallHandler2> result = new LinkedHashMap<>();
+      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
       result.put("fun genericEcho(T): kotlin.collections.List<T>",
-        new InboundCallHandler2(Arrays.asList(requestSerializer), responseSerializer) {
+        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
           @Override public Object call(@NotNull List<?> args) {
             return service.genericEcho((String) args.get(0));
           }
@@ -199,15 +199,15 @@ public final class ZiplineTestInternals {
       return "EchoZiplineService";
     }
 
-    @Override public Map<String, InboundCallHandler2> inboundCallHandlers(
+    @Override public Map<String, InboundCallHandler> inboundCallHandlers(
         EchoZiplineService service, InboundBridge.Context context) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
-      Map<String, InboundCallHandler2> result = new LinkedHashMap<>();
+      Map<String, InboundCallHandler> result = new LinkedHashMap<>();
       result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-        new InboundCallHandler2(Arrays.asList(requestSerializer), responseSerializer) {
+        new InboundCallHandler(Arrays.asList(requestSerializer), responseSerializer) {
           @Override public Object call(@NotNull List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -26,9 +26,7 @@ import app.cash.zipline.testing.EchoService;
 import app.cash.zipline.testing.EchoZiplineService;
 import app.cash.zipline.testing.GenericEchoService;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import kotlin.Pair;
 import kotlin.PublishedApi;
 import kotlin.coroutines.EmptyCoroutineContext;
@@ -93,22 +91,22 @@ public final class ZiplineTestInternals {
       return "EchoService";
     }
 
-    @Override
-    public Map<String, ZiplineFunction<EchoService>> ziplineFunctions(
+    @Override public List<ZiplineFunction<EchoService>> ziplineFunctions(
         SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, echoRequestKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, echoResponseKt);
-      Map<String, ZiplineFunction<EchoService>> result = new LinkedHashMap<>();
-      result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-        new ZiplineFunction<EchoService>(Arrays.asList(requestSerializer), responseSerializer) {
+      return Arrays.asList(
+        new ZiplineFunction<EchoService>(
+            "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+            Arrays.asList(requestSerializer), responseSerializer) {
           @Override
           public Object call(EchoService service, List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }
-        });
-      return result;
+        }
+      );
     }
 
     @Override public EchoService outboundService(OutboundBridge.Context context) {
@@ -149,22 +147,20 @@ public final class ZiplineTestInternals {
     }
 
     @Override
-    public Map<String, ZiplineFunction<GenericEchoService<String>>> ziplineFunctions(
+    public List<ZiplineFunction<GenericEchoService<String>>> ziplineFunctions(
         SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, stringKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, listOfStringKt);
-      Map<String, ZiplineFunction<GenericEchoService<String>>> result = new LinkedHashMap<>();
-      result.put("fun genericEcho(T): kotlin.collections.List<T>",
+      return Arrays.asList(
         new ZiplineFunction<GenericEchoService<String>>(
+            "fun genericEcho(T): kotlin.collections.List<T>",
             Arrays.asList(requestSerializer), responseSerializer) {
-          @Override
-          public Object call(GenericEchoService<String> service, List<?> args) {
+          @Override public Object call(GenericEchoService<String> service, List<?> args) {
             return service.genericEcho((String) args.get(0));
           }
         });
-      return result;
     }
 
     @Override public GenericEchoService<String> outboundService(OutboundBridge.Context context) {
@@ -204,22 +200,20 @@ public final class ZiplineTestInternals {
     }
 
     @Override
-    public Map<String, ZiplineFunction<EchoZiplineService>> ziplineFunctions(
+    public List<ZiplineFunction<EchoZiplineService>> ziplineFunctions(
         SerializersModule serializersModule) {
       KSerializer<?> requestSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, echoRequestKt);
       KSerializer<?> responseSerializer
         = (KSerializer) SerializersKt.serializer(serializersModule, echoResponseKt);
-      Map<String, ZiplineFunction<EchoZiplineService>> result = new LinkedHashMap<>();
-      result.put("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      return Arrays.asList(
         new ZiplineFunction<EchoZiplineService>(
+            "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
             Arrays.asList(requestSerializer), responseSerializer) {
-          @Override
-          public Object call(EchoZiplineService service, List<?> args) {
+          @Override public Object call(EchoZiplineService service, List<?> args) {
             return service.echo((EchoRequest) args.get(0));
           }
         });
-      return result;
     }
 
     @Override public EchoZiplineService outboundService(

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -17,7 +17,6 @@ package app.cash.zipline.kotlin;
 
 import app.cash.zipline.internal.bridge.Endpoint;
 import app.cash.zipline.internal.bridge.OutboundBridge;
-import app.cash.zipline.internal.bridge.OutboundCall;
 import app.cash.zipline.internal.bridge.ZiplineFunction;
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter;
 import app.cash.zipline.testing.EchoRequest;
@@ -115,21 +114,13 @@ public final class ZiplineTestInternals {
 
     private static class GeneratedOutboundService implements EchoService {
       private final OutboundBridge.Context context;
-      private final KSerializer<EchoRequest> requestSerializer;
-      private final KSerializer<EchoResponse> responseSerializer;
 
       GeneratedOutboundService(OutboundBridge.Context context) {
         this.context = context;
-        this.requestSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
-        this.responseSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
       }
 
       @Override public EchoResponse echo(EchoRequest request) {
-        OutboundCall outboundCall = context.newCall("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse", 1);
-        outboundCall.parameter(requestSerializer, request);
-        return outboundCall.invoke(this, responseSerializer);
+        return (EchoResponse) context.call(this, 0, request);
       }
 
       @Override public void close() {
@@ -169,21 +160,13 @@ public final class ZiplineTestInternals {
 
     private static class GeneratedOutboundService implements GenericEchoService<String> {
       private final OutboundBridge.Context context;
-      private final KSerializer<String> requestSerializer;
-      private final KSerializer<List<String>> responseSerializer;
 
       GeneratedOutboundService(OutboundBridge.Context context) {
         this.context = context;
-        this.requestSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), stringKt);
-        this.responseSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), listOfStringKt);
       }
 
       @Override public List<String> genericEcho(String request) {
-        OutboundCall outboundCall = context.newCall("fun genericEcho(T): kotlin.collections.List<T>", 1);
-        outboundCall.parameter(requestSerializer, request);
-        return outboundCall.invoke(this, responseSerializer);
+        return (List<String>) context.call(this, 0, request);
       }
 
       @Override public void close() {
@@ -224,21 +207,13 @@ public final class ZiplineTestInternals {
     private static class GeneratedOutboundService
         implements EchoZiplineService {
       private final OutboundBridge.Context context;
-      private final KSerializer<EchoRequest> requestSerializer;
-      private final KSerializer<EchoResponse> responseSerializer;
 
       GeneratedOutboundService(OutboundBridge.Context context) {
         this.context = context;
-        this.requestSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoRequestKt);
-        this.responseSerializer
-          = (KSerializer) SerializersKt.serializer(context.getSerializersModule(), echoResponseKt);
       }
 
       @Override public EchoResponse echo(EchoRequest request) {
-        OutboundCall outboundCall = context.newCall("fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse", 1);
-        outboundCall.parameter(requestSerializer, request);
-        return outboundCall.invoke(this, responseSerializer);
+        return (EchoResponse) context.call(this, 0, request);
       }
 
       @Override public void close() {

--- a/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -23,11 +23,9 @@ import app.cash.zipline.testing.GenericEchoService
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import java.lang.reflect.ParameterizedType
 import kotlin.test.assertEquals
 import kotlinx.serialization.KSerializer
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
-import org.jetbrains.kotlin.descriptors.runtime.structure.parameterizedTypeArguments
 import org.junit.Ignore
 import org.junit.Test
 
@@ -298,15 +296,6 @@ class ZiplineKotlinPluginTest {
       )
     )
     assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-
-    val callHandlerClass = result.classLoader.loadClass(
-      "app.cash.zipline.testing.SampleService\$Companion\$Adapter\$GeneratedInboundCallHandler"
-    )
-    assertThat(callHandlerClass).isNotNull()
-    assertThat(callHandlerClass.declaredFields.map {
-      val parameterizedType = it.genericType as? ParameterizedType ?: return@map null
-      parameterizedType.parameterizedTypeArguments[0].typeName
-    }).contains("kotlinx.coroutines.flow.Flow<app.cash.zipline.testing.EchoResponse>")
   }
 }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -116,7 +116,8 @@ class Endpoint internal constructor(
     // Detect leaked old services when creating new services.
     detectLeaks()
 
-    val outboundContext: OutboundBridge.Context = newOutboundContext(name)
+    val ziplineFunctions = adapter.ziplineFunctions(json.serializersModule)
+    val outboundContext = newOutboundContext(name, ziplineFunctions)
     val result = adapter.outboundService(outboundContext)
     eventListener.takeService(name, result)
     trackLeaks(eventListener, name, outboundContext, result)
@@ -142,7 +143,10 @@ class Endpoint internal constructor(
     InboundBridge.Context(name, service, json, this)
 
   @PublishedApi
-  internal fun newOutboundContext(name: String) = OutboundBridge.Context(name, json, this)
+  internal fun newOutboundContext(
+    name: String,
+    ziplineFunctions: List<ZiplineFunction<*>>,
+  ) = OutboundBridge.Context(name, json, this, ziplineFunctions)
 
   internal inner class InboundService<T : ZiplineService>(
     val service: T,

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -102,8 +102,9 @@ class Endpoint internal constructor(
     eventListener.bindService(name, service)
 
     val context = newInboundContext(name, service)
-    val callHandlers = adapter.ziplineFunctions(context.serializersModule)
-    inboundServices[name] = InboundService(service, context, callHandlers)
+    val ziplineFunctions = adapter.ziplineFunctions(context.serializersModule)
+    val ziplineFunctionsMap = ziplineFunctions.associateBy { it.name }
+    inboundServices[name] = InboundService(service, context, ziplineFunctionsMap)
   }
 
   fun <T : ZiplineService> take(name: String): T {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineFunction.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineFunction.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import app.cash.zipline.ZiplineService
+import kotlinx.serialization.KSerializer
+
+@PublishedApi
+internal abstract class ZiplineFunction<T : ZiplineService>(
+  val argSerializers: List<KSerializer<*>>,
+  val resultSerializer: KSerializer<*>,
+) {
+  open fun call(service: T, args: List<*>): Any? {
+    error("unexpected call")
+  }
+
+  open suspend fun callSuspending(service: T, args: List<*>): Any? {
+    error("unexpected call")
+  }
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineFunction.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineFunction.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.KSerializer
 
 @PublishedApi
 internal abstract class ZiplineFunction<T : ZiplineService>(
+  val name: String,
   val argSerializers: List<KSerializer<*>>,
   val resultSerializer: KSerializer<*>,
 ) {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.Encoder
   abstract fun inboundCallHandlers(
     service: T,
     context: InboundBridge.Context,
-  ): Map<String, InboundCallHandler2>
+  ): Map<String, InboundCallHandler>
 
   abstract fun outboundService(
     context: OutboundBridge.Context

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.modules.SerializersModule
 
   abstract fun ziplineFunctions(
     serializersModule: SerializersModule
-  ): Map<String, ZiplineFunction<T>>
+  ): List<ZiplineFunction<T>>
 
   abstract fun outboundService(
     context: OutboundBridge.Context

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -25,17 +25,16 @@ import kotlinx.serialization.encoding.Encoder
  * Adapts [ZiplineService] implementations to receive incoming and send outgoing calls. Most
  * implementations are generated.
  */
-@PublishedApi
-internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<T> {
+@PublishedApi internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<T> {
   private val contextualSerializer = ContextualSerializer(PassByReference::class)
   abstract val serialName: String
 
   override val descriptor  = contextualSerializer.descriptor
 
-  abstract fun inboundCallHandler(
+  abstract fun inboundCallHandlers(
     service: T,
-    context: InboundBridge.Context
-  ): InboundCallHandler
+    context: InboundBridge.Context,
+  ): Map<String, InboundCallHandler2>
 
   abstract fun outboundService(
     context: OutboundBridge.Context

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.ContextualSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
 
 /**
  * Adapts [ZiplineService] implementations to receive incoming and send outgoing calls. Most
@@ -29,12 +30,11 @@ import kotlinx.serialization.encoding.Encoder
   private val contextualSerializer = ContextualSerializer(PassByReference::class)
   abstract val serialName: String
 
-  override val descriptor  = contextualSerializer.descriptor
+  override val descriptor = contextualSerializer.descriptor
 
-  abstract fun inboundCallHandlers(
-    service: T,
-    context: InboundBridge.Context,
-  ): Map<String, InboundCallHandler>
+  abstract fun ziplineFunctions(
+    serializersModule: SerializersModule
+  ): Map<String, ZiplineFunction<T>>
 
   abstract fun outboundService(
     context: OutboundBridge.Context

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -38,20 +38,6 @@ internal interface InboundBridge {
   }
 }
 
-@PublishedApi
-internal abstract class InboundCallHandler(
-  val argSerializers: List<KSerializer<*>>,
-  val resultSerializer: KSerializer<*>,
-) {
-  open fun call(args: List<*>): Any? {
-    error("unexpected call")
-  }
-
-  open suspend fun callSuspending(args: List<*>): Any? {
-    error("unexpected call")
-  }
-}
-
 /**
  * This class models a single call received from another Kotlin platform in the same process.
  *

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -47,6 +47,20 @@ internal interface InboundCallHandler {
   suspend fun callSuspending(inboundCall: InboundCall): Array<String>
 }
 
+@PublishedApi
+internal abstract class InboundCallHandler2(
+  val argSerializers: List<KSerializer<*>>,
+  val resultSerializer: KSerializer<*>,
+) {
+  open fun call(args: List<*>): Any? {
+    error("unexpected call")
+  }
+
+  open suspend fun callSuspending(args: List<*>): Any? {
+    error("unexpected call")
+  }
+}
+
 /**
  * This class models a single call received from another Kotlin platform in the same process.
  *

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/inbound.kt
@@ -39,16 +39,7 @@ internal interface InboundBridge {
 }
 
 @PublishedApi
-internal interface InboundCallHandler {
-  val context: InboundBridge.Context
-
-  fun call(inboundCall: InboundCall): Array<String>
-
-  suspend fun callSuspending(inboundCall: InboundCall): Array<String>
-}
-
-@PublishedApi
-internal abstract class InboundCallHandler2(
+internal abstract class InboundCallHandler(
   val argSerializers: List<KSerializer<*>>,
   val resultSerializer: KSerializer<*>,
 ) {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -15,8 +15,8 @@
  */
 package app.cash.zipline
 
-import app.cash.zipline.internal.bridge.ZiplineFunction
 import app.cash.zipline.internal.bridge.OutboundBridge
+import app.cash.zipline.internal.bridge.ZiplineFunction
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -53,29 +53,35 @@ interface SampleService : ZiplineService {
 
       override fun ziplineFunctions(
         serializersModule: SerializersModule,
-      ): Map<String, ZiplineFunction<SampleService>> {
+      ): List<ZiplineFunction<SampleService>> {
         val sampleRequestSerializer = serializersModule.serializer<SampleRequest>()
         val sampleResponseSerializer = serializersModule.serializer<SampleResponse>()
         val unitSerializer = Unit.serializer()
-        val result = mutableMapOf<String, ZiplineFunction<SampleService>>()
-        result["fun close(): kotlin.Unit"] =
-          ZiplineFunction0(listOf(), unitSerializer)
-        result["fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse"] =
-          ZiplineFunction1(listOf(sampleRequestSerializer), sampleResponseSerializer)
-        return result
+        return listOf(
+          ZiplineFunction0(listOf(), unitSerializer),
+          ZiplineFunction1(listOf(sampleRequestSerializer), sampleResponseSerializer),
+        )
       }
 
       class ZiplineFunction0(
         argSerializers: List<KSerializer<*>>,
         resultSerializer: KSerializer<*>,
-      ) : ZiplineFunction<SampleService>(argSerializers, resultSerializer) {
+      ) : ZiplineFunction<SampleService>(
+        "fun close(): kotlin.Unit",
+        argSerializers,
+        resultSerializer,
+      ) {
         override fun call(service: SampleService, args: List<*>): Any? = service.close()
       }
 
       class ZiplineFunction1(
         argSerializers: List<KSerializer<*>>,
         resultSerializer: KSerializer<*>,
-      ) : ZiplineFunction<SampleService>(argSerializers, resultSerializer) {
+      ) : ZiplineFunction<SampleService>(
+        "fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse",
+        argSerializers,
+        resultSerializer,
+      ) {
         override fun call(service: SampleService, args: List<*>): Any? =
           service.ping(args[0] as SampleRequest)
       }

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -16,7 +16,7 @@
 package app.cash.zipline
 
 import app.cash.zipline.internal.bridge.InboundBridge
-import app.cash.zipline.internal.bridge.InboundCallHandler2
+import app.cash.zipline.internal.bridge.InboundCallHandler
 import app.cash.zipline.internal.bridge.OutboundBridge
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import kotlinx.serialization.KSerializer
@@ -54,11 +54,11 @@ interface SampleService : ZiplineService {
       override fun inboundCallHandlers(
         service: SampleService,
         context: InboundBridge.Context
-      ): Map<String, InboundCallHandler2> {
+      ): Map<String, InboundCallHandler> {
         val sampleRequestSerializer = context.serializersModule.serializer<SampleRequest>()
         val sampleResponseSerializer = context.serializersModule.serializer<SampleResponse>()
         val unitSerializer = Unit.serializer()
-        val result = mutableMapOf<String, InboundCallHandler2>()
+        val result = mutableMapOf<String, InboundCallHandler>()
         result["fun close(): kotlin.Unit"] =
           InboundCallHandler0(listOf(), unitSerializer, service)
         result["fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse"] =
@@ -70,7 +70,7 @@ interface SampleService : ZiplineService {
         argSerializers: List<KSerializer<*>>,
         resultSerializer: KSerializer<*>,
         val service: SampleService,
-      ) : InboundCallHandler2(argSerializers, resultSerializer) {
+      ) : InboundCallHandler(argSerializers, resultSerializer) {
         override fun call(args: List<*>): Any? = service.close()
       }
 
@@ -78,7 +78,7 @@ interface SampleService : ZiplineService {
         argSerializers: List<KSerializer<*>>,
         resultSerializer: KSerializer<*>,
         val service: SampleService,
-      ) : InboundCallHandler2(argSerializers, resultSerializer) {
+      ) : InboundCallHandler(argSerializers, resultSerializer) {
         override fun call(args: List<*>): Any? = service.ping(args[0] as SampleRequest)
       }
 

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -58,23 +58,12 @@ interface SampleService : ZiplineService {
         val sampleResponseSerializer = serializersModule.serializer<SampleResponse>()
         val unitSerializer = Unit.serializer()
         return listOf(
-          ZiplineFunction0(listOf(), unitSerializer),
-          ZiplineFunction1(listOf(sampleRequestSerializer), sampleResponseSerializer),
+          ZiplineFunction0(listOf(sampleRequestSerializer), sampleResponseSerializer),
+          ZiplineFunction1(listOf(), unitSerializer),
         )
       }
 
       class ZiplineFunction0(
-        argSerializers: List<KSerializer<*>>,
-        resultSerializer: KSerializer<*>,
-      ) : ZiplineFunction<SampleService>(
-        "fun close(): kotlin.Unit",
-        argSerializers,
-        resultSerializer,
-      ) {
-        override fun call(service: SampleService, args: List<*>): Any? = service.close()
-      }
-
-      class ZiplineFunction1(
         argSerializers: List<KSerializer<*>>,
         resultSerializer: KSerializer<*>,
       ) : ZiplineFunction<SampleService>(
@@ -86,6 +75,17 @@ interface SampleService : ZiplineService {
           service.ping(args[0] as SampleRequest)
       }
 
+      class ZiplineFunction1(
+        argSerializers: List<KSerializer<*>>,
+        resultSerializer: KSerializer<*>,
+      ) : ZiplineFunction<SampleService>(
+        "fun close(): kotlin.Unit",
+        argSerializers,
+        resultSerializer,
+      ) {
+        override fun call(service: SampleService, args: List<*>): Any? = service.close()
+      }
+
       override fun outboundService(
         context: OutboundBridge.Context
       ): SampleService = GeneratedOutboundService(context)
@@ -93,19 +93,13 @@ interface SampleService : ZiplineService {
       private class GeneratedOutboundService(
         private val context: OutboundBridge.Context
       ) : SampleService {
-        private val requestSerializer = context.serializersModule.serializer<SampleRequest>()
-        private val responseSerializer = context.serializersModule.serializer<SampleResponse>()
-
         override fun ping(request: SampleRequest): SampleResponse {
-          val call = context.newCall("fun ping(app.cash.zipline.SampleRequest): app.cash.zipline.SampleResponse", 1)
-          call.parameter(requestSerializer, request)
-          return call.invoke(this, responseSerializer)
+          return context.call(this, 0, request) as SampleResponse
         }
 
         override fun close() {
-          this.context.closed = true
-          val call = context.newCall("fun close(): kotlin.Unit", 0)
-          return call.invoke(this, Unit.serializer())
+          context.closed = true
+          return context.call(this, 1) as Unit
         }
       }
     }


### PR DESCRIPTION
This replaces a big when() with a Map. It moves responsibilities
out of the generated code.