### PR TITLE
Use target mode as task dependency discriminator

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -80,7 +80,9 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
     }
 
     project.tasks.withType(KotlinWebpack::class.java).configureEach { kotlinWebpack ->
-      kotlinWebpack.dependsOn(compileZiplineTaskName)
+      if (kotlinBinary.mode.toString().equals(kotlinWebpack.mode.toString(), ignoreCase = true)) {
+        kotlinWebpack.dependsOn(compileZiplineTaskName)
+      }
     }
   }
 


### PR DESCRIPTION
Checks the Kotlin executable target mode against the webpack target mode, and only adds the Zipline compile task as a task dependancy if they both match. This prevents the issue where running development webpack causes both compile Zipline production and compile Kotlin production to run. 

This approach is slightly fragile as it depends on both modes having the same name, but that's pretty unlikely to change.