### PR TITLE
Tools and documentation to generate EdDSA keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,20 @@ when a `close()` call is missed.
 
 Zipline uses [EdDSA] signatures to authenticate downloaded libraries.
 
-Set up is straightforward. Generate an EdDSA key pair and put the private key on your build server
-and the public key in each host application.
+Set up is straightforward. Generate an EdDSA key pair. A task for this is installed with the Zipline
+Gradle plugin.
 
-Configure the build server to sign:
+```
+$ ./gradlew :generateZiplineManifestKeyPair
+...
+---------------- ----------------------------------------------------------------
+     PUBLIC KEY: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    PRIVATE KEY: YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+---------------- ----------------------------------------------------------------
+...
+```
+
+Put the private key on the build server and configure it to sign builds:
 
 ```kotlin
 tasks.withType(ZiplineCompileTask::class) {
@@ -153,7 +163,7 @@ tasks.withType(ZiplineCompileTask::class) {
 }
 ```
 
-And the host application to verify:
+Put the public key in each host application and configure it to verify signatures:
 
 ```kotlin
 val manifestVerifier = ManifestVerifier.Builder()

--- a/zipline-cli/README.md
+++ b/zipline-cli/README.md
@@ -34,6 +34,7 @@ Use Zipline without Gradle.
   -h, --help      Show this help message and exit.
   -V, --version   Print version information and exit.
 Commands:
-  download  Recursively download Zipline code to a directory from a URL.
-  help      Displays help information about the specified command
+  download           Recursively download Zipline code to a directory from a URL
+  generate-key-pair  Generate an Ed25519 key pair for ManifestSigner and ManifestVerifier
+  help               Displays help information about the specified command
 ```

--- a/zipline-cli/build.gradle.kts
+++ b/zipline-cli/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
   testImplementation(libs.kotlin.test)
   testImplementation(libs.okio.core)
   testImplementation(libs.okHttp.mockWebServer)
