### PR TITLE
Require callers to explicitly opt out of signature checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ must be confined to a single thread.
 ```kotlin
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   val manifestUrl = "http://localhost:8080/manifest.zipline.json"
-  val loader = ZiplineLoader(dispatcher, OkHttpClient())
+  val loader = ZiplineLoader(
+    dispatcher,
+    ManifestVerifier.NO_SIGNATURE_CHECKS,
+    OkHttpClient(),
+  )
   return loader.loadOnce("trivia", manifestUrl)
 }
 ```

--- a/samples/emoji-search/presenters/src/androidMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/androidMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -15,7 +15,9 @@
  */
 package app.cash.zipline.samples.emojisearch
 
+import android.content.Context
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import java.util.concurrent.Executors
 import kotlin.coroutines.EmptyCoroutineContext
@@ -27,7 +29,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
-import android.content.Context
 
 class EmojiSearchZipline(context: Context) {
   private val executorService = Executors.newSingleThreadExecutor { Thread(it, "Zipline") }
@@ -40,6 +41,7 @@ class EmojiSearchZipline(context: Context) {
   private val ziplineLoader = ZiplineLoader(
     context = context,
     dispatcher = dispatcher,
+    manifestVerifier = NO_SIGNATURE_CHECKS,
     httpClient = client,
   )
 

--- a/samples/emoji-search/presenters/src/iosMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
+++ b/samples/emoji-search/presenters/src/iosMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchZipline.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.samples.emojisearch
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.*
@@ -40,6 +41,7 @@ class EmojiSearchZipline(
 
   private val ziplineLoader = ZiplineLoader(
     dispatcher = dispatcher,
+    manifestVerifier = NO_SIGNATURE_CHECKS,
     httpClient = httpClient,
     nowEpochMs = { NSDate().timeIntervalSince1970().toLong() * 1000 },
   )

--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.samples.trivia
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
@@ -27,8 +28,9 @@ fun getTriviaService(zipline: Zipline): TriviaService {
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   val manifestUrl = "http://localhost:8080/manifest.zipline.json"
   val loader = ZiplineLoader(
-    dispatcher = dispatcher,
-    httpClient = OkHttpClient(),
+    dispatcher,
+    NO_SIGNATURE_CHECKS,
+    OkHttpClient(),
   )
   return loader.loadOnce("trivia", manifestUrl).zipline
 }

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Download.kt
@@ -17,6 +17,7 @@
 package app.cash.zipline.cli
 
 import app.cash.zipline.cli.Download.Companion.NAME
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import java.io.File
 import java.util.concurrent.Executors
@@ -59,6 +60,7 @@ class Download : Runnable {
     println("Zipline Download [manifestUrl=$manifestUrl][downloadDir=$downloadDir]...")
     val ziplineLoader = ZiplineLoader(
       dispatcher = dispatcher,
+      manifestVerifier = NO_SIGNATURE_CHECKS,
       httpClient = client,
     )
     runBlocking {
@@ -72,7 +74,11 @@ class Download : Runnable {
   }
 
   override fun run() {
-    download(applicationName = applicationName, manifestUrl = manifestUrl, downloadDir = downloadDir)
+    download(
+      applicationName = applicationName,
+      manifestUrl = manifestUrl,
+      downloadDir = downloadDir,
+    )
   }
 
   companion object {

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineGradleDownloader.kt
@@ -16,6 +16,7 @@
 
 package app.cash.zipline.gradle
 
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import java.io.File
 import java.util.concurrent.Executors
@@ -33,6 +34,7 @@ class ZiplineGradleDownloader {
   fun download(downloadDir: File, applicationName: String, manifestUrl: String) {
     val ziplineLoader = ZiplineLoader(
       dispatcher = dispatcher,
+      manifestVerifier = NO_SIGNATURE_CHECKS,
       httpClient = client,
     )
     runBlocking {

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
@@ -16,10 +16,11 @@
 package app.cash.zipline.tests
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
-import java.util.concurrent.Executors
 import java.time.Instant
+import java.util.concurrent.Executors
 import kotlin.system.exitProcess
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -41,6 +42,7 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   }
   val loader = ZiplineLoader(
     dispatcher = dispatcher,
+    manifestVerifier = NO_SIGNATURE_CHECKS,
     httpClient = localDirectoryHttpClient,
   )
 

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
@@ -27,20 +27,20 @@ import okhttp3.OkHttpClient
 fun ZiplineLoader(
   context: Context,
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: OkHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = { System.currentTimeMillis() },
   serializersModule: SerializersModule = EmptySerializersModule(),
-  manifestVerifier: ManifestVerifier? = null,
 ): ZiplineLoader {
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(context),
     dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
     httpFetcher = HttpFetcher(OkHttpZiplineHttpClient(httpClient), eventListener),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
     serializersModule = serializersModule,
-    manifestVerifier = manifestVerifier,
     embeddedDir = null,
     embeddedFileSystem = null,
     cache = null,

--- a/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
+++ b/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
@@ -32,10 +32,10 @@ actual val systemFileSystem = FileSystem.SYSTEM
 
 actual fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
   eventListener: EventListener,
-  manifestVerifier: ManifestVerifier?,
 ): ZiplineLoader = error("testZiplineLoader not available for Android")
 
 internal actual fun testSqlDriverFactory(): SqlDriverFactory =

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -59,11 +59,11 @@ import okio.Path
 class ZiplineLoader internal constructor(
   private val sqlDriverFactory: SqlDriverFactory,
   private val dispatcher: CoroutineDispatcher,
+  private val manifestVerifier: ManifestVerifier,
   private val httpFetcher: HttpFetcher,
   private val eventListener: EventListener,
   private val nowEpochMs: () -> Long,
   private val serializersModule: SerializersModule,
-  private val manifestVerifier: ManifestVerifier?,
   private val embeddedDir: Path?,
   private val embeddedFileSystem: FileSystem?,
   internal val cache: ZiplineCache?,
@@ -78,11 +78,11 @@ class ZiplineLoader internal constructor(
   ): ZiplineLoader = ZiplineLoader(
     sqlDriverFactory = sqlDriverFactory,
     dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
     httpFetcher = httpFetcher,
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
     serializersModule = serializersModule,
-    manifestVerifier = manifestVerifier,
     embeddedDir = embeddedDir,
     embeddedFileSystem = embeddedFileSystem,
     cache = cache,
@@ -113,11 +113,11 @@ class ZiplineLoader internal constructor(
     return ZiplineLoader(
       sqlDriverFactory = sqlDriverFactory,
       dispatcher = dispatcher,
+      manifestVerifier = manifestVerifier,
       httpFetcher = httpFetcher,
       eventListener = eventListener,
       nowEpochMs = nowEpochMs,
       serializersModule = serializersModule,
-      manifestVerifier = manifestVerifier,
       embeddedDir = embeddedDir,
       embeddedFileSystem = embeddedFileSystem,
       cache = cache,
@@ -360,7 +360,7 @@ class ZiplineLoader internal constructor(
       ?: return null
 
     // Defend against changes to the locally-cached copy.
-    manifestVerifier?.verify(result.manifestBytes, result.manifest)
+    manifestVerifier.verify(result.manifestBytes, result.manifest)
 
     return result
   }
@@ -378,7 +378,7 @@ class ZiplineLoader internal constructor(
     }
 
     // Defend against unauthorized changes in the supply chain.
-    manifestVerifier?.verify(result.manifestBytes, result.manifest)
+    manifestVerifier.verify(result.manifestBytes, result.manifest)
 
     return result
   }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -17,6 +17,7 @@ package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.internal.cache.ZiplineCache
 import app.cash.zipline.loader.internal.fetcher.MANIFEST_MAX_SIZE
 import app.cash.zipline.loader.internal.getApplicationManifestFileName
@@ -29,7 +30,7 @@ import okio.FileSystem
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoaderTester(
   private val eventListener: EventListener = EventListener.NONE,
-  private val manifestVerifier: ManifestVerifier? = null,
+  private val manifestVerifier: ManifestVerifier = NO_SIGNATURE_CHECKS
 ) {
   val tempDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "okio-${randomToken().hex()}"
 
@@ -59,10 +60,10 @@ class LoaderTester(
     systemFileSystem.createDirectories(embeddedDir, mustCreate = true)
     loader = testZiplineLoader(
       dispatcher = dispatcher,
+      manifestVerifier = manifestVerifier,
       httpClient = httpClient,
       nowEpochMs = { nowMillis },
       eventListener = eventListener,
-      manifestVerifier = manifestVerifier,
     ).withEmbedded(
       embeddedDir = embeddedDir,
       embeddedFileSystem = embeddedFileSystem,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
+import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import app.cash.zipline.loader.internal.tink.subtle.Field25519
 import app.cash.zipline.loader.internal.tink.subtle.KeyPair
@@ -30,10 +31,10 @@ expect val systemFileSystem: FileSystem
 
 expect fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier = NO_SIGNATURE_CHECKS,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
   eventListener: EventListener = EventListener.NONE,
-  manifestVerifier: ManifestVerifier? = null,
 ): ZiplineLoader
 
 internal expect fun testSqlDriverFactory(): SqlDriverFactory

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
@@ -25,20 +25,20 @@ import okhttp3.OkHttpClient
 
 fun ZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: ZiplineHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = { System.currentTimeMillis() },
   serializersModule: SerializersModule = EmptySerializersModule(),
-  manifestVerifier: ManifestVerifier? = null,
 ): ZiplineLoader {
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(),
     dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
     httpFetcher = HttpFetcher(httpClient, eventListener),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
     serializersModule = serializersModule,
-    manifestVerifier = manifestVerifier,
     embeddedDir = null,
     embeddedFileSystem = null,
     cache = null,
@@ -47,6 +47,7 @@ fun ZiplineLoader(
 
 fun ZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: OkHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = { System.currentTimeMillis() },
@@ -54,6 +55,7 @@ fun ZiplineLoader(
 ): ZiplineLoader {
   return ZiplineLoader(
     dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
     httpClient = OkHttpZiplineHttpClient(httpClient),
     nowEpochMs = nowEpochMs,
     eventListener = eventListener,

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
@@ -27,10 +27,10 @@ actual val systemFileSystem = FileSystem.SYSTEM
 
 actual fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
   eventListener: EventListener,
-  manifestVerifier: ManifestVerifier?,
 ) = ZiplineLoader(
   dispatcher = dispatcher,
   httpClient = httpClient,

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
@@ -19,27 +19,25 @@ import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
-@OptIn(ExperimentalSerializationApi::class) // Zipline must track changes to EmptySerializersModule.
 fun ZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: ZiplineHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long,
-  serializersModule: SerializersModule = EmptySerializersModule,
-  manifestVerifier: ManifestVerifier? = null,
+  serializersModule: SerializersModule = EmptySerializersModule(),
 ): ZiplineLoader {
   return ZiplineLoader(
     sqlDriverFactory = SqlDriverFactory(),
     dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
     httpFetcher = HttpFetcher(httpClient, eventListener),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
     serializersModule = serializersModule,
-    manifestVerifier = manifestVerifier,
     embeddedDir = null,
     embeddedFileSystem = null,
     cache = null,

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
@@ -28,16 +28,16 @@ actual val systemFileSystem = FileSystem.SYSTEM
 
 actual fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
   eventListener: EventListener,
-  manifestVerifier: ManifestVerifier?,
 ) = ZiplineLoader(
   dispatcher = dispatcher,
+  manifestVerifier = manifestVerifier,
   httpClient = httpClient,
   nowEpochMs = nowEpochMs,
   eventListener = eventListener,
-  manifestVerifier = manifestVerifier,
 )
 
 internal actual fun testSqlDriverFactory() = SqlDriverFactory()


### PR DESCRIPTION
Previously the ManifestVerifier was nullable and had a default
value of null. Code that had signature checks disabled didn't
look insecure.

With this change callers must explicitly opt-out of signature
checks by passing ManifestVerifier.NO_SIGNATURE_CHECKS.