### PR TITLE
Replace `map` with `zip` to retain provider chain

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -96,8 +96,8 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
         configuration.signingKeys.asMap.values
       }.flatMap {
         it.map { dslKey ->
-          dslKey.privateKeyHex.map { privateKeyHex ->
-            ManifestSigningKey(dslKey.name, dslKey.algorithmId.get(), privateKeyHex.decodeHex())
+          dslKey.privateKeyHex.zip(dslKey.algorithmId) { privateKeyHex, algorithmId ->
+            ManifestSigningKey(dslKey.name, algorithmId, privateKeyHex.decodeHex())
           }
         }.flatten()
       })


### PR DESCRIPTION
Otherwise we lose potential dependencies of the `algorithmId` by calling `get()`.

We also _might_ be able to just make these objects not using properties as one could probably provide into the container, but I'm less sure about that...