### PR TITLE
Tweak doc generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTask
 
 buildscript {
@@ -28,6 +29,10 @@ plugins {
 }
 
 apply(plugin = "org.jetbrains.dokka")
+tasks.named("dokkaHtmlMultiModule", DokkaMultiModuleTask::class.java).configure {
+  removeChildTask(":zipline-cli")
+  removeChildTask(":zipline-kotlin-plugin")
+}
 
 apply(plugin = "com.vanniktech.maven.publish.base")
 

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
@@ -35,12 +35,6 @@ import org.gradle.work.InputChanges
 
 /**
  * Compiles `.js` files to `.zipline` files.
- *
- * This also writes a Webpack configuration file `webpack.config.d/zipline.js`. in the directory
- * required by the Kotlin Gradle plugin.
- *
- * https://kotlinlang.org/docs/js-project-setup.html#webpack-configuration-file
- * https://webpack.js.org/concepts/configuration/
  */
 abstract class ZiplineCompileTask : DefaultTask() {
 

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompiler.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompiler.kt
@@ -36,7 +36,7 @@ import okio.HashingSink
 import okio.buffer
 import okio.sink
 
-object ZiplineCompiler {
+internal object ZiplineCompiler {
   private const val MODULE_PATH_PREFIX = "./"
   private const val ZIPLINE_EXTENSION = ".zipline"
 

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDownloadTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDownloadTask.kt
@@ -23,6 +23,11 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+/**
+ * Download a Zipline application as part of your build process, such as for embedding into
+ * an Android or iOS app to support offline, first-launch, and/or other usage.
+ */
+@Suppress("unused") // Public API for Gradle plugin users.
 abstract class ZiplineDownloadTask : DefaultTask() {
   @get:Input
   abstract val applicationName: Property<String>
@@ -33,10 +38,9 @@ abstract class ZiplineDownloadTask : DefaultTask() {
   @get:OutputDirectory
   abstract val downloadDir: DirectoryProperty
 
-  private val ziplineDownloader = ZiplineGradleDownloader()
-
   @TaskAction
   fun task() {
+    val ziplineDownloader = ZiplineGradleDownloader()
     ziplineDownloader.download(downloadDir.get().asFile, applicationName.get(), manifestUrl.get())
   }
 }

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
@@ -25,7 +25,7 @@ import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
 
-class ZiplineGradleDownloader {
+internal class ZiplineGradleDownloader {
   private val executorService = Executors.newSingleThreadExecutor { Thread(it, "Zipline") }
   private val dispatcher = executorService.asCoroutineDispatcher()
   private val client = OkHttpClient()

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.JsIrBinary
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.slf4j.LoggerFactory
 
+@Suppress("unused") // Created reflectively by Gradle.
 class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
   override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
 


### PR DESCRIPTION
- Do not document CLI or Kotlin plugin as public types.
- Hide some Gradle plugin types as internal.