### PR TITLE
Make ZiplineCache a top-level type, again

### DIFF
--- a/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
+++ b/zipline-loader/src/androidTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
@@ -30,14 +30,6 @@ import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 
 actual val systemFileSystem = FileSystem.SYSTEM
 
-actual fun testZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: ZiplineHttpClient,
-  nowEpochMs: () -> Long,
-  eventListener: EventListener,
-): ZiplineLoader = error("testZiplineLoader not available for Android")
-
 internal actual fun testSqlDriverFactory(): SqlDriverFactory =
   error("testSqlDriverFactory not available for Android")
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/Fetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/Fetcher.kt
@@ -33,6 +33,7 @@ internal interface Fetcher {
     applicationName: String,
     id: String,
     sha256: ByteString,
+    nowEpochMs: Long,
     baseUrl: String?,
     url: String,
   ): ByteString?
@@ -46,13 +47,21 @@ internal suspend fun List<Fetcher>.fetch(
   applicationName: String,
   id: String,
   sha256: ByteString,
+  nowEpochMs: Long,
   baseUrl: String?,
   url: String,
 ): ByteString? = concurrentDownloadsSemaphore.withPermit {
   var firstException: Exception? = null
   for (fetcher in this) {
     try {
-      return@withPermit fetcher.fetch(applicationName, id, sha256, baseUrl, url) ?: continue
+      return@withPermit fetcher.fetch(
+        applicationName = applicationName,
+        id = id,
+        sha256 = sha256,
+        nowEpochMs = nowEpochMs,
+        baseUrl = baseUrl,
+        url = url
+      ) ?: continue
     } catch (e: Exception) {
       if (firstException == null) {
         firstException = e

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
-import app.cash.zipline.loader.internal.cache.ZiplineCache
+import app.cash.zipline.loader.ZiplineCache
 import okio.ByteString
 
 /**
@@ -29,16 +29,17 @@ internal class FsCachingFetcher(
     applicationName: String,
     id: String,
     sha256: ByteString,
+    nowEpochMs: Long,
     baseUrl: String?,
     url: String,
   ): ByteString? {
-    return cache.getOrPut(applicationName, sha256) {
-      delegate.fetch(applicationName, id, sha256, baseUrl, url)
+    return cache.getOrPut(applicationName, sha256, nowEpochMs) {
+      delegate.fetch(applicationName, id, sha256, nowEpochMs, baseUrl, url)
     }
   }
 
-  fun loadPinnedManifest(applicationName: String): LoadedManifest? {
-    return cache.getPinnedManifest(applicationName)
+  fun loadPinnedManifest(applicationName: String, nowEpochMs: Long): LoadedManifest? {
+    return cache.getPinnedManifest(applicationName, nowEpochMs)
   }
 
   /**
@@ -47,18 +48,18 @@ internal class FsCachingFetcher(
    * This assumes that all artifacts in [loadedManifest] are currently pinned. Fetchers do not
    * necessarily enforce this assumption.
    */
-  fun pin(applicationName: String, loadedManifest: LoadedManifest) =
-    cache.pinManifest(applicationName, loadedManifest)
+  fun pin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) =
+    cache.pinManifest(applicationName, loadedManifest, nowEpochMs)
 
   /**
    * Removes the pins for [applicationName] in [loadedManifest] so they may be pruned.
    */
-  fun unpin(applicationName: String, loadedManifest: LoadedManifest) =
-    cache.unpinManifest(applicationName, loadedManifest)
+  fun unpin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) =
+    cache.unpinManifest(applicationName, loadedManifest, nowEpochMs)
 
   /**
    * Updates freshAt timestamp for manifests that in later network fetch is still the freshest.
    */
-  fun updateFreshAt(applicationName: String, loadedManifest: LoadedManifest) =
-    cache.updateManifestFreshAt(applicationName, loadedManifest)
+  fun updateFreshAt(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) =
+    cache.updateManifestFreshAt(applicationName, loadedManifest, nowEpochMs)
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
@@ -31,6 +31,7 @@ internal class FsEmbeddedFetcher(
     applicationName: String,
     id: String,
     sha256: ByteString,
+    nowEpochMs: Long,
     baseUrl: String?,
     url: String,
   ): ByteString? = fetchByteString(embeddedDir / sha256.hex())

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
@@ -32,12 +32,13 @@ import okio.ByteString.Companion.encodeUtf8
  */
 internal class HttpFetcher(
   private val httpClient: ZiplineHttpClient,
-  private val eventListener: EventListener = EventListener.NONE,
+  private val eventListener: EventListener,
 ) : Fetcher {
   override suspend fun fetch(
     applicationName: String,
     id: String,
     sha256: ByteString,
+    nowEpochMs: Long,
     baseUrl: String?,
     url: String,
   ) = fetchByteString(

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -18,7 +18,6 @@ package app.cash.zipline.loader
 import app.cash.zipline.EventListener
 import app.cash.zipline.Zipline
 import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
-import app.cash.zipline.loader.internal.cache.ZiplineCache
 import app.cash.zipline.loader.internal.fetcher.MANIFEST_MAX_SIZE
 import app.cash.zipline.loader.internal.getApplicationManifestFileName
 import app.cash.zipline.loader.testing.LoaderTestFixtures
@@ -58,6 +57,11 @@ class LoaderTester(
   fun beforeTest() {
     systemFileSystem.createDirectories(tempDir, mustCreate = true)
     systemFileSystem.createDirectories(embeddedDir, mustCreate = true)
+    cache = testZiplineCache(
+      systemFileSystem,
+      cacheDir,
+      cacheMaxSizeInBytes.toLong()
+    )
     loader = testZiplineLoader(
       dispatcher = dispatcher,
       manifestVerifier = manifestVerifier,
@@ -68,15 +72,12 @@ class LoaderTester(
       embeddedDir = embeddedDir,
       embeddedFileSystem = embeddedFileSystem,
     ).withCache(
-      directory = cacheDir,
-      fileSystem = systemFileSystem,
-      maxSizeInBytes = cacheMaxSizeInBytes.toLong(),
+      cache
     )
-    cache = loader.cache!!
   }
 
   fun afterTest() {
-    loader.close()
+    cache.close()
   }
 
   fun seedEmbedded(applicationName: String, seed: String) {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -19,6 +19,7 @@ import app.cash.turbine.test
 import app.cash.zipline.Zipline
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
 import app.cash.zipline.loader.internal.getApplicationManifestFileName
+import app.cash.zipline.loader.internal.systemEpochMsClock
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.alphaUrl
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.assertDownloadedToEmbeddedManifest
@@ -291,6 +292,7 @@ class ZiplineLoaderTest {
       applicationName = applicationName,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
       initializer = initializer,
+      nowEpochMs = systemEpochMsClock(),
     )
   }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
@@ -38,8 +38,9 @@ class FetcherTest {
       applicationName: String,
       id: String,
       sha256: ByteString,
+      nowEpochMs: Long,
       baseUrl: String?,
-      url: String
+      url: String,
     ): ByteString? {
       alphaFetcherIds.add(id)
       return null
@@ -51,9 +52,10 @@ class FetcherTest {
       applicationName: String,
       id: String,
       sha256: ByteString,
+      nowEpochMs: Long,
       baseUrl: String?,
       url: String,
-    ): ByteString {
+    ): ByteString? {
       bravoFetcherIds.add(id)
       return bravoByteString
     }
@@ -73,6 +75,7 @@ class FetcherTest {
       applicationName = "foxtrot",
       id = "alpha",
       sha256 = "alpha".encodeUtf8().sha256(),
+      nowEpochMs = 1_000L,
       baseUrl = null,
       url = "alpha",
     )
@@ -81,6 +84,7 @@ class FetcherTest {
       applicationName = "foxtrot",
       id = "bravo",
       sha256 = "bravo".encodeUtf8().sha256(),
+      nowEpochMs = 1_000L,
       baseUrl = null,
       url = "bravo",
     )

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcherTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcherTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.loader.FakeZiplineHttpClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,7 +23,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 class HttpFetcherTest {
-  private val httpFetcher = HttpFetcher(FakeZiplineHttpClient())
+  private val httpFetcher = HttpFetcher(FakeZiplineHttpClient(), EventListener.NONE)
   private val json = Json {
     prettyPrint = true
   }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -26,16 +26,25 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import okio.ByteString
 import okio.FileSystem
+import okio.Path
 
 expect val systemFileSystem: FileSystem
 
-expect fun testZiplineLoader(
+fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
   manifestVerifier: ManifestVerifier = NO_SIGNATURE_CHECKS,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
   eventListener: EventListener = EventListener.NONE,
-): ZiplineLoader
+) = ZiplineLoader(
+  dispatcher, manifestVerifier, httpClient, eventListener, nowEpochMs
+)
+
+fun testZiplineCache(
+  fileSystem: FileSystem,
+  directory: Path,
+  maxSizeInBytes: Long,
+): ZiplineCache = ZiplineCache(testSqlDriverFactory(), fileSystem, directory, maxSizeInBytes)
 
 internal expect fun testSqlDriverFactory(): SqlDriverFactory
 

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
@@ -15,28 +15,27 @@
  */
 package app.cash.zipline.loader
 
-import android.content.Context
 import app.cash.zipline.EventListener
-import app.cash.zipline.loader.internal.cache.SqlDriverFactory
-import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 import app.cash.zipline.loader.internal.systemEpochMsClock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import okhttp3.OkHttpClient
-import okio.FileSystem
-import okio.Path
 
-fun ZiplineCache(
-  context: Context,
-  fileSystem: FileSystem,
-  directory: Path,
-  maxSizeInBytes: Long,
-): ZiplineCache {
-  return ZiplineCache(
-    sqlDriverFactory = SqlDriverFactory(context),
-    fileSystem = fileSystem,
-    directory = directory,
-    maxSizeInBytes = maxSizeInBytes,
+fun ZiplineLoader(
+  dispatcher: CoroutineDispatcher,
+  manifestVerifier: ManifestVerifier,
+  httpClient: OkHttpClient,
+  eventListener: EventListener = EventListener.NONE,
+  nowEpochMs: () -> Long = systemEpochMsClock,
+  serializersModule: SerializersModule = EmptySerializersModule(),
+): ZiplineLoader {
+  return ZiplineLoader(
+    dispatcher = dispatcher,
+    manifestVerifier = manifestVerifier,
+    httpClient = OkHttpZiplineHttpClient(httpClient),
+    eventListener = eventListener,
+    nowEpochMs = nowEpochMs,
+    serializersModule = serializersModule,
   )
 }

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
@@ -15,51 +15,19 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
-import app.cash.zipline.loader.internal.fetcher.HttpFetcher
-import app.cash.zipline.loader.internal.systemEpochMsClock
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.modules.SerializersModule
-import okhttp3.OkHttpClient
+import okio.FileSystem
+import okio.Path
 
-fun ZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: ZiplineHttpClient,
-  eventListener: EventListener = EventListener.NONE,
-  nowEpochMs: () -> Long = systemEpochMsClock,
-  serializersModule: SerializersModule = EmptySerializersModule(),
-): ZiplineLoader {
-  return ZiplineLoader(
+fun ZiplineCache(
+  fileSystem: FileSystem,
+  directory: Path,
+  maxSizeInBytes: Long,
+): ZiplineCache {
+  return ZiplineCache(
     sqlDriverFactory = SqlDriverFactory(),
-    dispatcher = dispatcher,
-    manifestVerifier = manifestVerifier,
-    httpFetcher = HttpFetcher(httpClient, eventListener),
-    eventListener = eventListener,
-    nowEpochMs = nowEpochMs,
-    serializersModule = serializersModule,
-    embeddedDir = null,
-    embeddedFileSystem = null,
-    cache = null,
-  )
-}
-
-fun ZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: OkHttpClient,
-  eventListener: EventListener = EventListener.NONE,
-  nowEpochMs: () -> Long = systemEpochMsClock,
-  serializersModule: SerializersModule = EmptySerializersModule()
-): ZiplineLoader {
-  return ZiplineLoader(
-    dispatcher = dispatcher,
-    manifestVerifier = manifestVerifier,
-    httpClient = OkHttpZiplineHttpClient(httpClient),
-    nowEpochMs = nowEpochMs,
-    eventListener = eventListener,
-    serializersModule = serializersModule
+    fileSystem = fileSystem,
+    directory = directory,
+    maxSizeInBytes = maxSizeInBytes,
   )
 }

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
@@ -15,29 +15,13 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import java.security.SecureRandom
-import kotlinx.coroutines.CoroutineDispatcher
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.FileSystem
 
 actual val systemFileSystem = FileSystem.SYSTEM
-
-actual fun testZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: ZiplineHttpClient,
-  nowEpochMs: () -> Long,
-  eventListener: EventListener,
-) = ZiplineLoader(
-  dispatcher = dispatcher,
-  httpClient = httpClient,
-  nowEpochMs = nowEpochMs,
-  eventListener = eventListener,
-  manifestVerifier = manifestVerifier,
-)
 
 internal actual fun testSqlDriverFactory() = SqlDriverFactory()
 

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
@@ -15,32 +15,19 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
-import app.cash.zipline.loader.internal.fetcher.HttpFetcher
-import app.cash.zipline.loader.internal.systemEpochMsClock
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.modules.SerializersModule
+import okio.FileSystem
+import okio.Path
 
-fun ZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: ZiplineHttpClient,
-  eventListener: EventListener = EventListener.NONE,
-  nowEpochMs: () -> Long = systemEpochMsClock,
-  serializersModule: SerializersModule = EmptySerializersModule(),
-): ZiplineLoader {
-  return ZiplineLoader(
+fun ZiplineCache(
+  fileSystem: FileSystem,
+  directory: Path,
+  maxSizeInBytes: Long,
+): ZiplineCache {
+  return ZiplineCache(
     sqlDriverFactory = SqlDriverFactory(),
-    dispatcher = dispatcher,
-    manifestVerifier = manifestVerifier,
-    httpFetcher = HttpFetcher(httpClient, eventListener),
-    eventListener = eventListener,
-    nowEpochMs = nowEpochMs,
-    serializersModule = serializersModule,
-    embeddedDir = null,
-    embeddedFileSystem = null,
-    cache = null,
+    fileSystem = fileSystem,
+    directory = directory,
+    maxSizeInBytes = maxSizeInBytes,
   )
 }

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
@@ -15,30 +15,14 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import kotlin.random.Random
-import kotlinx.coroutines.CoroutineDispatcher
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
 actual val systemFileSystem = FileSystem.SYSTEM
-
-actual fun testZiplineLoader(
-  dispatcher: CoroutineDispatcher,
-  manifestVerifier: ManifestVerifier,
-  httpClient: ZiplineHttpClient,
-  nowEpochMs: () -> Long,
-  eventListener: EventListener,
-) = ZiplineLoader(
-  dispatcher = dispatcher,
-  manifestVerifier = manifestVerifier,
-  httpClient = httpClient,
-  nowEpochMs = nowEpochMs,
-  eventListener = eventListener,
-)
 
 internal actual fun testSqlDriverFactory() = SqlDriverFactory()
 


### PR DESCRIPTION
In integrating this into another project I learned that
some callers will want to use different ZiplineLoader
configurations with the same ZiplineCache instance.

This promotes ZiplineCache to a top-level type that can
be created and closed independently of the ZiplineLoader
instances that use it.