### PR TITLE
Add fresh at timestamp to cache DB schema

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -99,7 +99,7 @@ class ZiplineLoader internal constructor(
     nowMs: () -> Long
   ): ZiplineLoader {
     fileSystem.createDirectories(directory, mustCreate = false)
-    val driver = sqlDriverFactory.create(directory / "zipline.db", Database.Schema)
+    val driver = sqlDriverFactory.create(directory / "zipline-2022-08-04.db", Database.Schema)
     val databaseCloseable = object : Closeable {
       override fun close() {
         driver.close()

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCache.kt
@@ -251,7 +251,9 @@ internal class ZiplineCache internal constructor(
       manifest_for_application_name = manifestForApplicationName,
       file_state = FileState.DIRTY,
       size_bytes = 0L,
-      last_used_at_epoch_ms = nowMs()
+      last_used_at_epoch_ms = nowMs(),
+      // TODO pass this in from http client
+      fresh_at_epoch_ms = nowMs()
     )
     val metadata = getOrNull(sha256)!!
 

--- a/zipline-loader/src/commonMain/sqldelight/app/cash/zipline/loader/internal/cache/Files.sq
+++ b/zipline-loader/src/commonMain/sqldelight/app/cash/zipline/loader/internal/cache/Files.sq
@@ -6,7 +6,8 @@ CREATE TABLE files (
   manifest_for_application_name TEXT, -- LIKE 'red' or maybe 'red.manifest.json', null for all files except manifest
   file_state TEXT AS FileState NOT NULL,
   size_bytes INTEGER NOT NULL,
-  last_used_at_epoch_ms INTEGER NOT NULL
+  last_used_at_epoch_ms INTEGER NOT NULL,
+  fresh_at_epoch_ms INTEGER NOT NULL
 );
 
 CREATE UNIQUE INDEX files_sha256_hex ON files(sha256_hex);
@@ -31,8 +32,8 @@ WHERE id = :id
 LIMIT 1;
 
 insert:
-INSERT INTO files(sha256_hex, manifest_for_application_name, file_state, size_bytes, last_used_at_epoch_ms)
-VALUES (?, ?, ?, ?, ?);
+INSERT INTO files(sha256_hex, manifest_for_application_name, file_state, size_bytes, last_used_at_epoch_ms, fresh_at_epoch_ms)
+VALUES (?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE files
@@ -40,7 +41,14 @@ SET file_state = :file_state, size_bytes = :size_bytes, last_used_at_epoch_ms = 
 WHERE id = :id;
 
 selectOldestReady:
-SELECT id, sha256_hex, manifest_for_application_name, file_state, size_bytes, last_used_at_epoch_ms
+SELECT
+id,
+sha256_hex,
+manifest_for_application_name,
+file_state,
+size_bytes,
+last_used_at_epoch_ms,
+fresh_at_epoch_ms
 FROM files f
 LEFT JOIN pins p ON (f.id = p.file_id)
 WHERE
@@ -56,7 +64,8 @@ sha256_hex,
 manifest_for_application_name,
 file_state,
 size_bytes,
-last_used_at_epoch_ms
+last_used_at_epoch_ms,
+fresh_at_epoch_ms
 FROM files f
 LEFT JOIN pins p ON (
   f.id = p.file_id AND
@@ -73,7 +82,8 @@ sha256_hex,
 manifest_for_application_name,
 file_state,
 size_bytes,
-last_used_at_epoch_ms
+last_used_at_epoch_ms,
+fresh_at_epoch_ms
 FROM files f
 LEFT JOIN pins p ON (
   f.id = p.file_id AND

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseCommonTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseCommonTest.kt
@@ -62,7 +62,8 @@ class DatabaseCommonTest {
       manifest_for_application_name = manifestForApplicationName,
       file_state = FileState.DIRTY,
       size_bytes = 0L,
-      last_used_at_epoch_ms = 1
+      last_used_at_epoch_ms = 1,
+      fresh_at_epoch_ms = 1
     )
 
     // Inserting another row with the same sha256_hex should fail!
@@ -72,7 +73,8 @@ class DatabaseCommonTest {
         manifest_for_application_name = manifestForApplicationName,
         file_state = FileState.DIRTY,
         size_bytes = 0L,
-        last_used_at_epoch_ms = 1
+        last_used_at_epoch_ms = 1,
+        fresh_at_epoch_ms = 1
       )
     }
 


### PR DESCRIPTION
New filename for cache DB will prevent collision with old versions during pre 1.0.0 development.