### PR TITLE
Avoid unnecessary encode/decode steps on manifests

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
@@ -27,19 +27,3 @@ interface ZiplineHttpClient {
    */
   fun resolve(baseUrl: String, link: String): String
 }
-
-/**
- * Returns a manifest equivalent to [manifest], but with module URLs resolved against [baseUrl].
- * This way consumers of the manifest don't need to know the URL that the manifest was downloaded
- * from.
- */
-internal fun ZiplineHttpClient.resolveUrls(
-  manifest: ZiplineManifest,
-  baseUrl: String
-): ZiplineManifest {
-  return manifest.copy(
-    modules = manifest.modules.mapValues { (_, module) ->
-      module.copy(url = resolve(baseUrl, module.url))
-    }
-  )
-}

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
@@ -15,11 +15,7 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.EventListener
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import okio.ByteString
 
 /**
  * Preferred construction is via [ZiplineManifest.create]
@@ -71,16 +67,5 @@ data class ZiplineManifest private constructor(
       mainFunction = mainFunction,
       signatures = signatures,
     )
-
-    fun ByteString.decodeToZiplineManifest(
-      eventListener: EventListener,
-      applicationName: String,
-      url: String?,
-    ) = try {
-      Json.decodeFromString<ZiplineManifest>(this.utf8())
-    } catch (e: Exception) {
-      eventListener.manifestParseFailed(applicationName, url, e)
-      throw e
-    }
   }
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/Fetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/Fetcher.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.loader.fetcher
 
-import app.cash.zipline.loader.ZiplineManifest
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import okio.ByteString
@@ -62,7 +61,7 @@ internal interface Fetcher {
    */
   suspend fun pin(
     applicationName: String,
-    manifest: ZiplineManifest,
+    loadedManifest: LoadedManifest,
   )
 
   /**
@@ -72,18 +71,9 @@ internal interface Fetcher {
    */
   suspend fun unpin(
     applicationName: String,
-    manifest: ZiplineManifest,
+    loadedManifest: LoadedManifest,
   )
 }
