### PR TITLE
Fix up some false-positive service leak warnings

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -113,7 +113,12 @@ class Endpoint internal constructor(
     val callHandler = OutboundCallHandler(name, this, functions)
     val result = adapter.outboundService(callHandler)
     eventListener.takeService(name, result)
-    trackLeaks(eventListener, name, callHandler, result)
+
+    // Track leaks for services that can't release themselves automatically.
+    if (result !is SuspendCallback<*> && result !is CancelCallback) {
+      trackLeaks(eventListener, name, callHandler, result)
+    }
+
     return result
   }
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/InboundService.kt
@@ -109,11 +109,16 @@ internal class InboundService<T : ZiplineService>(
         job.cancel()
       }
     }
+
+    // Note that encoding the cancelCallback has the side effect of registering it on the endpoint.
+    // This must precede configuring the invokeOnCompletion() handler.
+    val encodedCallback = endpoint.json.encodeToStringFast(cancelCallbackSerializer, cancelCallback)
+
     job.invokeOnCompletion {
       endpoint.remove(cancelCallback)
     }
 
-    return endpoint.json.encodeToStringFast(cancelCallbackSerializer, cancelCallback)
+    return encodedCallback
   }
 
   private fun unexpectedFunction(functionName: String?) = ZiplineApiMismatchException(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -63,7 +63,6 @@ internal class OutboundCallHandler(
     return callResult.result.getOrThrow()
   }
 
-
   /** Used by generated code to call a suspending function. */
   suspend fun callSuspending(
     service: ZiplineService,


### PR DESCRIPTION
We're warning of leaks for things that close themselves. These
aren't leaks because the objects are closed, just the peer
doesn't know it.