### PR TITLE
Change CallChannel to accept a single String

### DIFF
--- a/zipline/native/InboundCallChannel.cpp
+++ b/zipline/native/InboundCallChannel.cpp
@@ -52,22 +52,22 @@ jobjectArray InboundCallChannel::serviceNamesArray(Context *context, JNIEnv* env
   return javaResult;
 }
 
-jobjectArray InboundCallChannel::call(Context *context, JNIEnv* env,
-                                      jobjectArray encodedArguments) const {
+jstring InboundCallChannel::call(Context *context, JNIEnv* env,
+                                      jstring callJson) const {
   JSContext *jsContext = context->jsContext;
   JSValue global = JS_GetGlobalObject(jsContext);
   JSValue thisPointer = JS_GetProperty(jsContext, global, nameAtom);
   JSValueConst arguments[1];
-  arguments[0] = context->toJsStringArray(env, encodedArguments);
+  arguments[0] = context->toJsString(env, callJson);
 
   JSValue jsResult = JS_Invoke(jsContext, thisPointer, context->callAtom, 1, arguments);
-  jobjectArray javaResult;
+  jstring javaResult;
   auto tag = JS_VALUE_GET_NORM_TAG(jsResult);
   if (tag == JS_TAG_EXCEPTION) {
     context->throwJsException(env, jsResult);
     javaResult = nullptr;
-  } else if (tag == JS_TAG_OBJECT) {
-    javaResult = context->toJavaStringArray(env, jsResult);
+  } else if (tag == JS_TAG_STRING) {
+    javaResult = context->toJavaString(env, jsResult);
   } else {
     assert(false); // Unexpected tag.
   }

--- a/zipline/native/InboundCallChannel.h
+++ b/zipline/native/InboundCallChannel.h
@@ -29,7 +29,7 @@ public:
   ~InboundCallChannel();
 
   jobjectArray serviceNamesArray(Context* context, JNIEnv*) const;
-  jobjectArray call(Context *context, JNIEnv* env, jobjectArray encodedArguments) const;
+  jstring call(Context *context, JNIEnv* env, jstring callJson) const;
   jboolean disconnect(Context *context, JNIEnv* env, jstring instanceName) const;
 
   JSContext *jsContext;

--- a/zipline/native/OutboundCallChannel.cpp
+++ b/zipline/native/OutboundCallChannel.cpp
@@ -25,7 +25,7 @@ OutboundCallChannel::OutboundCallChannel(Context* c, JNIEnv* env, const char* na
       javaThis(env->NewGlobalRef(object)),
       callChannelClass(static_cast<jclass>(env->NewGlobalRef(env->FindClass("app/cash/zipline/internal/bridge/CallChannel")))),
       serviceNamesArrayMethod(env->GetMethodID(callChannelClass, "serviceNamesArray", "()[Ljava/lang/String;")),
-      callMethod(env->GetMethodID(callChannelClass, "call", "([Ljava/lang/String;)[Ljava/lang/String;")),
+      callMethod(env->GetMethodID(callChannelClass, "call", "(Ljava/lang/String;)Ljava/lang/String;")),
       disconnectMethod(env->GetMethodID(callChannelClass, "disconnect", "(Ljava/lang/String;)Z")) {
   functions.push_back(JS_CFUNC_DEF("serviceNamesArray", 0, OutboundCallChannel::serviceNamesArray));
   functions.push_back(JS_CFUNC_DEF("call", 1, OutboundCallChannel::call));
@@ -82,13 +82,13 @@ OutboundCallChannel::call(JSContext* ctx, JSValueConst this_val, int argc, JSVal
   auto env = context->getEnv();
   env->PushLocalFrame(argc + 1);
   jvalue args[1];
-  args[0].l = context->toJavaStringArray(env, argv[0]);
+  args[0].l = context->toJavaString(env, argv[0]);
 
-  jobjectArray javaResult = static_cast<jobjectArray>(env->CallObjectMethodA(
+  jstring javaResult = static_cast<jstring>(env->CallObjectMethodA(
       channel->javaThis, channel->callMethod, args));
   JSValue jsResult;
   if (!env->ExceptionCheck()) {
-    jsResult = context->toJsStringArray(env, javaResult);
+    jsResult = context->toJsString(env, javaResult);
   } else {
     jsResult = context->throwJavaExceptionFromJs(env);
   }

--- a/zipline/native/quickjs-jni.cpp
+++ b/zipline/native/quickjs-jni.cpp
@@ -168,9 +168,9 @@ Java_app_cash_zipline_JniCallChannel_serviceNamesArray(JNIEnv* env, jobject thiz
   return channel->serviceNamesArray(context, env);
 }
 
-extern "C" JNIEXPORT jobjectArray JNICALL
+extern "C" JNIEXPORT jstring JNICALL
 Java_app_cash_zipline_JniCallChannel_call(JNIEnv* env, jobject thiz, jlong _context,
-                                          jlong instance, jobjectArray encodedArguments) {
+                                          jlong instance, jstring callJson) {
   Context* context = reinterpret_cast<Context*>(_context);
   if (!context) {
     throwJavaException(env, "java/lang/IllegalStateException", "QuickJs instance was closed");
@@ -183,7 +183,7 @@ Java_app_cash_zipline_JniCallChannel_call(JNIEnv* env, jobject thiz, jlong _cont
     return nullptr;
   }
 
-  return channel->call(context, env, encodedArguments);
+  return channel->call(context, env, callJson);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -36,7 +36,7 @@ internal interface CallChannel {
    * Kotlin/JS.
    */
   @JsName("call")
-  fun call(encodedArguments: Array<String>): Array<String>
+  fun call(callJson: String): String
 
   /**
    * Remove [instanceName] from the receiver. After making this call it is an error to make calls

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -61,13 +61,13 @@ class Endpoint internal constructor(
       return serviceNames.toTypedArray()
     }
 
-    override fun call(encodedArguments: Array<String>): Array<String> {
-      val call = json.decodeFromStringFast(callSerializer, encodedArguments.single())
+    override fun call(callJson: String): String {
+      val call = json.decodeFromStringFast(callSerializer, callJson)
       val service = call.inboundService ?: error("no handler for ${call.serviceName}")
 
       return when {
         call.callbackName != null -> service.callSuspending(call)
-        else -> arrayOf(service.call(call))
+        else -> service.call(call)
       }
     }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
@@ -64,7 +64,7 @@ internal class InboundService<T : ZiplineService>(
     )
   }
 
-  fun callSuspending(call: RealCall): Array<String> {
+  fun callSuspending(call: RealCall): String {
     val suspendCallbackName = call.callbackName!!
     val job = endpoint.scope.launch {
       val function = call.function as ZiplineFunction<ZiplineService>?
@@ -107,7 +107,7 @@ internal class InboundService<T : ZiplineService>(
       endpoint.remove(cancelCallbackName)
     }
 
-    return arrayOf()
+    return ""
   }
 
   private fun unexpectedFunction(functionName: String?) = ZiplineApiMismatchException(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -53,12 +53,9 @@ internal class OutboundCallHandler(
     val encodedCall = endpoint.json.encodeToStringFast(endpoint.callSerializer, call)
 
     val callStart = endpoint.eventListener.callStart(call)
-    val encodedResult = endpoint.outboundChannel.call(arrayOf(encodedCall))
+    val encodedResult = endpoint.outboundChannel.call(encodedCall)
 
-    val result = endpoint.json.decodeFromStringFast(
-      function.callResultSerializer,
-      encodedResult.single(),
-    )
+    val result = endpoint.json.decodeFromStringFast(function.callResultSerializer, encodedResult)
     endpoint.eventListener.callEnd(call, result, callStart)
     return result.getOrThrow()
   }
@@ -95,7 +92,7 @@ internal class OutboundCallHandler(
           cancelCallback.cancel()
         }
 
-        endpoint.outboundChannel.call(arrayOf(encodedCall))
+        endpoint.outboundChannel.call(encodedCall)
       }
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -35,8 +35,8 @@ internal fun newEndpointPair(
         return b.inboundChannel.serviceNamesArray()
       }
 
-      override fun call(encodedArguments: Array<String>): Array<String> {
-        return b.inboundChannel.call(encodedArguments)
+      override fun call(callJson: String): String {
+        return b.inboundChannel.call(callJson)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -65,9 +65,9 @@ actual class Zipline private constructor(
         return jsInboundBridge.serviceNamesArray()
       }
 
-      override fun call(encodedArguments: Array<String>): Array<String> {
+      override fun call(callJson: String): String {
         check(scope.isActive) { "Zipline closed" }
-        return jsInboundBridge.call(encodedArguments)
+        return jsInboundBridge.call(callJson)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/LoggingCallChannel.kt
@@ -20,7 +20,7 @@ import app.cash.zipline.internal.bridge.CallChannel
 class LoggingCallChannel : CallChannel {
   val log = mutableListOf<String>()
   val serviceNamesResult = mutableListOf<String>()
-  val callResult = mutableListOf<String>()
+  var callResult = ""
   var disconnectThrow = false
   var disconnectResult = true
 
@@ -29,9 +29,9 @@ class LoggingCallChannel : CallChannel {
     return serviceNamesResult.toTypedArray()
   }
 
-  override fun call(encodedArguments: Array<String>): Array<String> {
-    log += "call(${encodedArguments.joinToString(", ")})"
-    return callResult.toTypedArray()
+  override fun call(callJson: String): String {
+    log += "call($callJson)"
+    return callResult
   }
 
   override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/QuickJsOutboundChannelTest.kt
@@ -43,26 +43,12 @@ class QuickJsOutboundChannelTest {
 
   @Test
   fun callHappyPath() {
-    callChannel.callResult += "result one"
-    callChannel.callResult += "result two"
+    callChannel.callResult = "result one"
     val callResult = quickJs.evaluate("""
-      globalThis.${outboundChannelName}.call(
-        ['firstArg', 'secondArg']
-      );
-    """.trimIndent()) as Array<Any>
-    assertContentEquals(
-      arrayOf(
-        "result one",
-        "result two",
-      ),
-      callResult,
-    )
-    assertEquals(
-      listOf(
-        "call(firstArg, secondArg)",
-      ),
-      callChannel.log,
-    )
+      globalThis.${outboundChannelName}.call('firstArg');
+    """.trimIndent())
+    assertEquals("result one", callResult)
+    assertEquals(listOf("call(firstArg)"), callChannel.log)
   }
 
   @Test

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -28,14 +28,14 @@ internal class JniCallChannel(
     instance: Long
   ): Array<String>
 
-  override fun call(encodedArguments: Array<String>) =
-    call(quickJs.context, instance, encodedArguments)
+  override fun call(callJson: String) =
+    call(quickJs.context, instance, callJson)
 
   private external fun call(
     context: Long,
     instance: Long,
-    encodedArguments: Array<String>,
-  ): Array<String>
+    callJson: String,
+  ): String
 
   override fun disconnect(instanceName: String): Boolean =
     disconnect(quickJs.context, instance, instanceName)

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/GlobalBridge.kt
@@ -61,11 +61,9 @@ internal object GlobalBridge : JsPlatform, CallChannel {
 
   override fun serviceNamesArray() = inboundChannel.serviceNamesArray()
 
-  override fun call(encodedArguments: Array<String>) =
-    inboundChannel.call(encodedArguments)
+  override fun call(callJson: String) = inboundChannel.call(callJson)
 
-  override fun disconnect(instanceName: String) =
-    inboundChannel.disconnect(instanceName)
+  override fun disconnect(instanceName: String) = inboundChannel.disconnect(instanceName)
 
   override fun runJob(timeoutId: Int) {
     val job = jobs.remove(timeoutId) ?: return

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -52,8 +52,8 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
         return jsOutboundChannel.serviceNamesArray()
       }
 
-      override fun call(encodedArguments: Array<String>): Array<String> {
-        return jsOutboundChannel.call(encodedArguments)
+      override fun call(callJson: String): String {
+        return jsOutboundChannel.call(callJson)
       }
 
       override fun disconnect(instanceName: String): Boolean {

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -49,19 +49,19 @@ internal class InboundCallChannel(
     return kotlinResult
   }
 
-  override fun call(encodedArguments: Array<String>): Array<String> {
+  override fun call(callJson: String): String {
     quickJs.checkNotClosed()
 
     val globalThis = JS_GetGlobalObject(context)
     val inboundChannel = JS_GetPropertyStr(context, globalThis, inboundChannelName)
     val property = JS_NewAtom(context, "call")
-    val arg0 = with(quickJs) { encodedArguments.toJsValue() }
+    val arg0 = JS_NewString(context, callJson)
 
     val jsResult = memScoped {
       val args = allocArrayOf(arg0)
       JS_Invoke(context, inboundChannel, property, 1, args)
     }
-    val kotlinResult = with(quickJs) { jsResult.toKotlinInstanceOrNull() } as Array<String>
+    val kotlinResult = with(quickJs) { jsResult.toKotlinInstanceOrNull() } as String
 
     JS_FreeValue(context, jsResult)
     JS_FreeValue(context, arg0)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -348,9 +348,9 @@ actual class QuickJs private constructor(
 
   internal fun jsOutboundCall(argc: Int, argv: CArrayPointer<JSValue>): CValue<JSValue> {
     assert(argc == 1)
-    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as Array<String>
+    val arg0 = JsValueArrayToInstanceRef(argv, 0).toKotlinInstanceOrNull() as String
     val result = outboundChannel!!.call(arg0)
-    return result.toJsValue()
+    return JS_NewString(context, result)
   }
 
   internal fun jsOutboundDisconnect(argc: Int, argv: CArrayPointer<JSValue>): CValue<JSValue> {

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryNative.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryNative.kt
@@ -19,10 +19,10 @@ import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 
 internal actual fun trackLeaks(
-    eventListener: EventListener,
-    serviceName: String,
-    callHandler: OutboundCallHandler,
-    service: ZiplineService
+  eventListener: EventListener,
+  serviceName: String,
+  callHandler: OutboundCallHandler,
+  service: ZiplineService
 ) {
   // TODO: can we implement this with ARC?
 }


### PR DESCRIPTION
Now that we're encoding in JSON we don't need the flexibility
of a string array.