-
-/**
- * A manifest plus the original bytes we loaded for it. We need the original bytes for signature
- * verification.
- */
-class LoadedManifest(
-  val manifestBytes: ByteString,
-  val manifest: ZiplineManifest,
-)
 
 /**
  * Use a [concurrentDownloadsSemaphore] to control parallelism of fetching operations.
@@ -126,14 +116,14 @@ internal suspend fun List<Fetcher>.fetchManifest(
 
 internal suspend fun List<Fetcher>.pin(
   applicationName: String,
-  manifest: ZiplineManifest,
+  loadedManifest: LoadedManifest,
 ) = this.forEach { fetcher ->
-  fetcher.pin(applicationName, manifest)
+  fetcher.pin(applicationName, loadedManifest)
 }
 
 internal suspend fun List<Fetcher>.unpin(
   applicationName: String,
-  manifest: ZiplineManifest,
+  loadedManifest: LoadedManifest,
 ) = this.forEach { fetcher ->
-  fetcher.unpin(applicationName, manifest)
+  fetcher.unpin(applicationName, loadedManifest)
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/FsCachingFetcher.kt
@@ -16,7 +16,6 @@
 package app.cash.zipline.loader.fetcher
 
 import app.cash.zipline.loader.ZiplineCache
-import app.cash.zipline.loader.ZiplineManifest
 import okio.ByteString
 
 /**
@@ -51,9 +50,9 @@ internal class FsCachingFetcher(
     }
   }
 
-  override suspend fun pin(applicationName: String, manifest: ZiplineManifest) =
-    cache.pinManifest(applicationName, manifest)
+  override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) =
+    cache.pinManifest(applicationName, loadedManifest)
 
-  override suspend fun unpin(applicationName: String, manifest: ZiplineManifest) =
-    cache.unpinManifest(applicationName, manifest)
+  override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) =
+    cache.unpinManifest(applicationName, loadedManifest)
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/FsEmbeddedFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/FsEmbeddedFetcher.kt
@@ -18,7 +18,6 @@ package app.cash.zipline.loader.fetcher
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.ZiplineLoader.Companion.getApplicationManifestFileName
 import app.cash.zipline.loader.ZiplineManifest
-import app.cash.zipline.loader.ZiplineManifest.Companion.decodeToZiplineManifest
 import okio.ByteString
 import okio.FileSystem
 import okio.Path
@@ -45,17 +44,19 @@ internal class FsEmbeddedFetcher(
     val manifestBytes = fetchByteString(
       embeddedDir / getApplicationManifestFileName(applicationName)
     ) ?: return null
-    val manifest = manifestBytes.decodeToZiplineManifest(eventListener, applicationName, url)
-    return LoadedManifest(manifestBytes, manifest)
+    return LoadedManifest(manifestBytes)
   }
 
   override suspend fun pin(
     applicationName: String,
-    manifest: ZiplineManifest
+    loadedManifest: LoadedManifest,
   ) {
   }
 
-  override suspend fun unpin(applicationName: String, manifest: ZiplineManifest) {
+  override suspend fun unpin(
+    applicationName: String,
+    loadedManifest: LoadedManifest,
+  ) {
   }
 
   private fun fetchByteString(filePath: Path) = when {

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/HttpFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/HttpFetcher.kt
@@ -18,9 +18,14 @@ package app.cash.zipline.loader.fetcher
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineManifest
-import app.cash.zipline.loader.ZiplineManifest.Companion.decodeToZiplineManifest
-import app.cash.zipline.loader.resolveUrls
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 
 /**
  * Download resources from the network. If the download fails, the exception is reported to
@@ -43,23 +48,62 @@ internal class HttpFetcher(
     url: String?,
   ): LoadedManifest? {
     if (url == null) return null // This fetcher requires URLs.
-    val manifestBytes = fetchByteString(applicationName, url)
-    val manifestWithRelativeUrls = manifestBytes.decodeToZiplineManifest(
-      eventListener,
-      applicationName,
-      url,
-    )
-    val manifest = httpClient.resolveUrls(manifestWithRelativeUrls, url)
-    return LoadedManifest(manifestBytes, manifest)
+    val manifestBytesWithRelativeUrls = fetchByteString(applicationName, url)
+
+    try {
+      val manifestJsonElementWithRelativeUrls =
+        json.parseToJsonElement(manifestBytesWithRelativeUrls.utf8())
+      val manifestJsonElement = resolveUrls(manifestJsonElementWithRelativeUrls, url)
+      val manifestJson = json.encodeToString(JsonElement.serializer(), manifestJsonElement)
+      return LoadedManifest(
+        manifestBytes = manifestJson.encodeUtf8(),
+        manifest = json.decodeFromJsonElement<ZiplineManifest>(manifestJsonElement)
+      )
+    } catch (e: Exception) {
+      eventListener.manifestParseFailed(applicationName, url, e)
+      throw e
+    }
+  }
+
+  /**
+   * Returns a manifest equivalent to [manifest], but with module URLs resolved against [baseUrl].
+   * This way consumers of the manifest don't need to know the URL that the manifest was downloaded
+   * from.
+   *
+   * This operates on the JSON model and not the decoded model so unknown values are not lost when
+   * the updated JSON is written to disk.
+   */
+  internal fun resolveUrls(manifest: JsonElement, baseUrl: String): JsonElement {
+    val newContent = manifest.jsonObject.toMutableMap()
+
+    val modules = newContent["modules"]
+    if (modules != null) {
+      val newModules = mutableMapOf<String, JsonElement>()
+      for ((key, module) in modules.jsonObject) {
+        val newModule = module.jsonObject.toMutableMap()
+        val url = newModule["url"]
+        if (url != null) {
+          val urlString = url.jsonPrimitive.content
+          newModule["url"] = JsonPrimitive(httpClient.resolve(baseUrl, urlString))
+        }
+        newModules[key] = JsonObject(newModule)
+      }
+      newContent["modules"] = JsonObject(newModules)
+    }
+
+    return JsonObject(newContent)
   }
 
   override suspend fun pin(
     applicationName: String,
-    manifest: ZiplineManifest,
+    loadedManifest: LoadedManifest,
   ) {
   }
 