+  testImplementation(libs.truth)
 }
 
 mavenPublishing {

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
@@ -29,7 +29,7 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 
 @Command(
-  name = NAME, description = ["Recursively download Zipline code to a directory from a URL."],
+  name = NAME, description = ["Recursively download Zipline code to a directory from a URL"],
   mixinStandardHelpOptions = true, versionProvider = Main.VersionProvider::class
 )
 class Download : Runnable {

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/GenerateKeyPair.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/GenerateKeyPair.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.zipline.cli
+
+import app.cash.zipline.cli.GenerateKeyPair.Companion.NAME
+import app.cash.zipline.loader.internal.generateKeyPair
+import java.io.PrintStream
+import picocli.CommandLine.Command
+
+@Command(
+  name = NAME,
+  description = [
+    "Generate an Ed25519 key pair for ManifestSigner and ManifestVerifier"
+  ],
+  mixinStandardHelpOptions = true,
+  versionProvider = Main.VersionProvider::class,
+)
+class GenerateKeyPair : Runnable {
+  override fun run() {
+    run(System.out)
+  }
+
+  internal fun run(out: PrintStream) {
+    val keyPair = generateKeyPair()
+    out.println(" PUBLIC KEY: ${keyPair.publicKey.hex()}")
+    out.println("PRIVATE KEY: ${keyPair.privateKey.hex()}")
+  }
+
+  companion object {
+    const val NAME = "generate-key-pair"
+  }
+}

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/GenerateKeyPair.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/GenerateKeyPair.kt
@@ -29,12 +29,10 @@ import picocli.CommandLine.Command
   mixinStandardHelpOptions = true,
   versionProvider = Main.VersionProvider::class,
 )
-class GenerateKeyPair : Runnable {
+class GenerateKeyPair(
+  private val out: PrintStream = System.out,
+) : Runnable {
   override fun run() {
-    run(System.out)
-  }
-
-  internal fun run(out: PrintStream) {
     val keyPair = generateKeyPair()
     out.println(" PUBLIC KEY: ${keyPair.publicKey.hex()}")
     out.println("PRIVATE KEY: ${keyPair.privateKey.hex()}")

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Main.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Main.kt
@@ -30,7 +30,7 @@ import picocli.CommandLine.Spec
 @Command(name = NAME, description = ["Use Zipline without Gradle."],
   mixinStandardHelpOptions = true,
   synopsisSubcommandLabel = "COMMAND",
-  subcommands = [Download::class, HelpCommand::class],
+  subcommands = [Download::class, GenerateKeyPair::class, HelpCommand::class],
   versionProvider = Main.VersionProvider::class,
 )
 class Main : Runnable {

--- a/zipline-cli/src/test/kotlin/app/cash/zipline/cli/GenerateKeyPairTest.kt
+++ b/zipline-cli/src/test/kotlin/app/cash/zipline/cli/GenerateKeyPairTest.kt
@@ -24,13 +24,14 @@ import picocli.CommandLine
 import picocli.CommandLine.UnmatchedArgumentException
 
 class GenerateKeyPairTest {
+  private val systemOut = Buffer()
+
   @Test fun happyPath() {
-    val buffer = Buffer()
     val generateKeyPair = fromArgs()
-    generateKeyPair.run(PrintStream(buffer.outputStream()))
-    assertThat(buffer.readUtf8Line()).matches(" PUBLIC KEY: [\\da-f]{64}")
-    assertThat(buffer.readUtf8Line()).matches("PRIVATE KEY: [\\da-f]{64}")
-    assertThat(buffer.readUtf8Line()).isNull()
+    generateKeyPair.run()
+    assertThat(systemOut.readUtf8Line()).matches(" PUBLIC KEY: [\\da-f]{64}")
+    assertThat(systemOut.readUtf8Line()).matches("PRIVATE KEY: [\\da-f]{64}")
+    assertThat(systemOut.readUtf8Line()).isNull()
   }
 
   @Test fun unmatchedArgument() {
@@ -39,9 +40,10 @@ class GenerateKeyPairTest {
     }
   }
 
-  companion object {
-    fun fromArgs(vararg args: String?): GenerateKeyPair {
-      return CommandLine.populateCommand(GenerateKeyPair(), *args)
-    }
+  private fun fromArgs(vararg args: String?): GenerateKeyPair {
+    return CommandLine.populateCommand(
+      GenerateKeyPair(PrintStream(systemOut.outputStream())),
+      *args,
+    )
   }
 }

--- a/zipline-cli/src/test/kotlin/app/cash/zipline/cli/GenerateKeyPairTest.kt
+++ b/zipline-cli/src/test/kotlin/app/cash/zipline/cli/GenerateKeyPairTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.cli
+
+import com.google.common.truth.Truth.assertThat
+import java.io.PrintStream
+import kotlin.test.assertFailsWith
+import okio.Buffer
+import org.junit.Test
+import picocli.CommandLine
+import picocli.CommandLine.UnmatchedArgumentException
+
+class GenerateKeyPairTest {
+  @Test fun happyPath() {
+    val buffer = Buffer()
+    val generateKeyPair = fromArgs()
+    generateKeyPair.run(PrintStream(buffer.outputStream()))
+    assertThat(buffer.readUtf8Line()).matches(" PUBLIC KEY: [\\da-f]{64}")
+    assertThat(buffer.readUtf8Line()).matches("PRIVATE KEY: [\\da-f]{64}")
+    assertThat(buffer.readUtf8Line()).isNull()
+  }
+
+  @Test fun unmatchedArgument() {
+    assertFailsWith<UnmatchedArgumentException> {
+      fromArgs("-unexpected")
+    }
+  }
+
+  companion object {
+    fun fromArgs(vararg args: String?): GenerateKeyPair {
+      return CommandLine.populateCommand(GenerateKeyPair(), *args)
+    }
+  }
+}

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -101,18 +101,14 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
   }
 
   private fun createGenerateKeyPairTask(project: Project) {
-    val name = "generateZiplineManifestKeyPair"
-    val rootProjectTasks = project.rootProject.tasks
-    if (rootProjectTasks.findByName(name) == null) {
-      rootProjectTasks.create(name) { task ->
-        task.doLast {
-          val logger = LoggerFactory.getLogger(ZiplinePlugin::class.java)
-          val keyPair = generateKeyPair()
-          logger.warn("---------------- ----------------------------------------------------------------")
-          logger.warn("     PUBLIC KEY: ${keyPair.publicKey.hex()}")
-          logger.warn("    PRIVATE KEY: ${keyPair.privateKey.hex()}")
-          logger.warn("---------------- ----------------------------------------------------------------")
-        }
+    project.tasks.register("generateZiplineManifestKeyPair") { task ->
+      task.doLast {
+        val logger = LoggerFactory.getLogger(ZiplinePlugin::class.java)
+        val keyPair = generateKeyPair()
+        logger.warn("---------------- ----------------------------------------------------------------")
+        logger.warn("     PUBLIC KEY: ${keyPair.publicKey.hex()}")
+        logger.warn("    PRIVATE KEY: ${keyPair.privateKey.hex()}")
+        logger.warn("---------------- ----------------------------------------------------------------")
       }
     }
   }

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.gradle
 
+import app.cash.zipline.loader.internal.generateKeyPair
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Delete
@@ -27,6 +28,7 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.targets.js.ir.JsIrBinary
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
+import org.slf4j.LoggerFactory
 
 class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
   override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
@@ -41,6 +43,8 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
 
   override fun apply(target: Project) {
     super.apply(target)
+
+    createGenerateKeyPairTask(target)
 
     val extension = target.extensions.findByType(KotlinMultiplatformExtension::class.java)
       ?: return
@@ -93,6 +97,23 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
     }
     return project.provider {
       listOf() // No options.
+    }
+  }
+
+  private fun createGenerateKeyPairTask(project: Project) {
+    val name = "generateZiplineManifestKeyPair"
+    val rootProjectTasks = project.rootProject.tasks
+    if (rootProjectTasks.findByName(name) == null) {
+      rootProjectTasks.create(name) { task ->
+        task.doLast {
+          val logger = LoggerFactory.getLogger(ZiplinePlugin::class.java)
+          val keyPair = generateKeyPair()
+          logger.warn("---------------- ----------------------------------------------------------------")
+          logger.warn("     PUBLIC KEY: ${keyPair.publicKey.hex()}")
+          logger.warn("    PRIVATE KEY: ${keyPair.privateKey.hex()}")
+          logger.warn("---------------- ----------------------------------------------------------------")
+        }
+      }
     }
   }
 }

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
@@ -18,7 +18,6 @@ package app.cash.zipline.gradle
 
 import com.google.common.truth.Truth.assertThat
 import java.io.File
-import kotlin.test.assertEquals
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
@@ -157,6 +156,22 @@ class ZiplinePluginTest {
     val manifest = ziplineOut.resolve("manifest.zipline.json")
     assertThat(manifest.readText())
       .containsMatch(""""signatures":\{"key1":"\w{128}","key2":"\w{128}"}""")
+  }
+
+  @Test
+  fun generateZiplineManifestKeyPair() {
+    val projectDir = File("src/test/projects/basic")
+
+    val taskName = ":generateZiplineManifestKeyPair"
+    val result = createRunner(projectDir, taskName).build()
+    assertThat(SUCCESS_OUTCOMES)
+      .contains(result.task(taskName)!!.outcome)
+    assertThat(result.output).containsMatch(
+      """
+      |     PUBLIC KEY: [\da-f]{64}
+      |    PRIVATE KEY: [\da-f]{64}
+      |""".trimMargin()
+    )
   }
 
   private fun createRunner(projectDir: File, vararg taskNames: String): GradleRunner {

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
@@ -162,10 +162,9 @@ class ZiplinePluginTest {
   fun generateZiplineManifestKeyPair() {
     val projectDir = File("src/test/projects/basic")
 
-    val taskName = ":generateZiplineManifestKeyPair"
-    val result = createRunner(projectDir, taskName).build()
+    val result = createRunner(projectDir, "generateZiplineManifestKeyPair").build()
     assertThat(SUCCESS_OUTCOMES)
-      .contains(result.task(taskName)!!.outcome)
+      .contains(result.task(":lib:generateZiplineManifestKeyPair")!!.outcome)
     assertThat(result.output).containsMatch(
       """
       |     PUBLIC KEY: [\da-f]{64}

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/KeyPair.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/KeyPair.kt
@@ -15,27 +15,19 @@
 ////////////////////////////////////////////////////////////////////////////////
 package app.cash.zipline.loader.internal.tink.subtle
 
-import app.cash.zipline.loader.randomByteString
 import okio.ByteString
 
 /** Defines the KeyPair consisting of a private key and its corresponding public key.  */
-class KeyPair private constructor(
+class KeyPair internal constructor(
   val publicKey: ByteString,
   val privateKey: ByteString,
-) {
-  companion object {
-    /** Returns a new `<publicKey / privateKey>` KeyPair.  */
-    internal fun newKeyPair(): KeyPair {
-      return newKeyPairFromSeed(randomByteString(Field25519.FIELD_LEN))
-    }
+)
 
-    /** Returns a new `<publicKey / privateKey>` KeyPair generated from a seed. */
-    fun newKeyPairFromSeed(secretSeed: ByteString): KeyPair {
-      require(secretSeed.size == Field25519.FIELD_LEN) {
-        "Given secret seed length is not ${Field25519.FIELD_LEN}"
-      }
-      val publicKey = Ed25519.scalarMultWithBaseToBytes(Ed25519.getHashedScalar(secretSeed))
-      return KeyPair(publicKey, secretSeed)
-    }
+/** Returns a new `<publicKey / privateKey>` KeyPair generated from a seed. */
+fun newKeyPairFromSeed(secretSeed: ByteString): KeyPair {
+  require(secretSeed.size == Field25519.FIELD_LEN) {
+    "Given secret seed length is not ${Field25519.FIELD_LEN}"
   }
+  val publicKey = Ed25519.scalarMultWithBaseToBytes(Ed25519.getHashedScalar(secretSeed))
+  return KeyPair(publicKey, secretSeed)
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519SignTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519SignTest.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.loader.internal.tink.subtle
 
 import app.cash.zipline.loader.canLoadTestResources
+import app.cash.zipline.loader.generateKeyPairForTest
 import app.cash.zipline.loader.randomByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -30,7 +31,7 @@ import okio.ByteString.Companion.toByteString
 class Ed25519SignTest {
   @Test
   fun testSigningOneKeyWithMultipleMessages() {
-    val keyPair = KeyPair.newKeyPair()
+    val keyPair = generateKeyPairForTest()
     val signer = Ed25519Sign(keyPair.privateKey)
     val verifier = Ed25519Verify(keyPair.publicKey)
     for (i in 0..99) {
@@ -51,7 +52,7 @@ class Ed25519SignTest {
 
   @Test
   fun testSigningOneKeyWithTheSameMessage() {
-    val keyPair = KeyPair.newKeyPair()
+    val keyPair = generateKeyPairForTest()
     val signer = Ed25519Sign(keyPair.privateKey)
     val verifier = Ed25519Verify(keyPair.publicKey)
     val msg = randomByteString(20)
@@ -87,7 +88,7 @@ class Ed25519SignTest {
   @Test
   fun testSigningWithMultipleRandomKeysAndMessages() {
     for (i in 0..99) {
-      val keyPair = KeyPair.newKeyPair()
+      val keyPair = generateKeyPairForTest()
       val signer = Ed25519Sign(keyPair.privateKey)
       val verifier = Ed25519Verify(keyPair.publicKey)
       val msg = randomByteString(20)
@@ -135,7 +136,7 @@ class Ed25519SignTest {
   fun testKeyPairFromSeedTooShort() {
     val keyMaterial = randomByteString(10)
     assertFailsWith<IllegalArgumentException> {
-      KeyPair.newKeyPairFromSeed(keyMaterial)
+      newKeyPairFromSeed(keyMaterial)
     }
   }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -17,6 +17,9 @@ package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.tink.subtle.Field25519
+import app.cash.zipline.loader.internal.tink.subtle.KeyPair
+import app.cash.zipline.loader.internal.tink.subtle.newKeyPairFromSeed
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -53,4 +56,12 @@ fun prettyPrint(jsonString: String): String {
   }
   val jsonTree = json.decodeFromString(JsonElement.serializer(), jsonString)
   return json.encodeToString(JsonElement.serializer(), jsonTree)
+}
+
+/**
+ * Returns a new `<publicKey / privateKey>` KeyPair. The PRNG for this function is not secure on all
+ * platforms and should not be used for production code.
+ */
+internal fun generateKeyPairForTest(): KeyPair {
+  return newKeyPairFromSeed(randomByteString(Field25519.FIELD_LEN))
 }

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/internalJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/internalJvm.kt
@@ -16,6 +16,24 @@
 package app.cash.zipline.loader.internal
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.internal.tink.subtle.Field25519
+import app.cash.zipline.loader.internal.tink.subtle.KeyPair
+import app.cash.zipline.loader.internal.tink.subtle.newKeyPairFromSeed
+import java.security.SecureRandom
+import okio.ByteString.Companion.toByteString
 
 internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) =
   loadJsModule(bytecode, id)
+
+/** Returns a new `<publicKey / privateKey>` KeyPair. */
+fun generateKeyPair(): KeyPair {
+  val secureRandom = SecureRandom()
+    .also {
+      it.nextLong() // Force seeding.
+    }
+
+  val secretSeed = ByteArray(Field25519.FIELD_LEN)
+  secureRandom.nextBytes(secretSeed)
+
+  return newKeyPairFromSeed(secretSeed.toByteString())
+}


### PR DESCRIPTION
It's also possible to use the Tink API directly. Using the Tink
CLI isn't great; those keys are protos inside JSON which makes
them awkward to deal with.