### PR TITLE
Make serviceNames and clientNames internal-only

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
@@ -19,10 +19,10 @@ import kotlinx.serialization.json.Json
 
 expect class Zipline {
   /** Name of services that have been published with [bind]. */
-  val serviceNames: Set<String>
+  internal val serviceNames: Set<String>
 
   /** Names of services that can be consumed with [take]. */
-  val clientNames: Set<String>
+  internal val clientNames: Set<String>
 
   /**
    * The JSON codec for exchanging messages with the other endpoint.

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/Zipline.kt
@@ -78,10 +78,10 @@ actual class Zipline private constructor(
   actual val json: Json
     get() = endpoint.json
 
-  actual val serviceNames: Set<String>
+  internal actual val serviceNames: Set<String>
     get() = endpoint.serviceNames
 
-  actual val clientNames: Set<String>
+  internal actual val clientNames: Set<String>
     get() = endpoint.clientNames
 
   init {

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -67,10 +67,10 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
 
   actual val json = endpoint.json
 
-  actual val serviceNames: Set<String>
+  internal actual val serviceNames: Set<String>
     get() = endpoint.serviceNames
 
-  actual val clientNames: Set<String>
+  internal actual val clientNames: Set<String>
     get() = endpoint.clientNames
 
   internal val eventLoop: EventLoop = endpoint.take(eventLoopName)


### PR DESCRIPTION
I'm intending to introduce ZiplineServiceClass to expose these
same values with a more capable API. I'm not there yet, and
so I'm hiding these from the public API for now.

https://github.com/cashapp/zipline/issues/556