### PR TITLE
Change internal service names to be more useful

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/platform.kt
@@ -18,7 +18,7 @@ package app.cash.zipline.internal
 import app.cash.zipline.ZiplineService
 
 const val ziplineInternalPrefix = "zipline/"
-internal const val passByReferencePrefix = "service/"
+internal expect val passByReferencePrefix: String
 internal const val eventLoopName = "${ziplineInternalPrefix}event_loop"
 internal const val consoleName = "${ziplineInternalPrefix}console"
 internal const val eventListenerName = "${ziplineInternalPrefix}event_listener"

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/platformEngine.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/platformEngine.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+internal actual val passByReferencePrefix = "zipline/host-"

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -172,10 +172,10 @@ internal class EndpointTest {
     val echoService = object : SuspendingEchoService {
       override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
         // In the middle of a suspending call there's a temporary reference to the callback.
-        assertEquals(setOf("echoService", "service/1"), endpointA.serviceNames)
-        assertEquals(setOf("echoService", "service/1"), endpointB.clientNames)
-        assertEquals(setOf("service/1"), endpointA.clientNames)
-        assertEquals(setOf("service/1"), endpointB.serviceNames)
+        assertEquals(setOf("echoService", "zipline/host-1"), endpointA.serviceNames)
+        assertEquals(setOf("echoService", "zipline/host-1"), endpointB.clientNames)
+        assertEquals(setOf("zipline/host-1"), endpointA.clientNames)
+        assertEquals(setOf("zipline/host-1"), endpointB.serviceNames)
         return EchoResponse("hello, ${request.message}")
       }
     }

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -174,7 +174,7 @@ internal class EventListenerEndpointTest {
       |{
       |  "service": "echoService",
       |  "function": "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-      |  "callback": "service/1",
+      |  "callback": "zipline/host-1",
       |  "args": [
       |    {
       |      "message": "ping"
@@ -184,7 +184,7 @@ internal class EventListenerEndpointTest {
       """.trimMargin(),
       prettyPrint(clientCall.encodedCall),
     )
-    assertEquals(listOf("service/1"), clientCall.serviceNames) // This is the callback.
+    assertEquals(listOf("zipline/host-1"), clientCall.serviceNames) // This is the callback.
 
     val serviceCall = serviceListener.calls.removeFirst()
     assertEquals("echoService", serviceCall.serviceName)
@@ -199,7 +199,7 @@ internal class EventListenerEndpointTest {
       |{
       |  "service": "echoService",
       |  "function": "suspend fun suspendingEcho(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
-      |  "callback": "service/1",
+      |  "callback": "zipline/host-1",
       |  "args": [
       |    {
       |      "message": "ping"
@@ -209,14 +209,14 @@ internal class EventListenerEndpointTest {
       """.trimMargin(),
       prettyPrint(serviceCall.encodedCall),
     )
-    assertEquals(listOf("service/1"), serviceCall.serviceNames)
+    assertEquals(listOf("zipline/host-1"), serviceCall.serviceNames)
 
     val clientResult = clientListener.results.removeFirst()
     assertEquals(EchoResponse("pong"), clientResult.result.getOrNull())
     assertEquals(
       """
       |{
-      |  "service": "service/1",
+      |  "service": "zipline/host-1",
       |  "function": "fun success(T): kotlin.Unit",
       |  "args": [
       |    {
@@ -234,7 +234,7 @@ internal class EventListenerEndpointTest {
     assertEquals(
       """
       |{
-      |  "service": "service/1",
+      |  "service": "zipline/host-1",
       |  "function": "fun success(T): kotlin.Unit",
       |  "args": [
       |    {
@@ -294,13 +294,13 @@ internal class EventListenerEndpointTest {
       |  "function": "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
       |  "args": [
       |    "hello",
-      |    "service/1"
+      |    "zipline/host-1"
       |  ]
       |}
       """.trimMargin(),
       prettyPrint(clientCall.encodedCall),
     )
-    assertEquals(listOf("service/1"), clientCall.serviceNames) // This is the callback.
+    assertEquals(listOf("zipline/host-1"), clientCall.serviceNames) // This is the callback.
 
     val serviceCall = serviceListener.calls.removeFirst()
     assertEquals("echoTransformer", serviceCall.serviceName)
@@ -319,25 +319,25 @@ internal class EventListenerEndpointTest {
       |  "function": "fun transform(kotlin.String, app.cash.zipline.testing.EchoService): app.cash.zipline.testing.EchoService",
       |  "args": [
       |    "hello",
-      |    "service/1"
+      |    "zipline/host-1"
       |  ]
       |}
       """.trimMargin(),
       prettyPrint(serviceCall.encodedCall),
     )
-    assertEquals(listOf("service/1"), serviceCall.serviceNames)
+    assertEquals(listOf("zipline/host-1"), serviceCall.serviceNames)
 
     val clientResult = clientListener.results.removeFirst()
     assertEquals(transformedService, clientResult.result.getOrNull()) // This is a stub.
     assertEquals(
       """
       |{
-      |  "success": "service/1"
+      |  "success": "zipline/host-1"
       |}
       """.trimMargin(),
       prettyPrint(clientResult.encodedResult),
     )
-    assertEquals(listOf("service/1"), clientResult.serviceNames)
+    assertEquals(listOf("zipline/host-1"), clientResult.serviceNames)
 
     val serviceResult = serviceListener.results.removeFirst()
     assertTrue(serviceResult.result.getOrNull() is EchoService)
@@ -345,12 +345,12 @@ internal class EventListenerEndpointTest {
     assertEquals(
       """
       |{
-      |  "success": "service/1"
+      |  "success": "zipline/host-1"
       |}
       """.trimMargin(),
       prettyPrint(serviceResult.encodedResult),
     )
-    assertEquals(listOf("service/1"), serviceResult.serviceNames)
+    assertEquals(listOf("zipline/host-1"), serviceResult.serviceNames)
   }
 
   private fun prettyPrint(jsonString: String): String {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -118,7 +118,7 @@ internal class ZiplineServiceTest {
     assertEquals(setOf("factory"), endpointA.serviceNames)
 
     val helloService = factoryClient.create("hello")
-    assertEquals(setOf("factory", "service/1"), endpointA.serviceNames)
+    assertEquals(setOf("factory", "zipline/host-1"), endpointA.serviceNames)
 
     assertEquals(EchoResponse("hello Jesse"), helloService.echo(EchoRequest("Jesse")))
     helloService.close()

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/internal/platformJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/internal/platformJs.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal
+
+internal actual val passByReferencePrefix = "zipline/js-"


### PR DESCRIPTION
We need anonymous names for services passed-by-reference and callbacks.
Previously the prefix was like service/1, without separate namespaces
for JS-inbound services and host-inbound services.

The new prefixes are zipline/host-1 for host-inbound services and
zipline/js-1 for JS-inbound services.