-  override suspend fun unpin(applicationName: String, manifest: ZiplineManifest) {
+  override suspend fun unpin(
+    applicationName: String,
+    loadedManifest: LoadedManifest,
+  ) {
   }
 
   private suspend fun fetchByteString(

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/LoadedManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/fetcher/LoadedManifest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader.fetcher
+
+import app.cash.zipline.loader.ZiplineManifest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okio.ByteString
+
+/**
+ * A manifest plus the original bytes we loaded for it. We need the original bytes for signature
+ * verification.
+ */
+data class LoadedManifest(
+  val manifestBytes: ByteString,
+  val manifest: ZiplineManifest,
+)
+
+internal val json = Json {
+  ignoreUnknownKeys = true
+}
+
+internal fun LoadedManifest(manifestBytes: ByteString): LoadedManifest {
+  val manifest = json.decodeFromString<ZiplineManifest>(manifestBytes.utf8())
+  return LoadedManifest(manifestBytes, manifest)
+}

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
@@ -46,7 +46,7 @@ class DownloadOnlyFetcherReceiverTest {
       bravoUrl to testFixtures.bravoByteString,
     )
 
-    loader.download("test", downloadDir, fileSystem, testFixtures.manifest)
+    loader.download("test", downloadDir, fileSystem, testFixtures.loadedManifest)
 
     assertTrue(fileSystem.exists(downloadDir / testFixtures.alphaSha256Hex))
     assertEquals(

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/FetcherTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/FetcherTest.kt
@@ -15,8 +15,8 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.loader.fetcher.LoadedManifest
 import app.cash.zipline.loader.fetcher.Fetcher
+import app.cash.zipline.loader.fetcher.LoadedManifest
 import app.cash.zipline.loader.fetcher.fetch
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import kotlin.test.assertEquals
@@ -55,11 +55,11 @@ class FetcherTest {
       error("unexpected call")
     }
 
-    override suspend fun pin(applicationName: String, manifest: ZiplineManifest) {
+    override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) {
       error("unexpected call")
     }
 
-    override suspend fun unpin(applicationName: String, manifest: ZiplineManifest) {
+    override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) {
       error("unexpected call")
     }
   }
@@ -83,11 +83,11 @@ class FetcherTest {
       error("unexpected call")
     }
 
-    override suspend fun pin(applicationName: String, manifest: ZiplineManifest) {
+    override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) {
       error("unexpected call")
     }
 
-    override suspend fun unpin(applicationName: String, manifest: ZiplineManifest) {
+    override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) {
       error("unexpected call")
     }
   }

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/HttpFetcherTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/HttpFetcherTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.loader.fetcher.HttpFetcher
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Test
+
+class HttpFetcherTest {
+  private val httpFetcher = HttpFetcher(FakeZiplineHttpClient())
+  private val json = Json {
+    prettyPrint = true
+  }
+
+  @Test
+  fun happyPath() {
+    val manifestWithRelativeUrls =
+      """
+      |{
+      |    "modules": {
+      |        "./hello.js": {
+      |            "url": "hello.zipline",
+      |            "sha256": "6bd4baa9f46afa62477fec8c9e95528de7539f036d26fc13885177b32fc0d6ab"
+      |        },
+      |        "./jello.js": {
+      |            "url": "jello.zipline",
+      |            "sha256": "7af37185091e22463ff627686aedfec3528376eb745026fae1d6153688885e73"
+      |        }
+      |    }
+      |}
+      """.trimMargin()
+
+    val manifestWithResolvedUrls = httpFetcher.resolveUrls(
+      manifest = json.parseToJsonElement(manifestWithRelativeUrls),
+      baseUrl = "https://example.com/path/",
+    )
+
+    assertEquals(
+      """
+      |{
+      |    "modules": {
+      |        "./hello.js": {
+      |            "url": "https://example.com/path/hello.zipline",
+      |            "sha256": "6bd4baa9f46afa62477fec8c9e95528de7539f036d26fc13885177b32fc0d6ab"
+      |        },
+      |        "./jello.js": {
+      |            "url": "https://example.com/path/jello.zipline",
+      |            "sha256": "7af37185091e22463ff627686aedfec3528376eb745026fae1d6153688885e73"
+      |        }
+      |    }
+      |}
+      """.trimMargin(),
+      json.encodeToString(JsonElement.serializer(), manifestWithResolvedUrls),
+    )
+  }
+
+  @Test
+  fun resolvedUrlsRetainsUnknownFields() {
+    val manifestWithRelativeUrls =
+      """
+      |{
+      |    "unknown string": "hello",
+      |    "modules": {
+      |        "./hello.js": {
+      |            "url": "hello.zipline",
+      |            "sha256": "6bd4baa9f46afa62477fec8c9e95528de7539f036d26fc13885177b32fc0d6ab"
+      |        }
+      |    }
+      |}
+      """.trimMargin()
+
+    val manifestWithResolvedUrls = httpFetcher.resolveUrls(
+      manifest = json.parseToJsonElement(manifestWithRelativeUrls),
+      baseUrl = "https://example.com/path/",
+    )
+
+    assertEquals(
+      """
+      |{
+      |    "unknown string": "hello",
+      |    "modules": {
+      |        "./hello.js": {
+      |            "url": "https://example.com/path/hello.zipline",
+      |            "sha256": "6bd4baa9f46afa62477fec8c9e95528de7539f036d26fc13885177b32fc0d6ab"
+      |        }
+      |    }
+      |}
+      """.trimMargin(),
+      json.encodeToString(JsonElement.serializer(), manifestWithResolvedUrls),
+    )
+  }
+}

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/LoadOrFallbackTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/LoadOrFallbackTest.kt
@@ -111,4 +111,15 @@ class LoadOrFallbackTest {
     })
     assertEquals(-1, tester.prune())
   }
