### PR TITLE
Use main function as identifier, not call

### DIFF
--- a/samples/emoji-search/presenters/build.gradle.kts
+++ b/samples/emoji-search/presenters/build.gradle.kts
@@ -46,7 +46,7 @@ val compileZipline by tasks.creating(JavaExec::class) {
   args = listOf(
     "$buildDir/compileSync/main/productionExecutable/kotlin",
     "$buildDir/zipline",
-    "app.cash.zipline.samples.emojisearch.preparePresenters()"
+    "app.cash.zipline.samples.emojisearch.preparePresenters"
   )
 }
 

--- a/samples/trivia/trivia-js/build.gradle.kts
+++ b/samples/trivia/trivia-js/build.gradle.kts
@@ -37,7 +37,7 @@ val compileZipline by tasks.creating(JavaExec::class) {
   args = listOf(
     "$buildDir/compileSync/main/productionExecutable/kotlin",
     "$buildDir/zipline",
-    "app.cash.zipline.samples.trivia.launchZipline()"
+    "app.cash.zipline.samples.trivia.launchZipline"
   )
 }
 

--- a/zipline-cli/src/test/kotlin/app/cash/zipline/cli/DownloadTest.kt
+++ b/zipline-cli/src/test/kotlin/app/cash/zipline/cli/DownloadTest.kt
@@ -80,7 +80,7 @@ class DownloadTest {
           dependsOnIds = listOf(),
         )
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     val manifestJsonString = Json.encodeToString(manifest)
 

--- a/zipline-gradle-plugin/README.md
+++ b/zipline-gradle-plugin/README.md
@@ -15,7 +15,7 @@ The plugin offers setting the following variables which are used in compilation.
 import app.cash.zipline.gradle.ZiplineCompileTask
 
 tasks.withType(ZiplineCompileTask::class) {
-  mainFunction.set("my.application.package.path.prepareFunction()")
+  mainFunction.set("my.application.package.path.prepareFunction")
 }
 ```
 

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineCompilerTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineCompilerTest.kt
@@ -143,7 +143,7 @@ class ZiplineCompilerTest {
     outputDir.mkdirs()
 
     val mainModuleId = "./app.js"
-    val mainFunction = "zipline.ziplineMain()"
+    val mainFunction = "zipline.ziplineMain"
     ZiplineCompiler.compile(
       inputDir = inputDir,
       outputDir = outputDir,
@@ -171,7 +171,7 @@ class ZiplineCompilerTest {
     outputDir.mkdirs()
 
     val mainModuleId = "./app.js"
-    val mainFunction = "zipline.ziplineMain()"
+    val mainFunction = "zipline.ziplineMain"
     ZiplineCompiler.incrementalCompile(
       outputDir = outputDir,
       mainFunction = mainFunction,

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloaderTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloaderTest.kt
@@ -62,7 +62,7 @@ class ZiplineGradleDownloaderTest {
           dependsOnIds = listOf(),
         )
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     val manifestJsonString = Json.encodeToString(manifest)
 

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/build.gradle.kts
@@ -39,5 +39,5 @@ val launchGreetService by tasks.creating(JavaExec::class) {
 }
 
 tasks.withType(ZiplineCompileTask::class) {
-  mainFunction.set("app.cash.zipline.tests.launchGreetService()")
+  mainFunction.set("app.cash.zipline.tests.launchGreetService")
 }

--- a/zipline-loader-testing/src/engineMain/kotlin/app/cash/zipline/loader/testing/LoaderTestFixtures.kt
+++ b/zipline-loader-testing/src/engineMain/kotlin/app/cash/zipline/loader/testing/LoaderTestFixtures.kt
@@ -56,7 +56,7 @@ class LoaderTestFixtures {
         dependsOnIds = listOf(),
       ),
     ),
-    mainFunction = "zipline.ziplineMain()"
+    mainFunction = "zipline.ziplineMain"
   )
 
   val manifestWithRelativeUrlsJsonString = Json.encodeToString(manifestWithRelativeUrls)
@@ -113,7 +113,7 @@ class LoaderTestFixtures {
             sha256 = seedFileSha256,
           )
         ),
-        mainFunction = "zipline.ziplineMain()",
+        mainFunction = "zipline.ziplineMain",
       )
 
       // Synthesize an unknown field to test forward-compatibility.

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -196,7 +196,7 @@ class ZiplineLoader internal constructor(
       // Run the application after initializer has been run on Zipline engine.
       manifest.manifest.mainFunction?.let { mainFunction ->
         zipline.quickJs.evaluate(
-          script = "require('${manifest.manifest.mainModuleId}').$mainFunction",
+          script = "require('${manifest.manifest.mainModuleId}').$mainFunction()",
           fileName = "ZiplineLoader.kt",
         )
       }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
@@ -35,7 +35,7 @@ data class ZiplineManifest private constructor(
    * This will usually be the last module in the manifest once it is topologically sorted.
    */
   val mainModuleId: String,
-  /** Fully qualified main function to start the application (ie. "zipline.main()"). */
+  /** Fully qualified main function to start the application (ie. "zipline.ziplineMain"). */
   val mainFunction: String?,
 
   /**

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineManifestTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineManifestTest.kt
@@ -40,7 +40,7 @@ class ZiplineManifestTest {
           dependsOnIds = listOf(),
         ),
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     val sorted = ZiplineManifest.create(
       modules = mapOf(
@@ -55,7 +55,7 @@ class ZiplineManifestTest {
           dependsOnIds = listOf("alpha"),
         ),
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     assertEquals(sorted, unsorted)
   }
@@ -70,7 +70,7 @@ class ZiplineManifestTest {
           dependsOnIds = listOf(),
         )
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     val unsortedException = assertFailsWith<IllegalArgumentException> {
       empty.copy(
@@ -105,7 +105,7 @@ class ZiplineManifestTest {
             dependsOnIds = listOf("alpha"),
           ),
         ),
-        mainFunction = "zipline.ziplineMain()",
+        mainFunction = "zipline.ziplineMain",
       )
     }
     assertEquals(
@@ -150,7 +150,7 @@ class ZiplineManifestTest {
           dependsOnIds = listOf("alpha"),
         ),
       ),
-      mainFunction = "zipline.ziplineMain()"
+      mainFunction = "zipline.ziplineMain"
     )
     assertEquals("bravo", manifest.mainModuleId)
   }
@@ -170,7 +170,7 @@ class ZiplineManifestTest {
           dependsOnIds = listOf("alpha"),
         ),
       ),
-      mainFunction = "zipline.ziplineMain()",
+      mainFunction = "zipline.ziplineMain",
     )
 
     val serialized = Json { prettyPrint = true }.encodeToString(original)
@@ -191,7 +191,7 @@ class ZiplineManifestTest {
         |        }
         |    },
         |    "mainModuleId": "bravo",
-        |    "mainFunction": "zipline.ziplineMain()",
+        |    "mainFunction": "zipline.ziplineMain",
         |    "signatures": {
         |    }
         |}


### PR DESCRIPTION
Main function should just be an identifier, not the entire call to allow for more flexible use.