### PR TITLE
Use generics for flows internals

### DIFF
--- a/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin-hosted/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -92,9 +92,11 @@ internal class ZiplineApis(
           it.owner.typeParameters.isEmpty()
       }
 
-  val flowSerializerFunction: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(bridgeFqName.child("flowSerializer"))
-      .single()
+  val flowSerializer: IrClassSymbol
+    get() = pluginContext.referenceClass(bridgeFqName.child("FlowSerializer"))!!
+
+  val flowZiplineService: IrClassSymbol
+    get() = pluginContext.referenceClass(bridgeFqName.child("FlowZiplineService"))!!
 
   val listOfFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(collectionsFqName.child("listOf"))


### PR DESCRIPTION
We no longer double-encode values passing through flows