### PR TITLE
No Okio dependency in the main Zipline module

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -79,9 +79,6 @@ kotlin {
 
     val engineMain by creating {
       dependsOn(commonMain)
-      dependencies {
-        api(libs.okio.core)
-      }
       kotlin.srcDir(versionWriterTaskProvider)
     }
     val engineTest by creating {


### PR DESCRIPTION
It was unused.