+
+  @Test
+  fun manifestContainsUnknownField() = runBlocking {
+    tester.includeUnknownFieldInJson = true
+    tester.seedEmbedded("red", "firetruck")
+    assertEquals("firetruck", tester.failureManifestFetchFails("red"))
+    assertEquals("firetruck", tester.failureCodeRunFails("red"))
+    assertEquals("firetruck", tester.failureCodeLoadFails("red"))
+    assertEquals("firetruck", tester.success("red", "firetruck"))
+    assertEquals("firetruck", tester.failureCodeFetchFails("red"))
+  }
 }

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -16,12 +16,14 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.fetcher.LoadedManifest
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.alphaUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.bravoUrl
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
+import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path
@@ -126,5 +128,18 @@ class ProductionFetcherReceiverTest {
       "fake".encodeUtf8()
     }
     assertEquals(testFixtures.alphaByteString, ziplineFileFromCache)
+  }
+
+  private suspend fun ZiplineLoader.loadOrFail(
+    applicationName: String,
+    manifest: ZiplineManifest,
+    initializer: (Zipline) -> Unit = {},
+  ): Zipline {
+    return createZiplineAndLoad(
+      applicationName = applicationName,
+      manifestUrl = null,
+      loadedManifest = LoadedManifest(ByteString.EMPTY, manifest),
+      initializer = initializer,
+    )
   }
 }

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineCacheTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/ZiplineCacheTest.kt
@@ -27,7 +27,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -217,7 +216,7 @@ class ZiplineCacheTest {
       it.write("red", fileApple.sha256(), fileApple)
       val manifestApple = createRelativeManifest("apple", fileApple.sha256())
       it.pinManifest("red", manifestApple)
-      assertEquals(manifestApple, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestApple, it.getPinnedManifest("red"))
       assertEquals(2, it.countFiles())
       assertEquals(2, it.countPins())
 
@@ -228,7 +227,7 @@ class ZiplineCacheTest {
       assertEquals(3, it.countPins())
 
       it.pinManifest("red", manifestFiretruck)
-      assertEquals(manifestFiretruck, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestFiretruck, it.getPinnedManifest("red"))
       assertEquals(4, it.countFiles()) // apple manifest remains in cache until prune.
       assertEquals(2, it.countPins())
     }
@@ -245,7 +244,7 @@ class ZiplineCacheTest {
       it.write("red", fileApple.sha256(), fileApple)
       val manifestApple = createRelativeManifest("apple", fileApple.sha256())
       it.pinManifest("red", manifestApple)
-      assertEquals(manifestApple, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestApple, it.getPinnedManifest("red"))
       assertEquals(2, it.countFiles())
       assertEquals(2, it.countPins())
 
@@ -256,7 +255,7 @@ class ZiplineCacheTest {
       assertEquals(3, it.countPins())
 
       it.unpinManifest("red", manifestFiretruck)
-      assertEquals(manifestApple, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestApple, it.getPinnedManifest("red"))
       assertEquals(3, it.countFiles()) // firetruck manifest isn't saved to file cache.
       assertEquals(2, it.countPins())
     }
@@ -274,16 +273,17 @@ class ZiplineCacheTest {
       it.write("red", fileFiretruck.sha256(), fileFiretruck)
       val manifestFiretruck = createRelativeManifest("firetruck", fileFiretruck.sha256())
 
-      assertEquals(manifestApple, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestApple, it.getPinnedManifest("red"))
       assertEquals(3, it.countPins())
 
-      val manifestFiretruckByteString = Json
-        .encodeToString(ZiplineManifest.serializer(), manifestFiretruck)
-        .encodeUtf8()
-      it.writeManifest("red", manifestFiretruckByteString.sha256(), manifestFiretruckByteString)
+      it.writeManifest(
+        "red",
+        manifestFiretruck.manifestBytes.sha256(),
+        manifestFiretruck.manifestBytes
+      )
       assertEquals(4, it.countPins())
 
-      assertEquals(manifestFiretruck, it.getPinnedManifest("red")?.manifest)
+      assertEquals(manifestFiretruck, it.getPinnedManifest("red"))
     }
   }
 


### PR DESCRIPTION
When we roundtrip a JSON-encoded manifest through the ZiplineManifest
model class, we lose all unknown fields. This is potentially hazardous
when combining disk caching with forwards-compatibility.

Avoid this by avoiding roundtripping through the model class completely.
The only difficulty this introduces is relative-to-absolute URL mapping
needs to happen in the JSON object model and not the data class. This is
clumsier but tolerable.

This also introduces tests to confirm that unknown fields are retained.

Note that this drops EventListener callbacks when the manifest encounters
a parse failure when sourced from the cache or embedded file system. This
was untested previously and is not a critical behavior.