### PR TITLE
Include encoded forms in EventListener APIs

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Call.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Call.kt
@@ -18,22 +18,41 @@ package app.cash.zipline
 /**
  * A single invocation of a function declared on a [ZiplineService].
  */
-interface ZiplineCall {
+class Call(
   /** The name of the service as used in [Zipline.bind] or [Zipline.take]. */
-  val serviceName: String
+  val serviceName: String,
 
   /**
    * The service instance. Do not downcast this to a concrete type; it may be a generated
    * implementation of the interface.
    */
-  val service: ZiplineService
+  val service: ZiplineService,
 
   /** The signature of the function that was invoked. */
-  val functionName: String
+  val functionName: String,
 
   /**
    * The original arguments passed to the function, in the order they appear in the function
    * signature.
    */
-  val args: List<*>
+  val args: List<*>,
+
+  /**
+   * Zipline's internal encoding of the call. This is intended to help with both debugging and
+   * optimization. The content of this string is not a stable format and should not be operated on
+   * programmatically.
+   *
+   * You can reduce the overhead of Zipline calls by making fewer calls or by and shrinking their
+   * encoded size.
+   */
+  val encodedCall: String,
+
+  serviceNames: List<String>,
+) {
+  /**
+   * Names of [ZiplineService] instances passed in the parameters of this call. These are opaque
+   * generated IDs that can be correlated to [EventListener.serviceLeaked] if the service is not
+   * closed properly.
+   */
+  val serviceNames: List<String> = serviceNames.toList() // Defensive copy.
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/CallResult.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/CallResult.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+/**
+ * The result of a [Call].
+ */
+class CallResult(
+  val result: Result<*>,
+
+  /**
+   * Zipline's internal encoding of the result. This is intended to help with both debugging and
+   * optimization. The content of this string is not a stable format and should not be operated on
+   * programmatically.
+   *
+   * You can reduce the overhead of Zipline calls by making fewer calls or by and shrinking their
+   * encoded size.
+   */
+  val encodedResult: String,
+
+  serviceNames: List<String>,
+) {
+  /**
+   * Names of [ZiplineService] instances passed in the result of this call. These are opaque
+   * generated IDs that can be correlated to [EventListener.serviceLeaked] if the service is not
+   * closed properly.
+   */
+  val serviceNames: List<String> = serviceNames.toList() // Defensive copy.
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
@@ -35,10 +35,10 @@ abstract class EventListener {
    * Invoked when a service function is called. This may be invoked for either suspending or
    * non-suspending functions.
    *
-   * @return any object. This value will be passed back to [callEnd] or [callFailed] when the call
-   *     is completed. The base function always returns null.
+   * @return any object. This value will be passed back to [callEnd] when the call is completed. The
+   *     base function always returns null.
    */
-  open fun callStart(call: ZiplineCall): Any? {
+  open fun callStart(call: Call): Any? {
     return null
   }
 
@@ -48,7 +48,7 @@ abstract class EventListener {
    * @param callStartResult the value returned by [callStart] for the start of this call. This is
    *     null unless [callStart] is overridden to return something else.
    */
-  open fun callEnd(call: ZiplineCall, result: Result<Any?>, callStartResult: Any?) {
+  open fun callEnd(call: Call, result: CallResult, callStartResult: Any?) {
   }
 
   /** Invoked when a service is garbage collected without being closed. */

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallCodec.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallCodec.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
+import app.cash.zipline.ZiplineService
+import app.cash.zipline.internal.decodeFromStringFast
+import app.cash.zipline.internal.encodeToStringFast
+import kotlinx.serialization.KSerializer
+
+/**
+ * Manages encoding an [InternalCall] to JSON and back.
+ *
+ * Zipline's support for both pass-by-value and pass-by-reference is supported by this codec. It
+ * keeps track of services passed by reference in both [Call] and [CallResult] instances. Service
+ * names are collected as a side effect of serialization by [PassByReferenceSerializer].
+ */
+internal class CallCodec(
+  private val endpoint: Endpoint,
+) {
+  private val callSerializer = RealCallSerializer(endpoint)
+
+  /** This list collects service names as they're decoded, including members of other types. */
+  val decodedServiceNames = mutableListOf<String>()
+
+  /** This list collects service names as they're encoded, including members of other types. */
+  val encodedServiceNames = mutableListOf<String>()
+
+  /**
+   * The most-recently received inbound call. Due to reentrant calls it's possible that this isn't
+   * the currently-executing call.
+   */
+  var lastInboundCall: Call? = null
+
+  var nextOutboundCallCallback: ((Call) -> Unit)? = null
+
+  internal fun encodeCall(
+    internalCall: InternalCall,
+    service: ZiplineService,
+  ): Call {
+    encodedServiceNames.clear()
+    val encodedCall = endpoint.json.encodeToStringFast(callSerializer, internalCall)
+    val result = Call(
+      internalCall.serviceName,
+      service,
+      internalCall.functionName,
+      internalCall.args,
+      encodedCall,
+      encodedServiceNames
+    )
+
+    val callback = nextOutboundCallCallback
+    if (callback != null) {
+      callback(result)
+      nextOutboundCallCallback = null
+    }
+
+    return result
+  }
+
+  internal fun decodeCall(
+    callJson: String,
+  ): InternalCall {
+    decodedServiceNames.clear()
+    val internalCall = endpoint.json.decodeFromStringFast(callSerializer, callJson)
+    val inboundService = internalCall.inboundService
+      ?: error("no handler for ${internalCall.serviceName}")
+    lastInboundCall = Call(
+      internalCall.serviceName,
+      inboundService.service,
+      internalCall.functionName,
+      internalCall.args,
+      callJson,
+      decodedServiceNames
+    )
+    return internalCall
+  }
+
+  internal fun encodeFailure(throwable: Throwable): String {
+    return endpoint.json.encodeToStringFast(
+      failureResultSerializer as KSerializer<Any?>,
+      Result.failure<Any?>(throwable),
+    )
+  }
+
+  internal fun encodeResult(
+    function: ZiplineFunction<*>,
+    result: Result<Any?>,
+  ): CallResult {
+    encodedServiceNames.clear()
+    val resultJson = endpoint.json.encodeToStringFast(
+      function.kotlinResultSerializer as KSerializer<Any?>,
+      result,
+    )
+    return CallResult(result, resultJson, encodedServiceNames)
+  }
+
+  internal fun decodeResult(
+    function: ZiplineFunction<*>,
+    resultJson: String,
+  ): CallResult {
+    decodedServiceNames.clear()
+    val result = endpoint.json.decodeFromStringFast(
+      function.kotlinResultSerializer,
+      resultJson,
+    )
+    return CallResult(result, resultJson, decodedServiceNames)
+  }
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
@@ -51,11 +51,8 @@ internal class InboundService<T : ZiplineService>(
       else -> Unit // Don't call callStart() for suspend callbacks.
     }
 
-    val theResult = try {
-      val success = function.call(service, internalCall.args)
-      Result.success(success)
-    } catch (e: Throwable) {
-      Result.failure(e)
+    val theResult = runCatching {
+      function.call(service, internalCall.args)
     }
 
     val callResult = endpoint.callCodec.encodeResult(function, theResult)
@@ -80,11 +77,8 @@ internal class InboundService<T : ZiplineService>(
         result = Result.failure(unexpectedFunction(internalCall.functionName))
       } else {
         val callStart = endpoint.eventListener.callStart(externalCall)
-        result = try {
-          val success = function.callSuspending(service, args)
-          Result.success(success)
-        } catch (e: Throwable) {
-          Result.failure(e)
+        result = runCatching {
+          function.callSuspending(service, args)
         }
         endpoint.callCodec.nextOutboundCallCallback = { callbackCall ->
           endpoint.eventListener.callEnd(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -15,9 +15,10 @@
  */
 package app.cash.zipline.internal.bridge
 
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.decodeFromStringFast
-import app.cash.zipline.internal.encodeToStringFast
 import kotlin.coroutines.Continuation
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -42,22 +43,20 @@ internal class OutboundCallHandler(
   ): Any? {
     val function = functionsList[functionIndex]
     val argsList = args.toList()
-    val call = RealCall(
+    val internalCall = InternalCall(
       serviceName = serviceName,
-      serviceOrNull = service,
       functionName = function.name,
       function = function,
       args = argsList
     )
-    val encodedCall = endpoint.json.encodeToStringFast(endpoint.callSerializer, call)
-
-    val callStart = endpoint.eventListener.callStart(call)
-    val encodedResult = endpoint.outboundChannel.call(encodedCall)
-
-    val result = endpoint.json.decodeFromStringFast(function.kotlinResultSerializer, encodedResult)
-    endpoint.eventListener.callEnd(call, result, callStart)
-    return result.getOrThrow()
+    val externalCall = endpoint.callCodec.encodeCall(internalCall, service)
+    val callStart = endpoint.eventListener.callStart(externalCall)
+    val encodedResult = endpoint.outboundChannel.call(externalCall.encodedCall)
+    val callResult = endpoint.callCodec.decodeResult(function, encodedResult)
+    endpoint.eventListener.callEnd(externalCall, callResult, callStart)
+    return callResult.result.getOrThrow()
   }
+
 
   /** Used by generated code to call a suspending function. */
   suspend fun callSuspending(
@@ -68,23 +67,23 @@ internal class OutboundCallHandler(
     val function = functionsList[functionIndex]
     val argsList = args.toList()
     val suspendCallback = RealSuspendCallback<Any?>()
-    val call = RealCall(
+    val internalCall = InternalCall(
       serviceName = serviceName,
-      serviceOrNull = service,
       functionName = function.name,
       function = function,
       suspendCallback = suspendCallback,
       args = argsList,
     )
-    suspendCallback.call = call
-    val encodedCall = endpoint.json.encodeToStringFast(endpoint.callSerializer, call)
-    suspendCallback.callStart = endpoint.eventListener.callStart(call)
+    val externalCall = endpoint.callCodec.encodeCall(internalCall, service)
+    suspendCallback.internalCall = internalCall
+    suspendCallback.externalCall = externalCall
+    suspendCallback.callStart = endpoint.eventListener.callStart(externalCall)
 
     return suspendCancellableCoroutine { continuation ->
       suspendCallback.continuation = continuation
       endpoint.incompleteContinuations += continuation
       endpoint.scope.launch {
-        val encodedCancelCallback = endpoint.outboundChannel.call(encodedCall)
+        val encodedCancelCallback = endpoint.outboundChannel.call(externalCall.encodedCall)
         val cancelCallback = endpoint.json.decodeFromStringFast(
           cancelCallbackSerializer,
           encodedCancelCallback,
@@ -100,7 +99,8 @@ internal class OutboundCallHandler(
   }
 
   private inner class RealSuspendCallback<R> : SuspendCallback<R> {
-    lateinit var call: RealCall
+    lateinit var internalCall: InternalCall
+    lateinit var externalCall: Call
     lateinit var continuation: Continuation<R>
     var callStart: Any? = null
 
@@ -116,11 +116,13 @@ internal class OutboundCallHandler(
     }
 
     private fun call(result: Result<R>) {
+      val suspendCall = endpoint.callCodec.lastInboundCall!!
+      val callResult = CallResult(result, suspendCall.encodedCall, suspendCall.serviceNames)
       completed = true
       // Suspend callbacks are one-shot. When triggered, remove them immediately.
       endpoint.remove(this@RealSuspendCallback)
       endpoint.incompleteContinuations -= continuation
-      endpoint.eventListener.callEnd(call, result, callStart)
+      endpoint.eventListener.callEnd(externalCall, callResult, callStart)
       continuation.resumeWith(result)
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/passByReference.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/passByReference.kt
@@ -16,7 +16,6 @@
 package app.cash.zipline.internal.bridge
 
 import app.cash.zipline.ZiplineService
-import app.cash.zipline.internal.passByReferencePrefix
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -54,13 +53,15 @@ internal class PassByReferenceSerializer(
 
   override fun serialize(encoder: Encoder, value: PassByReference) {
     require(value is SendByReference<*>)
-    val name = endpoint.generateName(prefix = passByReferencePrefix)
-    value.bind(endpoint, name)
-    encoder.encodeString(name)
+    val serviceName = endpoint.generatePassByReferenceName()
+    endpoint.callCodec.encodedServiceNames += serviceName
+    value.bind(endpoint, serviceName)
+    encoder.encodeString(serviceName)
   }
 
   override fun deserialize(decoder: Decoder): PassByReference {
-    val name = decoder.decodeString()
-    return ReceiveByReference(name, endpoint)
+    val serviceName = decoder.decodeString()
+    endpoint.callCodec.decodedServiceNames += serviceName
+    return ReceiveByReference(serviceName, endpoint)
   }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -28,9 +28,11 @@ import kotlinx.serialization.modules.SerializersModule
 internal fun newEndpointPair(
   scope: CoroutineScope,
   serializersModule: SerializersModule = EmptySerializersModule,
+  listenerA: EventListener = EventListener.NONE,
+  listenerB: EventListener = EventListener.NONE,
 ): Pair<Endpoint, Endpoint> {
   val pair = object : Any() {
-    val a: Endpoint = Endpoint(scope, serializersModule, EventListener.NONE, object : CallChannel {
+    val a: Endpoint = Endpoint(scope, serializersModule, listenerA, object : CallChannel {
       override fun serviceNamesArray(): Array<String> {
         return b.inboundChannel.serviceNamesArray()
       }
@@ -44,7 +46,7 @@ internal fun newEndpointPair(
       }
     })
 
-    val b: Endpoint = Endpoint(scope, serializersModule, EventListener.NONE, a.inboundChannel)
+    val b: Endpoint = Endpoint(scope, serializersModule, listenerB, a.inboundChannel)
   }
 
   return pair.a to pair.b

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -22,6 +22,7 @@ import app.cash.zipline.testing.EchoResponse
 import app.cash.zipline.testing.EchoService
 import app.cash.zipline.testing.SuspendingEchoService
 import app.cash.zipline.testing.newEndpointPair
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -38,6 +39,14 @@ import kotlinx.serialization.json.JsonElement
 internal class EventListenerEndpointTest {
   private val clientListener = CallListener()
   private val serviceListener = CallListener()
+
+  @AfterTest
+  fun tearDown() {
+    assertTrue(clientListener.calls.isEmpty())
+    assertTrue(clientListener.results.isEmpty())
+    assertTrue(serviceListener.calls.isEmpty())
+    assertTrue(serviceListener.results.isEmpty())
+  }
 
   @Test
   fun simpleRequestAndResponse() = runBlocking {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -1,0 +1,373 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.zipline
+
+import app.cash.zipline.internal.encodeToStringFast
+import app.cash.zipline.testing.EchoRequest
+import app.cash.zipline.testing.EchoResponse
+import app.cash.zipline.testing.EchoService
+import app.cash.zipline.testing.SuspendingEchoService
+import app.cash.zipline.testing.newEndpointPair
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * This test exercises EventListeners where both endpoints are on the same platform.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+internal class EventListenerEndpointTest {
+  private val clientListener = CallListener()
+  private val serviceListener = CallListener()
+
+  @Test
+  fun simpleRequestAndResponse() = runBlocking {
+    val (clientEndpoint, serviceEndpoint) = newEndpointPair(
+      scope = this,
+      listenerA = clientListener,
+      listenerB = serviceListener,
+    )
+
+    val service = object : EchoService {
+      override fun echo(request: EchoRequest): EchoResponse {
+        return EchoResponse("pong")
+      }
+    }
+
+    serviceEndpoint.bind<EchoService>("echoService", service)
+    val client = clientEndpoint.take<EchoService>("echoService")
+    client.echo(EchoRequest("ping"))
+
+    val clientCall = clientListener.calls.removeFirst()
+    assertEquals("echoService", clientCall.serviceName)
+    assertEquals(client, clientCall.service)
+    assertEquals(
+      "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      clientCall.functionName,
+    )
+    assertEquals(listOf(EchoRequest("ping")), clientCall.args)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoService",
+      |  "function": "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      |  "args": [
+      |    {
+      |      "message": "ping"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(clientCall.encodedCall),
+    )
+    assertEquals(listOf(), clientCall.serviceNames)
+
+    val serviceCall = serviceListener.calls.removeFirst()
+    assertEquals("echoService", serviceCall.serviceName)
+    assertEquals(service, serviceCall.service) // Note this is different from clientCall.service.
+    assertEquals(
+      "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      serviceCall.functionName,
+    )
+    assertEquals(listOf(EchoRequest("ping")), serviceCall.args)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoService",
+      |  "function": "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      |  "args": [
+      |    {
+      |      "message": "ping"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceCall.encodedCall),
+    )
+    assertEquals(listOf(), serviceCall.serviceNames)
+
+    val clientResult = clientListener.results.removeFirst()
+    assertEquals(EchoResponse("pong"), clientResult.result.getOrNull())
+    assertEquals(
+      """
+      |{
+      |  "success": {
+      |    "message": "pong"
+      |  }
+      |}
+      """.trimMargin(),
+      prettyPrint(clientResult.encodedResult),
+    )
+    assertEquals(listOf(), clientResult.serviceNames)
+
+    val serviceResult = serviceListener.results.removeFirst()
+    assertEquals(EchoResponse("pong"), serviceResult.result.getOrNull())
+    assertEquals(
+      """
+      |{
+      |  "success": {
+      |    "message": "pong"
+      |  }
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceResult.encodedResult),
+    )
+    assertEquals(listOf(), serviceResult.serviceNames)
+  }
+
+  @Test
+  fun suspendingRequestAndResponse() = runBlocking {
+    val (clientEndpoint, serviceEndpoint) = newEndpointPair(
+      scope = this,
+      listenerA = clientListener,
+      listenerB = serviceListener,
+    )
+
+    val service = object : SuspendingEchoService {
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
+        return EchoResponse("pong")
+      }
+    }
+
+    serviceEndpoint.bind<SuspendingEchoService>("echoService", service)
+    val client = clientEndpoint.take<SuspendingEchoService>("echoService")
+    client.suspendingEcho(EchoRequest("ping"))
+
+    val clientCall = clientListener.calls.removeFirst()
+    assertEquals("echoService", clientCall.serviceName)
+    assertEquals(client, clientCall.service)
+    assertEquals(
+      "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      clientCall.functionName,
+    )
+    assertEquals(listOf(EchoRequest("ping")), clientCall.args)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoService",
+      |  "function": "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      |  "callback": "service/1",
+      |  "args": [
+      |    {
+      |      "message": "ping"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(clientCall.encodedCall),
+    )
+    assertEquals(listOf("service/1"), clientCall.serviceNames) // This is the callback.
+
+    val serviceCall = serviceListener.calls.removeFirst()
+    assertEquals("echoService", serviceCall.serviceName)
+    assertEquals(service, serviceCall.service) // Note this is different from clientCall.service.
+    assertEquals(
+      "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      serviceCall.functionName,
+    )
+    assertEquals(listOf(EchoRequest("ping")), serviceCall.args)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoService",
+      |  "function": "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      |  "callback": "service/1",
+      |  "args": [
+      |    {
+      |      "message": "ping"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceCall.encodedCall),
+    )
+    assertEquals(listOf("service/1"), serviceCall.serviceNames)
+
+    val clientResult = clientListener.results.removeFirst()
+    assertEquals(EchoResponse("pong"), clientResult.result.getOrNull())
+    assertEquals(
+      """
+      |{
+      |  "service": "service/1",
+      |  "function": "fun success(T): kotlin.Unit",
+      |  "args": [
+      |    {
+      |      "message": "pong"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(clientResult.encodedResult),
+    )
+    assertEquals(listOf(), clientResult.serviceNames)
+
+    val serviceResult = serviceListener.results.removeFirst()
+    assertEquals(EchoResponse("pong"), serviceResult.result.getOrNull())
+    assertEquals(
+      """
+      |{
+      |  "service": "service/1",
+      |  "function": "fun success(T): kotlin.Unit",
+      |  "args": [
+      |    {
+      |      "message": "pong"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceResult.encodedResult),
+    )
+    assertEquals(listOf(), serviceResult.serviceNames)
+  }
+
+  @Test
+  fun serviceRequestAndResponse() = runBlocking {
+    val (clientEndpoint, serviceEndpoint) = newEndpointPair(
+      scope = this,
+      listenerA = clientListener,
+      listenerB = serviceListener,
+    )
+
+    val service = object : EchoTransformer {
+      override fun transform(prefix: String, service: EchoService): EchoService {
+        return object : EchoService {
+          override fun echo(request: EchoRequest): EchoResponse {
+            return EchoResponse("$prefix ${request.message}")
+          }
+
+          override fun close() {
+            service.close()
+          }
+        }
+      }
+    }
+
+    serviceEndpoint.bind<EchoTransformer>("echoTransformer", service)
+    val client = clientEndpoint.take<EchoTransformer>("echoTransformer")
+    val serviceArgument = object : EchoService {
+      override fun echo(request: EchoRequest): EchoResponse {
+        return EchoResponse("pong")
+      }
+    }
+    val transformedService = client.transform("hello", serviceArgument)
+
+    val clientCall = clientListener.calls.removeFirst()
+    assertEquals("echoTransformer", clientCall.serviceName)
+    assertEquals(client, clientCall.service)
+    assertEquals(
+      "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
+      clientCall.functionName,
+    )
+    assertEquals(listOf("hello", serviceArgument), clientCall.args)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoTransformer",
+      |  "function": "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
+      |  "args": [
+      |    "hello",
+      |    "service/1"
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(clientCall.encodedCall),
+    )
+    assertEquals(listOf("service/1"), clientCall.serviceNames) // This is the callback.
+
+    val serviceCall = serviceListener.calls.removeFirst()
+    assertEquals("echoTransformer", serviceCall.serviceName)
+    assertEquals(service, serviceCall.service) // Note this is different from clientCall.service.
+    assertEquals(
+      "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
+      serviceCall.functionName,
+    )
+    assertEquals("hello", serviceCall.args[0])
+    assertNotSame(serviceCall.args[1], serviceArgument) // The service receives a stub.
+    assertTrue(serviceCall.args[1] is EchoService)
+    assertEquals(
+      """
+      |{
+      |  "service": "echoTransformer",
+      |  "function": "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
+      |  "args": [
+      |    "hello",
+      |    "service/1"
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceCall.encodedCall),
+    )
+    assertEquals(listOf("service/1"), serviceCall.serviceNames)
+
+    val clientResult = clientListener.results.removeFirst()
+    assertEquals(transformedService, clientResult.result.getOrNull()) // This is a stub.
+    assertEquals(
+      """
+      |{
+      |  "success": "service/1"
+      |}
+      """.trimMargin(),
+      prettyPrint(clientResult.encodedResult),
+    )
+    assertEquals(listOf("service/1"), clientResult.serviceNames)
+
+    val serviceResult = serviceListener.results.removeFirst()
+    assertTrue(serviceResult.result.getOrNull() is EchoService)
+    assertNotSame(transformedService, serviceResult.result.getOrNull()) // This is the original.
+    assertEquals(
+      """
+      |{
+      |  "success": "service/1"
+      |}
+      """.trimMargin(),
+      prettyPrint(serviceResult.encodedResult),
+    )
+    assertEquals(listOf("service/1"), serviceResult.serviceNames)
+  }
+
+  private fun prettyPrint(jsonString: String): String {
+    val json = Json {
+      prettyPrint = true
+      prettyPrintIndent = "  "
+    }
+    val jsonTree = json.decodeFromString(JsonElement.serializer(), jsonString)
+    return json.encodeToStringFast(JsonElement.serializer(), jsonTree)
+  }
+
+  interface EchoTransformer : ZiplineService {
+    fun transform(prefix: String, service: EchoService): EchoService
+  }
+
+  class CallListener : EventListener() {
+    val calls = ArrayDeque<Call>()
+    val results = ArrayDeque<CallResult>()
+
+    override fun callStart(call: Call): Any? {
+      calls += call
+      return null
+    }
+
+    override fun callEnd(call: Call, result: CallResult, callStartResult: Any?) {
+      results += result
+    }
+  }
+}

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
@@ -31,6 +31,9 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+/**
+ * This test exercises event listeners using QuickJS.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventListenerTest {
   private val dispatcher = TestCoroutineDispatcher()

--- a/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -15,8 +15,9 @@
  */
 package app.cash.zipline.testing
 
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
 import app.cash.zipline.EventListener
-import app.cash.zipline.ZiplineCall
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.bridge.CancelCallback
 import app.cash.zipline.internal.bridge.SuspendCallback
@@ -42,7 +43,7 @@ class LoggingEventListener : EventListener() {
     )
   }
 
-  override fun callStart(call: ZiplineCall): Any? {
+  override fun callStart(call: Call): Any? {
     val callId = nextCallId++
     log(
       service = call.service,
@@ -52,11 +53,12 @@ class LoggingEventListener : EventListener() {
     return callId
   }
 
-  override fun callEnd(call: ZiplineCall, result: Result<Any?>, callStartResult: Any?) {
+  override fun callEnd(call: Call, result: CallResult, callStartResult: Any?) {
     log(
       service = call.service,
       serviceName = call.serviceName,
-      log = "callEnd $callStartResult ${call.serviceName} ${call.functionName} ${call.args} $result"
+      log = "callEnd $callStartResult " +
+        "${call.serviceName} ${call.functionName} ${call.args} ${result.result}"
     )
   }
 


### PR DESCRIPTION
I'm hoping this is sufficient to build a very powerful
DevelopmentEventListener that can trace leaks precisely.