### PR TITLE
Change how ZiplineLoader manifests are loaded from the cache

### DIFF
--- a/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/jvmMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -50,7 +50,7 @@ class EmojiSearchZipline {
     modelsStateFlow: MutableStateFlow<EmojiSearchViewModel>
   ) {
     coroutineScope.launch(dispatcher) {
-      val zipline = ziplineLoader.loadOrFallBack("emojiSearch", manifestUrl) {
+      val zipline = ziplineLoader.loadOnce("emojiSearch", manifestUrl) {
         it.bind<HostApi>("hostApi", hostApi)
       }
       this@EmojiSearchZipline.zipline = zipline

--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -27,5 +27,5 @@ fun getTriviaService(zipline: Zipline): TriviaService {
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   val manifestUrl = "http://localhost:8080/manifest.zipline.json"
   val loader = ZiplineLoader(dispatcher, OkHttpClient())
-  return loader.loadOrFail("trivia", manifestUrl)
+  return loader.loadOnce("trivia", manifestUrl)
 }

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
@@ -40,7 +40,7 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   }
   val loader = ZiplineLoader(dispatcher, localDirectoryHttpClient)
 
-  val zipline = loader.loadOrFail("test", "http://localhost:99999/manifest.zipline.json")
+  val zipline = loader.loadOnce("test", "http://localhost:99999/manifest.zipline.json")
 
   return zipline
 }

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import okhttp3.OkHttpClient
+import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 
 @OptIn(ExperimentalSerializationApi::class) // Zipline must track changes to EmptySerializersModule.
 fun ZiplineLoader(
@@ -37,7 +38,7 @@ fun ZiplineLoader(
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(context),
     dispatcher = dispatcher,
-    httpClient = OkHttpZiplineHttpClient(okHttpClient = httpClient),
+    httpFetcher = HttpFetcher(OkHttpZiplineHttpClient(okHttpClient = httpClient), eventListener),
     eventListener = eventListener,
     serializersModule = serializersModule,
     manifestVerifier = manifestVerifier,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
@@ -36,23 +36,22 @@ internal class FsCachingFetcher(
     }
   }
 
-  override suspend fun fetchManifest(
-    applicationName: String,
-    id: String,
-    url: String?,
-  ): LoadedManifest? {
-    // Prefer the network for the freshest manifest. Fallback to the cache if that fails.
-    return try {
-      delegate.fetchManifest(applicationName, id, url)
-        ?: cache.getPinnedManifest(applicationName)
-    } catch (e: Exception) {
-      cache.getPinnedManifest(applicationName) ?: throw e
-    }
+  fun loadPinnedManifest(applicationName: String): LoadedManifest? {
+    return cache.getPinnedManifest(applicationName)
   }
 
-  override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) =
+  /**
+   * Permits all downloads for [applicationName] not in [loadedManifest] to be pruned.
+   *
+   * This assumes that all artifacts in [loadedManifest] are currently pinned. Fetchers do not
+   * necessarily enforce this assumption.
+   */
+  fun pin(applicationName: String, loadedManifest: LoadedManifest) =
     cache.pinManifest(applicationName, loadedManifest)
 
-  override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) =
+  /**
+   * Removes the pins for [applicationName] in [loadedManifest] so they may be pruned.
+   */
+  fun unpin(applicationName: String, loadedManifest: LoadedManifest) =
     cache.unpinManifest(applicationName, loadedManifest)
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
@@ -34,27 +34,11 @@ internal class FsEmbeddedFetcher(
     url: String,
   ): ByteString? = fetchByteString(embeddedDir / sha256.hex())
 
-  override suspend fun fetchManifest(
-    applicationName: String,
-    id: String,
-    url: String?,
-  ): LoadedManifest? {
+  fun loadEmbeddedManifest(applicationName: String): LoadedManifest? {
     val manifestBytes = fetchByteString(
       embeddedDir / getApplicationManifestFileName(applicationName)
     ) ?: return null
     return LoadedManifest(manifestBytes)
-  }
-
-  override suspend fun pin(
-    applicationName: String,
-    loadedManifest: LoadedManifest,
-  ) {
-  }
-
-  override suspend fun unpin(
-    applicationName: String,
-    loadedManifest: LoadedManifest,
-  ) {
   }
 
   private fun fetchByteString(filePath: Path) = when {

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
@@ -17,7 +17,6 @@ package app.cash.zipline.loader.internal.fetcher
 
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.ZiplineHttpClient
-import app.cash.zipline.loader.ZiplineManifest
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -42,12 +41,7 @@ internal class HttpFetcher(
     url: String,
   ) = fetchByteString(applicationName, url)
 
-  override suspend fun fetchManifest(
-    applicationName: String,
-    id: String,
-    url: String?,
-  ): LoadedManifest? {
-    if (url == null) return null // This fetcher requires URLs.
+  suspend fun fetchManifest(applicationName: String, url: String): LoadedManifest {
     val manifestBytesWithRelativeUrls = fetchByteString(applicationName, url)
 
     try {
@@ -57,7 +51,7 @@ internal class HttpFetcher(
       val manifestJson = json.encodeToString(JsonElement.serializer(), manifestJsonElement)
       return LoadedManifest(
         manifestBytes = manifestJson.encodeUtf8(),
-        manifest = json.decodeFromJsonElement<ZiplineManifest>(manifestJsonElement)
+        manifest = json.decodeFromJsonElement(manifestJsonElement)
       )
     } catch (e: Exception) {
       eventListener.manifestParseFailed(applicationName, url, e)
@@ -92,18 +86,6 @@ internal class HttpFetcher(
     }
 
     return JsonObject(newContent)
-  }
-
-  override suspend fun pin(
-    applicationName: String,
-    loadedManifest: LoadedManifest,
-  ) {
-  }
-
-  override suspend fun unpin(
-    applicationName: String,
-    loadedManifest: LoadedManifest,
-  ) {
   }
 
   private suspend fun fetchByteString(

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -111,7 +111,7 @@ class LoaderTester(
       manifestUrl to loadedManifest.manifestBytes,
       "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString
     )
-    zipline = loader.loadOrFallBack(applicationName, manifestUrl)
+    zipline = loader.loadOnce(applicationName, manifestUrl)
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n"
     )
@@ -141,7 +141,7 @@ class LoaderTester(
     httpClient.filePathToByteString = mapOf(
       "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString
     )
-    zipline = loader.loadOrFallBack(applicationName, manifestUrl)
+    zipline = loader.loadOnce(applicationName, manifestUrl)
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n"
     )
@@ -162,7 +162,7 @@ class LoaderTester(
     httpClient.filePathToByteString = mapOf(
       manifestUrl to loadedManifest.manifestBytes,
     )
-    zipline = loader.loadOrFallBack(applicationName, manifestUrl)
+    zipline = loader.loadOnce(applicationName, manifestUrl)
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n"
     )
@@ -187,7 +187,7 @@ class LoaderTester(
       manifestUrl to loadedManifest.manifestBytes,
       "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString
     )
-    zipline = loader.loadOrFallBack(applicationName, manifestUrl)
+    zipline = loader.loadOnce(applicationName, manifestUrl)
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n"
     )
@@ -209,7 +209,7 @@ class LoaderTester(
       manifestUrl to loadedManifest.manifestBytes,
       "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString
     )
-    zipline = loader.loadOrFallBack(applicationName, manifestUrl) {
+    zipline = loader.loadOnce(applicationName, manifestUrl) {
       val loadedSeed = (it.quickJs.evaluate("globalThis.log", "assert.js") as String)
         .removeSuffix(" loaded\n")
       if (loadedSeed == seed) throw IllegalArgumentException("Zipline code run failed")

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -136,10 +136,9 @@ class ProductionFetcherReceiverTest {
     manifest: ZiplineManifest,
     initializer: (Zipline) -> Unit = {},
   ): Zipline {
-    return createZiplineAndLoad(
+    return loadFromManifest(
       applicationName = applicationName,
-      manifestUrl = null,
-      providedManifest = LoadedManifest(ByteString.EMPTY, manifest),
+      loadedManifest = LoadedManifest(ByteString.EMPTY, manifest),
       initializer = initializer,
     )
   }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
@@ -43,22 +43,6 @@ class FetcherTest {
       alphaFetcherIds.add(id)
       return null
     }
-
-    override suspend fun fetchManifest(
-      applicationName: String,
-      id: String,
-      url: String?,
-    ): LoadedManifest? {
-      error("unexpected call")
-    }
-
-    override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) {
-      error("unexpected call")
-    }
-
-    override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) {
-      error("unexpected call")
-    }
   }
 
   private val fetcherBravo = object : Fetcher {
@@ -70,22 +54,6 @@ class FetcherTest {
     ): ByteString? {
       bravoFetcherIds.add(id)
       return bravoByteString
-    }
-
-    override suspend fun fetchManifest(
-      applicationName: String,
-      id: String,
-      url: String?,
-    ): LoadedManifest? {
-      error("unexpected call")
-    }
-
-    override suspend fun pin(applicationName: String, loadedManifest: LoadedManifest) {
-      error("unexpected call")
-    }
-
-    override suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest) {
-      error("unexpected call")
     }
   }
 

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
@@ -17,6 +17,7 @@ package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -34,7 +35,7 @@ fun ZiplineLoader(
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(),
     dispatcher = dispatcher,
-    httpClient = httpClient,
+    httpFetcher = HttpFetcher(httpClient, eventListener),
     eventListener = eventListener,
     serializersModule = serializersModule,
     manifestVerifier = manifestVerifier,

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
@@ -17,6 +17,7 @@ package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -33,7 +34,7 @@ fun ZiplineLoader(
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(),
     dispatcher = dispatcher,
-    httpClient = httpClient,
+    httpFetcher = HttpFetcher(httpClient, eventListener),
     eventListener = eventListener,
     serializersModule = serializersModule,
     manifestVerifier = manifestVerifier,


### PR DESCRIPTION
Previously the caching fetcher owned decisions around when
to return manifests from the cache vs. returning manifests
from the network. This meant that a failing network call could
be served from the cache.

With this update the main ZiplineLoader class is responsible
for choosing where manifests come from: network, cache, or
embedded. It only loads from the cache if the first network
load fails. Subsequent manifest loads are never served from
the cache.