### PR TITLE
Configure Endpoint's JSON rules to be appropriately lenient

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -47,6 +47,16 @@ class Endpoint internal constructor(
   /** This uses both Zipline-provided serializers and user-provided serializers. */
   internal val json: Json = Json {
     useArrayPolymorphism = true
+
+    // For backwards-compatibility, allow new fields to be introduced.
+    ignoreUnknownKeys = true
+
+    // Because host and JS may disagree on default values, it's best to encode them.
+    encodeDefaults = true
+
+    // Support map keys whose values are arrays or objects.
+    allowStructuredMapKeys = true
+
     serializersModule = SerializersModule {
       contextual(PassByReference::class, PassByReferenceSerializer(this@Endpoint))
       contextual(Throwable::class, ThrowableSerializer)

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -16,7 +16,6 @@
 
 package app.cash.zipline
 
-import app.cash.zipline.internal.encodeToStringFast
 import app.cash.zipline.testing.EchoRequest
 import app.cash.zipline.testing.EchoResponse
 import app.cash.zipline.testing.EchoService
@@ -29,8 +28,6 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 
 /**
  * This test exercises EventListeners where both endpoints are on the same platform.
@@ -351,15 +348,6 @@ internal class EventListenerEndpointTest {
       prettyPrint(serviceResult.encodedResult),
     )
     assertEquals(listOf("zipline/host-1"), serviceResult.serviceNames)
-  }
-
-  private fun prettyPrint(jsonString: String): String {
-    val json = Json {
-      prettyPrint = true
-      prettyPrintIndent = "  "
-    }
-    val jsonTree = json.decodeFromString(JsonElement.serializer(), jsonString)
-    return json.encodeToStringFast(JsonElement.serializer(), jsonTree)
   }
 
   interface EchoTransformer : ZiplineService {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ManualCallEncodingTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ManualCallEncodingTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.EchoRequest
+import app.cash.zipline.testing.EchoResponse
+import app.cash.zipline.testing.EchoService
+import app.cash.zipline.testing.newEndpointPair
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+
+/**
+ * White box tests that confirm implementation details of call encoding work as expected on input
+ * that can't be produced through end-to-end tests.
+ */
+internal class ManualCallEncodingTest {
+
+  @Test
+  fun happyPath() = runBlocking {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    val requests = ArrayDeque<String>()
+    val service = object : EchoService {
+      override fun echo(request: EchoRequest): EchoResponse {
+        requests.addFirst("received '${request.message}'")
+        return EchoResponse("received '${request.message}'")
+      }
+    }
+    endpointA.bind<EchoService>("helloService", service)
+
+    val responseJson = endpointB.outboundChannel.call(
+      """
+      |{
+      |  "service": "helloService",
+      |  "function": "fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse",
+      |  "args": [
+      |    {
+      |      "message": "hello"
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+    )
+
+    assertEquals(
+      """
+      |{
+      |  "success": {
+      |    "message": "received 'hello'"
+      |  }
+      |}
+      """.trimMargin(),
+      prettyPrint(responseJson),
+    )
+
+    assertEquals("received 'hello'", requests.removeFirst())
+  }
+
+  @Test
+  fun absentValuesAreDefaulted() = runBlocking {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    val requests = ArrayDeque<String>()
+    val service = object : SendService {
+      override fun send(message: MessageWithDefaults) {
+        requests.addFirst("received $message")
+      }
+    }
+    endpointA.bind<SendService>("service", service)
+
+    val responseJson = endpointB.outboundChannel.call(
+      """
+      |{
+      |  "service": "service",
+      |  "function": "fun send(app.cash.zipline.ManualCallEncodingTest.MessageWithDefaults): kotlin.Unit",
+      |  "args": [
+      |    {
+      |    }
+      |  ]
+      |}
+      """.trimMargin(),
+    )
+
+    assertEquals(
+      """
+      |{
+      |  "success": {
+      |  }
+      |}
+      """.trimMargin(),
+      prettyPrint(responseJson),
+    )
+
+    assertEquals(
+      "received MessageWithDefaults(name=null, color=blue)",
+      requests.removeFirst(),
+    )
+  }
+
+  @Test
+  fun defaultValuesArePresent() = runBlocking {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    val service = object : ReceiveService {
+      override fun receive(): MessageWithDefaults {
+        return MessageWithDefaults()
+      }
+    }
+    endpointA.bind<ReceiveService>("service", service)
+
+    val responseJson = endpointB.outboundChannel.call(
+      """
+      |{
+      |  "service": "service",
+      |  "function": "fun receive(): app.cash.zipline.ManualCallEncodingTest.MessageWithDefaults",
+      |  "args": [
+      |  ]
+      |}
+      """.trimMargin(),
+    )
+
+    assertEquals(
+      """
+      |{
+      |  "success": {
+      |    "name": null,
+      |    "color": "blue"
+      |  }
+      |}
+      """.trimMargin(),
+      prettyPrint(responseJson),
+    )
+  }
+
+  @Test
+  fun mapsAreStructured() = runBlocking {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    val requests = ArrayDeque<String>()
+    val service = object : MapService {
+      override fun flip(map: Map<List<String>, List<Int>>): Map<List<Int>, List<String>> {
+        requests.addFirst("received $map")
+        return map.entries.associate { (key, value) -> value to key }
+      }
+    }
+    endpointA.bind<MapService>("service", service)
+
+    val responseJson = endpointB.outboundChannel.call(
+      """
+      |{
+      |  "service": "service",
+      |  "function": "fun flip(kotlin.collections.Map<kotlin.collections.List<kotlin.String>,kotlin.collections.List<kotlin.Int>>): kotlin.collections.Map<kotlin.collections.List<kotlin.Int>,kotlin.collections.List<kotlin.String>>",
+      |  "args": [
+      |    [
+      |      [
+      |        "a"
+      |      ],
+      |      [
+      |        1
+      |      ],
+      |      [
+      |        "b"
+      |      ],
+      |      [
+      |        5
+      |      ]
+      |    ]
+      |  ]
+      |}
+      """.trimMargin(),
+    )
+
+    assertEquals(
+      """
+      |{
+      |  "success": [
+      |    [
+      |      1
+      |    ],
+      |    [
+      |      "a"
+      |    ],
+      |    [
+      |      5
+      |    ],
+      |    [
+      |      "b"
+      |    ]
+      |  ]
+      |}
+      """.trimMargin(),
+      prettyPrint(responseJson),
+    )
+
+    assertEquals("received {[a]=[1], [b]=[5]}", requests.removeFirst())
+  }
+
+  @Serializable
+  data class MessageWithDefaults(
+    val name: String? = null,
+    val color: String = "blue",
+  )
+
+  interface SendService : ZiplineService {
+    fun send(message: MessageWithDefaults)
+  }
+
+  interface ReceiveService : ZiplineService {
+    fun receive(): MessageWithDefaults
+  }
+
+  interface MapService : ZiplineService {
+    fun flip(map: Map<List<String>, List<Int>>): Map<List<Int>, List<String>>
+  }
+}

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/testUtilEngine.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/testUtilEngine.kt
@@ -15,7 +15,10 @@
  */
 package app.cash.zipline
 
+import app.cash.zipline.internal.encodeToStringFast
 import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Yields until [condition] returns true.
@@ -29,4 +32,13 @@ suspend fun awaitCondition(condition: () -> Boolean) {
     if (condition()) return
   }
   throw AssertionError("gave up waiting for condition")
+}
+
+fun prettyPrint(jsonString: String): String {
+  val json = Json {
+    prettyPrint = true
+    prettyPrintIndent = "  "
+  }
+  val jsonTree = json.decodeFromString(JsonElement.serializer(), jsonString)
+  return json.encodeToStringFast(JsonElement.serializer(), jsonTree)
 }


### PR DESCRIPTION
Introducing new fields in particular should not fail parsing; instead
the new fields should be silently ignored.

Also improve behavior around defaults and structured maps.