### PR TITLE
Add mainModuleId and mainFunction to manifest

### DIFF
--- a/samples/emoji-search/presenters/build.gradle.kts
+++ b/samples/emoji-search/presenters/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 
 plugins {
   kotlin("multiplatform")
@@ -48,6 +46,8 @@ val compileZipline by tasks.creating(JavaExec::class) {
   args = listOf(
     "$buildDir/compileSync/main/productionExecutable/kotlin",
     "$buildDir/zipline",
+    "./zipline-root-presenters.js",
+    "app.cash.zipline.samples.emojisearch.preparePresenters()"
   )
 }
 

--- a/samples/trivia/trivia-js/build.gradle.kts
+++ b/samples/trivia/trivia-js/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 
 plugins {
   kotlin("multiplatform")
@@ -39,6 +37,8 @@ val compileZipline by tasks.creating(JavaExec::class) {
   args = listOf(
     "$buildDir/compileSync/main/productionExecutable/kotlin",
     "$buildDir/zipline",
+    "./zipline-root-trivia-js.js",
+    "app.cash.zipline.samples.trivia.launchZipline()"
   )
 }
 

--- a/zipline-cli/src/test/kotlin/app/cash/zipline/cli/DownloadTest.kt
+++ b/zipline-cli/src/test/kotlin/app/cash/zipline/cli/DownloadTest.kt
@@ -74,6 +74,8 @@ class DownloadTest {
     // Zipline files
     val applicationName = "app1"
     val manifest = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         "id" to ZiplineModule(
           url = webServer.url("/latest/app/alpha.zipline").toString(),

--- a/zipline-gradle-plugin/README.md
+++ b/zipline-gradle-plugin/README.md
@@ -6,6 +6,19 @@ Zipline Compilation
 
 The plugin compiles JavaScript files into `.zipline` files. These binary files are faster to launch.
 
+The plugin requires setting the following variables which are used in compilation.
+
+- `mainModuleId`: This is the JS module that your application's entrypoint function is in. This will usually be the last key in the `modules` map in the generated ZiplineManifest which is sorted topologically.
+- `mainFunction`: This is the fully qualified function call to start your application, note it does include the trailing `()` to initiate the call.
+
+```kts
+import app.cash.zipline.gradle.ZiplineCompileTask
+
+tasks.withType(ZiplineCompileTask::class) {
+  mainModuleId.set("./app-root.js")
+  mainFunction.set("my.path.prepareFunction()")
+}
+```
 
 Webpack Config
 ==============

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
@@ -21,6 +21,8 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
@@ -48,6 +50,12 @@ abstract class ZiplineCompileTask @Inject constructor(
   @get:OutputDirectory
   val outputDir: DirectoryProperty = objectFactory.directoryProperty()
 
+  @get:Input
+  val mainModuleId: Property<String> = objectFactory.property(String::class.java)
+
+  @get:Input
+  val mainFunction: Property<String> = objectFactory.property(String::class.java)
+
   @get:OutputFile
   val webpackConfigFile: File by lazy {
     project.projectDir.resolve(configFilePath)
@@ -57,7 +65,10 @@ abstract class ZiplineCompileTask @Inject constructor(
   fun task() {
     val inputDirFile = inputDir.get().asFile
     val outputDirFile = outputDir.get().asFile
-    ZiplineCompiler.compile(inputDirFile, outputDirFile)
+    val mainModuleId = mainModuleId.get()
+    val mainFunction = mainFunction.get()
+
+    ZiplineCompiler.compile(inputDirFile, outputDirFile, mainModuleId, mainFunction)
 
     val webpackHome = project.rootProject.buildDir.resolve("js/packages/placeholder-name")
     val directory = outputDirFile.relativeTo(webpackHome)

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompiler.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompiler.kt
@@ -33,7 +33,9 @@ import okio.sink
 object ZiplineCompiler {
   fun compile(
     inputDir: File,
-    outputDir: File
+    outputDir: File,
+    mainModuleId: String,
+    mainFunction: String
   ) {
     val modules = mutableMapOf<String, ZiplineModule>()
     val files = inputDir.listFiles()
@@ -77,7 +79,7 @@ object ZiplineCompiler {
         }
       }
     }
-    val manifest = ZiplineManifest.create(modules)
+    val manifest = ZiplineManifest.create(mainModuleId, mainFunction, modules)
     val manifestFile = File(outputDir.path, "manifest.zipline.json")
     manifestFile.writeText(Json.encodeToString(manifest))
   }
@@ -90,5 +92,10 @@ object ZiplineCompiler {
 fun main(vararg args: String) {
   val outputDir = File(args[1])
   outputDir.mkdirs()
-  ZiplineCompiler.compile(inputDir = File(args[0]), outputDir = outputDir)
+  ZiplineCompiler.compile(
+    inputDir = File(args[0]),
+    outputDir = outputDir,
+    mainModuleId = args[2],
+    mainFunction = args[3],
+  )
 }

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -45,20 +45,20 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
     version = BuildConfig.KOTLIN_PLUGIN_VERSION,
   )
 
-  override fun apply(project: Project) {
-    super.apply(project)
+  override fun apply(target: Project) {
+    super.apply(target)
 
-    val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
+    val extension = target.extensions.findByType(KotlinMultiplatformExtension::class.java)
       ?: return
 
     extension.targets.withType(KotlinJsIrTarget::class.java).all { kotlinTarget ->
       kotlinTarget.binaries.withType(JsIrBinary::class.java).all { kotlinBinary ->
-        registerCompileZiplineTask(project, kotlinBinary)
+        registerCompileZiplineTask(target, kotlinBinary)
       }
     }
 
-    project.tasks.named("clean", Delete::class.java).configure { clean ->
-      clean.delete.add(project.projectDir.resolve(ZiplineCompileTask.configFilePath))
+    target.tasks.named("clean", Delete::class.java).configure { clean ->
+      clean.delete.add(target.projectDir.resolve(ZiplineCompileTask.configFilePath))
     }
   }
 

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineCompilerTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineCompilerTest.kt
@@ -94,7 +94,9 @@ class ZiplineCompilerTest {
     val outputDir = File("$rootProject/build/zipline")
     outputDir.mkdirs()
 
-    ZiplineCompiler.compile(inputDir, outputDir)
+    val mainModuleId = "./app.js"
+    val mainFunction = "zipline.ziplineMain()"
+    ZiplineCompiler.compile(inputDir, outputDir, mainModuleId, mainFunction)
 
     val expectedNumberFiles = if (dirHasSourceMaps) inputDir.listFiles()!!.size / 2 else inputDir.listFiles()!!.size
     // Don't include Zipline manifest
@@ -105,6 +107,10 @@ class ZiplineCompilerTest {
     val manifestFile = File(outputDir, "manifest.zipline.json")
     val manifestString = manifestFile.readText()
     val manifest = Json.decodeFromString<ZiplineManifest>(manifestString)
+
+    // Confirm that mainModuleId and mainFunction have been added to the manifest
+    assertEquals(mainModuleId, manifest.mainModuleId)
+    assertEquals(mainFunction, manifest.mainFunction)
 
     // Confirm that all manifest files are present in outputDir
     outputDir.listFiles()!!.forEach { ziplineFile ->

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloaderTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloaderTest.kt
@@ -56,6 +56,8 @@ class ZiplineGradleDownloaderTest {
   fun `integration test to load from mock url`() {
     // Zipline files
     val manifest = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         "id" to ZiplineModule(
           url = webServer.url("/latest/app/alpha.zipline").toString(),

--- a/zipline-gradle-plugin/src/test/projects/basic/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/basic/build.gradle.kts
@@ -12,7 +12,6 @@ buildscript {
   }
 }
 
-
 allprojects {
   repositories {
     maven {

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/build.gradle.kts
@@ -1,5 +1,4 @@
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
+import app.cash.zipline.gradle.ZiplineCompileTask
 
 plugins {
   kotlin("multiplatform")
@@ -37,4 +36,9 @@ val launchGreetService by tasks.creating(JavaExec::class) {
   dependsOn(":lib:compileProductionExecutableKotlinJsZipline")
   classpath = jvmTestRuntimeClasspath
   mainClass.set("app.cash.zipline.tests.LaunchGreetServiceJvmKt")
+}
+
+tasks.withType(ZiplineCompileTask::class) {
+  mainModuleId.set("")
+  mainFunction.set("")
 }

--- a/zipline-gradle-plugin/src/test/projects/jvmOnly/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/jvmOnly/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import app.cash.zipline.gradle.ZiplineCompileTask
+
 plugins {
   kotlin("multiplatform")
   id("app.cash.zipline")
@@ -20,4 +22,9 @@ val jvmTestRuntimeClasspath by configurations.getting
 val bindAndTakeJvm by tasks.creating(JavaExec::class) {
   classpath = jvmTestRuntimeClasspath
   mainClass.set("app.cash.zipline.tests.BindAndTakeJvmKt")
+}
+
+tasks.withType(ZiplineCompileTask::class) {
+  mainModuleId.set("")
+  mainFunction.set("")
 }

--- a/zipline-gradle-plugin/src/test/projects/multipleJsTargets/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/multipleJsTargets/lib/build.gradle.kts
@@ -1,5 +1,4 @@
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
+import app.cash.zipline.gradle.ZiplineCompileTask
 
 plugins {
   kotlin("multiplatform")
@@ -24,4 +23,9 @@ kotlin {
       }
     }
   }
+}
+
+tasks.withType(ZiplineCompileTask::class) {
+  mainModuleId.set("")
+  mainFunction.set("")
 }

--- a/zipline-loader-testing/src/engineMain/kotlin/app/cash/zipline/loader/testing/LoaderTestFixtures.kt
+++ b/zipline-loader-testing/src/engineMain/kotlin/app/cash/zipline/loader/testing/LoaderTestFixtures.kt
@@ -21,7 +21,6 @@ import app.cash.zipline.loader.CURRENT_ZIPLINE_VERSION
 import app.cash.zipline.loader.ZiplineFile
 import app.cash.zipline.loader.ZiplineManifest
 import app.cash.zipline.loader.ZiplineModule
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okio.Buffer
@@ -41,6 +40,8 @@ class LoaderTestFixtures {
   val bravoSha256Hex = bravoSha256.hex()
 
   val manifestWithRelativeUrls = ZiplineManifest.create(
+    mainModuleId = "./app.js",
+    mainFunction = "zipline.ziplineMain()",
     modules = mapOf(
       "bravo" to ZiplineModule(
         url = bravoRelativeUrl,
@@ -100,6 +101,8 @@ class LoaderTestFixtures {
       seed: String,
       seedFileSha256: ByteString
     ) = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         seed to ZiplineModule(
           url = "$seed.zipline",

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
@@ -28,6 +28,13 @@ import okio.ByteString
  */
 @Serializable
 data class ZiplineManifest private constructor(
+  /**
+   * JS module ID for the application (ie. "./alpha-app.js").
+   * This will usually be the last module in the manifest once it is topologically sorted.
+   */
+  val mainModuleId: String,
+  /** Fully qualified main function to start the application (ie. "zipline.main()"). */
+  val mainFunction: String,
   /** This is an ordered map; its modules are always topologically sorted. */
   val modules: Map<String, ZiplineModule>
 ) {
@@ -38,8 +45,14 @@ data class ZiplineManifest private constructor(
   }
 
   companion object {
-    fun create(modules: Map<String, ZiplineModule>): ZiplineManifest =
-      ZiplineManifest(modules.keys
+    fun create(
+      mainModuleId: String,
+      mainFunction: String,
+      modules: Map<String, ZiplineModule>
+    ): ZiplineManifest = ZiplineManifest(
+      mainModuleId = mainModuleId,
+      mainFunction = mainFunction,
+      modules = modules.keys
         .toList()
         .topologicalSort { id ->
           modules[id]?.dependsOnIds
@@ -49,7 +62,7 @@ data class ZiplineManifest private constructor(
           modules[id]
             ?: throw IllegalArgumentException("Unexpected [id=$id] is not found in modules keys")
         }
-      )
+    )
 
     fun ByteString.decodeToZiplineManifest(
       eventListener: EventListener,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineManifestTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineManifestTest.kt
@@ -28,6 +28,8 @@ class ZiplineManifestTest {
   @Test
   fun manifestSortsModulesOnCreate() {
     val unsorted = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         "bravo" to ZiplineModule(
           url = "/bravo.zipline",
@@ -42,6 +44,8 @@ class ZiplineManifestTest {
       )
     )
     val sorted = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         "alpha" to ZiplineModule(
           url = "/alpha.zipline",
@@ -61,6 +65,8 @@ class ZiplineManifestTest {
   @Test
   fun manifestChecksThatModulesAreSortedIfClassIsCopied() {
     val empty = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf()
     )
     val unsortedException = assertFailsWith<IllegalArgumentException> {
@@ -90,6 +96,8 @@ class ZiplineManifestTest {
   fun failsOnCreateWhenCyclicalDependencies() {
     val selfDependencyException = assertFailsWith<IllegalArgumentException> {
       ZiplineManifest.create(
+        mainModuleId = "./app.js",
+        mainFunction = "zipline.ziplineMain()",
         modules = mapOf(
           "alpha" to ZiplineModule(
             url = "/alpha.zipline",
@@ -106,6 +114,8 @@ class ZiplineManifestTest {
 
     val cyclicalException = assertFailsWith<IllegalArgumentException> {
       ZiplineManifest.create(
+        mainModuleId = "./app.js",
+        mainFunction = "zipline.ziplineMain()",
         modules = mapOf(
           "alpha" to ZiplineModule(
             url = "/alpha.zipline",
@@ -129,6 +139,8 @@ class ZiplineManifestTest {
   @Test
   fun serializesToJson() {
     val original = ZiplineManifest.create(
+      mainModuleId = "./app.js",
+      mainFunction = "zipline.ziplineMain()",
       modules = mapOf(
         "alpha" to ZiplineModule(
           url = "/alpha.zipline",
@@ -147,6 +159,8 @@ class ZiplineManifestTest {
     assertEquals(
         """
         |{
+        |    "mainModuleId": "./app.js",
+        |    "mainFunction": "zipline.ziplineMain()",
         |    "modules": {
         |        "alpha": {
         |            "url": "/alpha.zipline",

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/testFixturesCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/testFixturesCommon.kt
@@ -19,6 +19,8 @@ package app.cash.zipline.loader
 import okio.ByteString.Companion.encodeUtf8
 
 val TEST_MANIFEST_PRODUCTION = ZiplineManifest.create(
+  mainModuleId = "./app.js",
+  mainFunction = "zipline.ziplineMain()",
   modules = mapOf(
     "kotlinx-serialization-json" to ZiplineModule(
       url = "/kotlinx-serialization-kotlinx-serialization-json-js-ir.zipline",


### PR DESCRIPTION
For easier review and more iterative development, I spiked this initial change out of a PR that kept growing and will land it as follow ups instead of blocking this manifest API change further. https://github.com/cashapp/zipline/pull/560