### PR TITLE
Switch to the embedded Kotlin compiler API

### DIFF
--- a/zipline-kotlin-plugin/build.gradle.kts
+++ b/zipline-kotlin-plugin/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -9,11 +8,11 @@ plugins {
   id("com.github.gmazzo.buildconfig")
   id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base")
-  id("com.github.johnrengelman.shadow")
 }
 
 dependencies {
-  compileOnly(kotlin("compiler"))
+  compileOnly(kotlin("compiler-embeddable"))
+  compileOnly(kotlin("stdlib"))
 
   kapt("com.google.auto.service:auto-service:1.0")
   compileOnly("com.google.auto.service:auto-service-annotations:1.0")
@@ -22,23 +21,6 @@ dependencies {
 buildConfig {
   packageName("app.cash.zipline.kotlin")
   buildConfigField("String", "KOTLIN_PLUGIN_ID", "\"${libs.plugins.zipline.kotlin.get()}\"")
-}
-
-val shadowJar = tasks.named("shadowJar", ShadowJar::class.java)
-shadowJar.configure {
-  relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
-}
-
-configurations {
-  // replace the standard jar with the one built by 'shadowJar' in both api and runtime variants
-  apiElements.get().outgoing.apply {
-    artifacts.clear()
-    artifact(shadowJar.flatMap { it.archiveFile })
-  }
-  runtimeElements.get().outgoing.apply {
-    artifacts.clear()
-    artifact(shadowJar.flatMap { it.archiveFile })
-  }
 }
 
 configure<MavenPublishBaseExtension> {

--- a/zipline-kotlin-plugin/gradle.properties
+++ b/zipline-kotlin-plugin/gradle.properties
@@ -1,2 +1,2 @@
-# We get the stdlib transitively as a compileOnly dependency.
+# We want the stdlib as a compileOnly dependency.
 kotlin.stdlib.default.dependency=false

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineComponentRegistrar.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineComponentRegistrar.kt
@@ -16,10 +16,10 @@
 package app.cash.zipline.kotlin
 
 import com.google.auto.service.AutoService
-import com.intellij.mock.MockProject
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 


### PR DESCRIPTION
This removes the need to use the shaodw plugin to relocate our bytecode to match.

Mostly just cribbing on #593.