### PR TITLE
Make the signaturePayload available in public API

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ManifestSigner.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ManifestSigner.kt
@@ -15,12 +15,8 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.loader.internal.signaturePayload
 import app.cash.zipline.loader.internal.tink.subtle.Ed25519Sign
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import okio.ByteString
-import okio.ByteString.Companion.encodeUtf8
 
 class ManifestSigner private constructor(
   private val privateKeys: Map<String, Ed25519Sign>,
@@ -34,10 +30,9 @@ class ManifestSigner private constructor(
   /** Returns a copy of [manifest] that is signed with all private keys held by this signer. */
   fun sign(manifest: ZiplineManifest): ZiplineManifest {
     // Sign with each signing key.
-    val signaturePayload = signaturePayload(Json.encodeToString(manifest))
-    val signaturePayloadBytes = signaturePayload.encodeUtf8()
+    val signaturePayload = manifest.signaturePayload
     val signatures = privateKeys.mapValues { (_, signer) ->
-      val signatureBytes = signer.sign(signaturePayloadBytes)
+      val signatureBytes = signer.sign(signaturePayload)
       return@mapValues signatureBytes.hex()
     }
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineManifest.kt
@@ -17,9 +17,13 @@ package app.cash.zipline.loader
 
 import app.cash.zipline.loader.internal.ByteStringAsHexSerializer
 import app.cash.zipline.loader.internal.isTopologicallySorted
+import app.cash.zipline.loader.internal.signaturePayload
 import app.cash.zipline.loader.internal.topologicalSort
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 
 /**
  * Preferred construction is via [ZiplineManifest.create]
@@ -121,6 +125,20 @@ data class ZiplineManifest private constructor(
     mainFunction = mainFunction,
     version = version,
   )
+
+  /**
+   * Returns a byte string representation of this manifest appropriate for signing and signature
+   * verification. The encoding omits [data not covered by signing][unsigned] and is
+   * deterministically-encoded.
+   *
+   * Use this to sign a manifest without [ManifestSigner], such as when signing with a hardware
+   * security module. Create a manifest from those externally-generated signatures with [copy].
+   */
+  val signaturePayload: ByteString
+    get() {
+      val signaturePayloadString = signaturePayload(Json.encodeToString(this))
+      return signaturePayloadString.encodeUtf8()
+    }
 
   companion object {
     fun create(

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/SignaturePayloadTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/SignaturePayloadTest.kt
@@ -55,8 +55,8 @@ class SignaturePayloadTest {
     )
 
     assertEquals(
-      signaturePayload(manifestA.toJson()),
-      signaturePayload(manifestB.toJson()),
+      manifestA.signaturePayload,
+      manifestB.signaturePayload,
     )
   }
 
@@ -87,8 +87,8 @@ class SignaturePayloadTest {
     )
 
     assertEquals(
-      signaturePayload(manifestA.toJson()),
-      signaturePayload(manifestB.toJson()),
+      manifestA.signaturePayload,
+      manifestB.signaturePayload,
     )
   }
 
@@ -118,8 +118,8 @@ class SignaturePayloadTest {
     )
 
     assertNotEquals(
-      signaturePayload(manifestA.toJson()),
-      signaturePayload(manifestB.toJson()),
+      manifestA.signaturePayload,
+      manifestB.signaturePayload,
     )
   }
 
@@ -142,8 +142,8 @@ class SignaturePayloadTest {
     )
 
     assertNotEquals(
-      signaturePayload(manifestA.toJson()),
-      signaturePayload(manifestB.toJson()),
+      manifestA.signaturePayload,
+      manifestB.signaturePayload,
     )
   }
 
@@ -166,8 +166,8 @@ class SignaturePayloadTest {
     )
 
     assertNotEquals(
-      signaturePayload(manifestA.toJson()),
-      signaturePayload(manifestB.toJson()),
+      manifestA.signaturePayload,
+      manifestB.signaturePayload,
     )
   }
 


### PR DESCRIPTION
We're looking into signing on an HSM, and that prevents us
from using the ManifestSigner API directly.