### PR TITLE
Change how throwables are serialized

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/CallChannel.kt
@@ -16,11 +16,6 @@
 package app.cash.zipline.internal.bridge
 
 import kotlin.js.JsName
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
 internal const val inboundChannelName = "app_cash_zipline_inboundChannel"
 internal const val outboundChannelName = "app_cash_zipline_outboundChannel"
@@ -46,16 +41,4 @@ internal interface CallChannel {
    */
   @JsName("disconnect")
   fun disconnect(instanceName: String): Boolean
-}
-
-internal object ThrowableSerializer : KSerializer<Throwable> {
-  override val descriptor = PrimitiveSerialDescriptor("ZiplineThrowable", PrimitiveKind.STRING)
-
-  override fun serialize(encoder: Encoder, value: Throwable) {
-    encoder.encodeString(toOutboundString(value))
-  }
-
-  override fun deserialize(decoder: Decoder): Throwable {
-    return toInboundThrowable(decoder.decodeString())
-  }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
@@ -15,6 +15,93 @@
  */
 package app.cash.zipline.internal.bridge
 
-internal expect fun toOutboundString(throwable: Throwable): String
+import app.cash.zipline.ZiplineApiMismatchException
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-internal expect fun toInboundThrowable(string: String): Throwable
+internal expect fun stacktraceString(throwable: Throwable): String
+
+internal expect fun toInboundThrowable(
+  stacktraceString: String,
+  constructor: (String) -> Throwable,
+): Throwable
+
+/**
+ * Serialize a [Throwable] in two parts:
+ *
+ *  * A list of types in preference-order. We'll only need one type in almost all cases, but if we
+ *    want to introduce new throwable subtypes in the future this enables backwards=compatibility.
+ *
+ *  * The throwable message and stacktrace, all together. This may be prefixed with the name
+ *    of the throwable class.
+ */
+@Serializable
+internal class ThrowableSurrogate(
+  /**
+   * A list of types in preference order to decode this throwable into. If a type is unrecognized
+   * it should be skipped, ultimately falling back to [Exception] if no types are recognized.
+   */
+  val types: List<String>,
+
+  /**
+   * The result of [Throwable.stackTraceToString], potentially with code from Zipline's bridges
+   * stripped.
+   */
+  val stacktraceString: String,
+)
+
+internal object ThrowableSerializer : KSerializer<Throwable> {
+  private val surrogateSerializer = ThrowableSurrogate.serializer()
+  override val descriptor = surrogateSerializer.descriptor
+
+  override fun serialize(encoder: Encoder, value: Throwable) {
+    val stacktraceString = stacktraceString(value)
+    val typeNames = knownTypeNames(value)
+
+    encoder.encodeSerializableValue(
+      surrogateSerializer,
+      ThrowableSurrogate(
+        types = typeNames,
+        stacktraceString = stacktraceString,
+      ),
+    )
+  }
+
+  override fun deserialize(decoder: Decoder): Throwable {
+    val surrogate = decoder.decodeSerializableValue(surrogateSerializer)
+
+    // Find a throwable type to decode as.
+    val typeNameToConstructor: Pair<String, (String) -> Throwable> =
+      surrogate.types.firstNotNullOfOrNull { typeName ->
+        val constructor = knownTypeConstructor(typeName) ?: return@firstNotNullOfOrNull null
+        typeName to constructor
+      } ?: ("Exception" to ::Exception)
+    val (typeName, constructor) = typeNameToConstructor
+
+    // Strip off "ZiplineApiMismatchException: " prefix (or similar) so it isn't repeated.
+    var stacktraceString = surrogate.stacktraceString
+    if (stacktraceString.startsWith(typeName) &&
+      stacktraceString.regionMatches(typeName.length, ": ", 0, 2)
+    ) {
+      stacktraceString = stacktraceString.substring(typeName.length + 2)
+    }
+
+    return toInboundThrowable(stacktraceString, constructor)
+  }
+
+  private fun knownTypeNames(throwable: Throwable): List<String> {
+    return when (throwable) {
+      is ZiplineApiMismatchException -> listOf("ZiplineApiMismatchException")
+      else -> listOf()
+    }
+  }
+
+  private fun knownTypeConstructor(typeName: String): ((String) -> Throwable)? {
+    return when (typeName) {
+      "ZiplineApiMismatchException" -> ::ZiplineApiMismatchException
+      else -> null
+    }
+  }
+}

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
@@ -127,10 +127,10 @@ class EventListenerTest {
   @Test fun jvmCallIncompatibleJsService() = runBlocking {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareJsBridges()")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
-      ZiplineApiMismatchException: no such method (incompatible API versions?)
+      no such method (incompatible API versions?)
       	called function:
       		fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -144,16 +144,16 @@ class EventListenerTest {
     val request = "[]"
     assertThat(eventListener.take()).isEqualTo("takeService $name")
     assertThat(eventListener.take()).isEqualTo("callStart 1 $name $funName $request")
-    assertThat(eventListener.take()).startsWith("callEnd 1 $name $funName $request Failure(java.lang.Exception: ZiplineApiMismatchException: no such method")
+    assertThat(eventListener.take()).startsWith("callEnd 1 $name $funName $request Failure(app.cash.zipline.ZiplineApiMismatchException: no such method")
   }
 
   @Test fun jvmCallUnknownJsService() = runBlocking {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.initZipline()")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       zipline.take<EchoService>("helloService").echo(EchoRequest("hello"))
     }).hasMessageThat().startsWith("""
-        ZiplineApiMismatchException: no such service (service closed?)
+        no such service (service closed?)
         	called service:
         		helloService
         	available services:
@@ -165,7 +165,7 @@ class EventListenerTest {
     val request = "[EchoRequest(message=hello)]"
     assertThat(eventListener.take()).isEqualTo("takeService $name")
     assertThat(eventListener.take()).isEqualTo("callStart 1 $name $funName $request")
-    assertThat(eventListener.take()).startsWith("callEnd 1 $name $funName $request Failure(java.lang.Exception: ZiplineApiMismatchException: no such service")
+    assertThat(eventListener.take()).startsWith("callEnd 1 $name $funName $request Failure(app.cash.zipline.ZiplineApiMismatchException: no such service")
   }
 
   @Test fun jsCallIncompatibleJvmService() = runBlocking {

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ThrowableSerializerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ThrowableSerializerTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.internal.bridge.ThrowableSerializer
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import org.junit.Test
+
+class ThrowableSerializerTest {
+  private val json = Json {
+    prettyPrint = true
+    serializersModule = SerializersModule {
+      contextual(Throwable::class, ThrowableSerializer)
+    }
+  }
+
+  @Test fun happyPath() {
+    val exception = Exception("boom")
+    exception.stackTrace = arrayOf(
+      StackTraceElement("ThrowableSerializerTest", "goBoom", "test.kt", 5)
+    )
+
+    val exceptionJson = """
+      |{
+      |    "types": [
+      |    ],
+      |    "stacktraceString": "java.lang.Exception: boom\n\tat ThrowableSerializerTest.goBoom(test.kt:5)"
+      |}
+      """.trimMargin()
+
+    assertEquals(
+      exceptionJson,
+      json.encodeToString(ThrowableSerializer, exception),
+    )
+
+    val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
+    assertEquals(Exception::class, decoded::class)
+    assertEquals(
+      """
+      |java.lang.Exception: boom
+      |${'\t'}at ThrowableSerializerTest.goBoom(test.kt:5)
+      """.trimMargin(),
+      decoded.message
+    )
+  }
+
+  @Test fun unrecognizedExceptionTypeDecodesAsException() {
+    val exceptionJson = """
+      |{
+      |    "types": [
+      |        "SomeFutureException",
+      |        "AnotherFutureException"
+      |    ],
+      |    "stacktraceString": "java.lang.Exception: boom"
+      |}
+      """.trimMargin()
+
+    val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
+    assertEquals(Exception::class, decoded::class)
+  }
+
+  @Test fun ziplineApiMismatchExceptionStripsPrefix() {
+    val exceptionJson = """
+      |{
+      |    "types": [
+      |        "ZiplineApiMismatchException"
+      |    ],
+      |    "stacktraceString": "ZiplineApiMismatchException: boom"
+      |}
+      """.trimMargin()
+
+    val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
+    assertEquals(ZiplineApiMismatchException::class, decoded::class)
+    assertEquals("boom", decoded.message)
+  }
+
+  @Test fun ziplineApiMismatchExceptionUnknownSubtypeDoesNotStripPrefix() {
+    val exceptionJson = """
+      |{
+      |    "types": [
+      |        "SomeFutureException",
+      |        "ZiplineApiMismatchException"
+      |    ],
+      |    "stacktraceString": "SomeFutureException: boom"
+      |}
+      """.trimMargin()
+
+    val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
+    assertEquals(ZiplineApiMismatchException::class, decoded::class)
+    assertEquals("SomeFutureException: boom", decoded.message)
+  }
+}

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -216,7 +216,7 @@ class ZiplineTest {
     assertThat(assertFailsWith<Exception> {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
-      ZiplineApiMismatchException: no such method (incompatible API versions?)
+      no such method (incompatible API versions?)
       	called function:
       		fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -233,7 +233,7 @@ class ZiplineTest {
     assertThat(assertFailsWith<Exception> {
       zipline.take<SuspendingPotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
-      ZiplineApiMismatchException: no such method (incompatible API versions?)
+      no such method (incompatible API versions?)
       	called function:
       		suspend fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -269,7 +269,7 @@ class ZiplineTest {
 
     assertThat(zipline.quickJs.evaluate("testing.app.cash.zipline.testing.suspendingPotatoException") as String?)
       .startsWith("""
-        Exception: app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
+        ZiplineApiMismatchException: app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
         	called function:
         		suspend fun echo(): app.cash.zipline.testing.EchoResponse
         	available functions:
@@ -287,7 +287,7 @@ class ZiplineTest {
     assertThat(assertFailsWith<Exception> {
       noSuchService.echo(EchoRequest("hello"))
     }).hasMessageThat().startsWith("""
-      ZiplineApiMismatchException: no such service (service closed?)
+      no such service (service closed?)
       	called service:
       		noSuchService
       	available services:
@@ -303,7 +303,7 @@ class ZiplineTest {
     assertThat(assertFailsWith<Exception> {
       noSuchService.suspendingEcho(EchoRequest("hello"))
     }).hasMessageThat().startsWith("""
-      ZiplineApiMismatchException: no such service (service closed?)
+      no such service (service closed?)
       	called service:
       		noSuchService
       	available services:
@@ -334,7 +334,7 @@ class ZiplineTest {
 
     assertThat(zipline.quickJs.evaluate("testing.app.cash.zipline.testing.suspendingPotatoException") as String?)
       .startsWith("""
-        Exception: app.cash.zipline.ZiplineApiMismatchException: no such service (service closed?)
+        ZiplineApiMismatchException: app.cash.zipline.ZiplineApiMismatchException: no such service (service closed?)
         	called service:
         		jvmSuspendingPotatoService
         	available services:

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/throwablesJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/throwablesJs.kt
@@ -15,6 +15,9 @@
  */
 package app.cash.zipline.internal.bridge
 
-internal actual fun toOutboundString(throwable: Throwable): String = throwable.stackTraceToString()
+internal actual fun stacktraceString(throwable: Throwable): String = throwable.stackTraceToString()
 
-internal actual fun toInboundThrowable(string: String): Throwable = Exception(string)
+internal actual fun toInboundThrowable(
+  stacktraceString: String,
+  constructor: (String) -> Throwable,
+): Throwable = constructor(stacktraceString)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/throwablesNative.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/throwablesNative.kt
@@ -15,6 +15,9 @@
  */
 package app.cash.zipline.internal.bridge
 
-internal actual fun toOutboundString(throwable: Throwable): String = throwable.stackTraceToString()
+internal actual fun stacktraceString(throwable: Throwable): String = throwable.stackTraceToString()
 
-internal actual fun toInboundThrowable(string: String): Throwable = Exception(string)
+internal actual fun toInboundThrowable(
+  stacktraceString: String,
+  constructor: (String) -> Throwable,
+): Throwable = constructor(stacktraceString)


### PR DESCRIPTION
This PR is backwards-incompatible and applications built with
this will not work with runtimes built on an earlier version,
or vice versa.

This splits serialized exceptions to express type information
separately. It will allow us to customize which exception types
are propagated. Initially this is used to make handing a
ZiplineApiMismatchException easy and safe.