### PR TITLE
Promote some loader tests to commonTest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ sqldelight-driver-native = { module = "com.squareup.sqldelight:native-driver", v
 sqldelight-driver-sqlite = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqldelight" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version = "3.34.0" }
-turbine = { module = "app.cash.turbine:turbine", version = "0.6.0" }
+turbine = { module = "app.cash.turbine:turbine", version = "0.8.0" }
 truth = { module = "com.google.truth:truth", version = "1.0" }
 
 [plugins]

--- a/zipline-loader/build.gradle.kts
+++ b/zipline-loader/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -135,16 +136,9 @@ android {
       manifest.srcFile("src/androidMain/AndroidManifest.xml")
     }
     getByName("androidTest") {
-      java.srcDirs("src/jniTest/kotlin/")
+      java.srcDirs("src/androidTest/kotlin/")
     }
   }
-}
-
-dependencies {
-  androidTestImplementation(libs.androidx.test.runner)
-  androidTestImplementation(libs.junit)
-  androidTestImplementation(libs.kotlinx.coroutines.test)
-  androidTestImplementation(libs.okio.fakeFileSystem)
 }
 
 sqldelight {
@@ -176,6 +170,10 @@ val fetchWycheproofJson by tasks.creating(Download::class) {
 
 tasks.withType<Test> {
   dependsOn(fetchWycheproofJson)
+}
+
+tasks.withType<AndroidUnitTest> {
+  enabled = false
 }
 
 configure<MavenPublishBaseExtension> {

--- a/zipline-loader/build.gradle.kts
+++ b/zipline-loader/build.gradle.kts
@@ -81,6 +81,9 @@ kotlin {
       dependencies {
         implementation(kotlin("test"))
         implementation(projects.ziplineLoaderTesting)
+        implementation(projects.zipline.testing)
+        implementation(libs.kotlinx.coroutines.test)
+        implementation(libs.turbine)
       }
     }
     val engineTest by creating {
@@ -93,17 +96,14 @@ kotlin {
       dependsOn(engineTest)
       dependencies {
         implementation(libs.junit)
-        implementation(libs.kotlinx.coroutines.test)
         implementation(libs.okio.fakeFileSystem)
         implementation(libs.sqldelight.driver.sqlite)
         implementation(libs.sqlite.jdbc)
-        implementation(libs.turbine)
       }
     }
     val jvmTest by getting {
       dependsOn(jniTest)
       dependencies {
-        implementation(projects.zipline.testing)
         implementation(projects.ziplineLoaderTesting)
       }
     }

--- a/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
+++ b/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.EventListener
+import kotlinx.coroutines.CoroutineDispatcher
+import okio.FileSystem
+
+// This file is necessary to get Android tests to build.
+//
+// Note that we don't run Android tests because we don't have the right QuickJS or SQLite to run
+// them on the JVM.
+
+actual val systemFileSystem = FileSystem.SYSTEM
+
+actual fun testZiplineLoader(
+  dispatcher: CoroutineDispatcher,
+  httpClient: ZiplineHttpClient,
+  eventListener: EventListener,
+  manifestVerifier: ManifestVerifier?,
+): ZiplineLoader = error("testZiplineLoader not available for Android")

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
@@ -18,26 +18,27 @@ package app.cash.zipline.loader
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.alphaUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.bravoUrl
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import okio.Path.Companion.toPath
-import okio.fakefilesystem.FakeFileSystem
-import org.junit.Test
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import okio.FileSystem
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DownloadOnlyFetcherReceiverTest {
   private val testFixtures = LoaderTestFixtures()
 
-  private val dispatcher = TestCoroutineDispatcher()
+  private val dispatcher = UnconfinedTestDispatcher()
   private val httpClient = FakeZiplineHttpClient()
-  private val loader = ZiplineLoader(
+  private val loader = testZiplineLoader(
     dispatcher = dispatcher,
     httpClient = httpClient,
   )
 
-  private val fileSystem = FakeFileSystem()
-  private val downloadDir = "/zipline/downloads".toPath()
+  private val fileSystem = systemFileSystem
+  private val downloadDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "okio-${randomToken().hex()}"
 
   @Test
   fun getFileFromNetworkSaveToFs() = runBlocking {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoadOrFallbackTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoadOrFallbackTest.kt
@@ -15,17 +15,27 @@
  */
 package app.cash.zipline.loader
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
-import org.junit.Test
 
 @Suppress("UnstableApiUsage")
 @ExperimentalCoroutinesApi
 class LoadOrFallbackTest {
-  @JvmField @Rule
-  val tester = LoaderTester()
+  private val tester = LoaderTester()
+
+  @BeforeTest
+  fun setUp() {
+    tester.beforeTest()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    tester.afterTest()
+  }
 
   @Test
   fun preferNetworkWhenThatWorks() = runBlocking {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
@@ -16,19 +16,30 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.testing.LoggingEventListener
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
-import org.junit.Test
+import okio.IOException
 
 @Suppress("UnstableApiUsage")
 @ExperimentalCoroutinesApi
 class LoaderEventsTest {
   private val eventListener = LoggingEventListener()
 
-  @JvmField @Rule
-  val tester = LoaderTester(eventListener)
+  private val tester = LoaderTester(eventListener)
+
+  @BeforeTest
+  fun setUp() {
+    tester.beforeTest()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    tester.afterTest()
+  }
 
   @Test
   fun happyPathEvents() = runBlocking {
@@ -73,9 +84,9 @@ class LoaderEventsTest {
         "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadFailed red https://example.com/files/red/red.manifest.zipline.json " +
-          "java.io.IOException: 404: https://example.com/files/red/red.manifest.zipline.json not found",
+          "${IOException::class.qualifiedName}: 404: https://example.com/files/red/red.manifest.zipline.json not found",
         "applicationLoadFailed red " +
-          "java.io.IOException: 404: https://example.com/files/red/red.manifest.zipline.json not found",
+          "${IOException::class.qualifiedName}: 404: https://example.com/files/red/red.manifest.zipline.json not found",
         "applicationLoadStart red null",
         "applicationLoadEnd red null",
       ),
@@ -94,9 +105,9 @@ class LoaderEventsTest {
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/unreachable.zipline",
         "downloadFailed red https://example.com/files/red/unreachable.zipline " +
-          "java.io.IOException: 404: https://example.com/files/red/unreachable.zipline not found",
+          "${IOException::class.qualifiedName}: 404: https://example.com/files/red/unreachable.zipline not found",
         "applicationLoadFailed red " +
-          "java.io.IOException: 404: https://example.com/files/red/unreachable.zipline not found",
+          "${IOException::class.qualifiedName}: 404: https://example.com/files/red/unreachable.zipline not found",
         "applicationLoadStart red null",
         "applicationLoadEnd red null",
       ),
@@ -134,7 +145,7 @@ class LoaderEventsTest {
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/crashes.zipline",
         "downloadEnd red https://example.com/files/red/crashes.zipline",
-        "applicationLoadFailed red java.lang.IllegalArgumentException: Zipline code run failed",
+        "applicationLoadFailed red ${IllegalArgumentException::class.qualifiedName}: Zipline code run failed",
         "applicationLoadStart red null",
         "applicationLoadEnd red null",
       ),

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -16,11 +16,14 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.Zipline
-import app.cash.zipline.loader.internal.fetcher.LoadedManifest
 import app.cash.zipline.loader.internal.cache.ZiplineCache
+import app.cash.zipline.loader.internal.fetcher.LoadedManifest
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.alphaUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.bravoUrl
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
@@ -28,14 +31,9 @@ import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path
-import org.junit.After
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
 
 class ProductionFetcherReceiverTest {
-  @JvmField @Rule
-  val tester = LoaderTester()
+  private val tester = LoaderTester()
 
   private lateinit var loader: ZiplineLoader
   private lateinit var cache: ZiplineCache
@@ -45,16 +43,18 @@ class ProductionFetcherReceiverTest {
 
   private lateinit var zipline: Zipline
 
-  @Before
+  @BeforeTest
   fun setUp() {
+    tester.beforeTest()
     loader = tester.loader
     cache = tester.cache
     embeddedFileSystem = tester.embeddedFileSystem
     embeddedDir = tester.embeddedDir
   }
 
-  @After
+  @AfterTest
   fun tearDown() {
+    tester.afterTest()
     loader.close()
   }
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
@@ -20,6 +20,9 @@ import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.alphaUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.bravoUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.manifestUrl
 import app.cash.zipline.loader.testing.SampleKeys
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,8 +30,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.encodeUtf8
-import org.junit.Rule
-import org.junit.Test
 
 /**
  * This test just confirms we actually use the [ManifestVerifier] when it is configured. It assumes
@@ -37,14 +38,23 @@ import org.junit.Test
 @Suppress("UnstableApiUsage")
 @ExperimentalCoroutinesApi
 class ZiplineLoaderSigningTest {
-  @JvmField @Rule
-  val tester = LoaderTester(
+  private val tester = LoaderTester(
     manifestVerifier = ManifestVerifier.Builder()
       .addEd25519("key1", SampleKeys.key1Public)
       .build()
   )
 
   private val testFixtures = LoaderTestFixtures()
+
+  @BeforeTest
+  fun setUp() {
+    tester.beforeTest()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    tester.afterTest()
+  }
 
   @Test
   fun signatureVerifiesAndChecksumsMatch(): Unit = runBlocking {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.EventListener
+import kotlin.random.Random
+import kotlinx.coroutines.CoroutineDispatcher
+import okio.ByteString.Companion.toByteString
+import okio.FileSystem
+
+expect val systemFileSystem: FileSystem
+
+expect fun testZiplineLoader(
+  dispatcher: CoroutineDispatcher,
+  httpClient: ZiplineHttpClient,
+  eventListener: EventListener = EventListener.NONE,
+  manifestVerifier: ManifestVerifier? = null,
+): ZiplineLoader
+
+fun randomToken() = Random.nextBytes(8).toByteString()

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.EventListener
+import kotlinx.coroutines.CoroutineDispatcher
+import okio.FileSystem
+
+actual val systemFileSystem = FileSystem.SYSTEM
+
+actual fun testZiplineLoader(
+  dispatcher: CoroutineDispatcher,
+  httpClient: ZiplineHttpClient,
+  eventListener: EventListener,
+  manifestVerifier: ManifestVerifier?,
+) = ZiplineLoader(
+  dispatcher = dispatcher,
+  httpClient = httpClient,
+  eventListener = eventListener,
+  manifestVerifier = manifestVerifier,
+)

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.EventListener
+import kotlinx.coroutines.CoroutineDispatcher
+import okio.FileSystem
+
+actual val systemFileSystem = FileSystem.SYSTEM
+
+actual fun testZiplineLoader(
+  dispatcher: CoroutineDispatcher,
+  httpClient: ZiplineHttpClient,
+  eventListener: EventListener,
+  manifestVerifier: ManifestVerifier?,
+) = ZiplineLoader(
+  dispatcher = dispatcher,
+  httpClient = httpClient,
+  eventListener = eventListener,
+  manifestVerifier = manifestVerifier,
+)


### PR DESCRIPTION
Unfortunately there's a bug where Okio's FakeFileSystem doesn't
work on Kotlin 1.7.0 on native due to a transitive dependency on
kotlinx-datetime.

https://youtrack.jetbrains.com/issue/KT-52554

I'm going to need to update Okio and ship a release. In the interim
just use the regular file system for these tests.