### PR TITLE
Move where SerializersModule is configured

### DIFF
--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
@@ -18,12 +18,6 @@ package app.cash.zipline.loader
 import android.content.Context
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
-import app.cash.zipline.loader.internal.fetcher.HttpFetcher
-import app.cash.zipline.loader.internal.systemEpochMsClock
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.modules.SerializersModule
-import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.modules.EmptySerializersModule
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
@@ -139,6 +140,7 @@ class ProductionFetcherReceiverTest {
     return loadFromManifest(
       applicationName = applicationName,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
+      serializersModule = EmptySerializersModule(),
       initializer = initializer,
       nowEpochMs = nowMillis,
     )

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.modules.EmptySerializersModule
 import okio.ByteString
 import okio.FileSystem
 import okio.Path
@@ -291,6 +292,7 @@ class ZiplineLoaderTest {
     return loadFromManifest(
       applicationName = applicationName,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
+      serializersModule = EmptySerializersModule(),
       initializer = initializer,
       nowEpochMs = systemEpochMsClock(),
     )

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
@@ -18,8 +18,6 @@ package app.cash.zipline.loader
 import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.systemEpochMsClock
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.modules.SerializersModule
 import okhttp3.OkHttpClient
 
 fun ZiplineLoader(
@@ -28,7 +26,6 @@ fun ZiplineLoader(
   httpClient: OkHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = systemEpochMsClock,
-  serializersModule: SerializersModule = EmptySerializersModule(),
 ): ZiplineLoader {
   return ZiplineLoader(
     dispatcher = dispatcher,
@@ -36,6 +33,5 @@ fun ZiplineLoader(
     httpClient = OkHttpZiplineHttpClient(httpClient),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
-    serializersModule = serializersModule,
   )
 }


### PR DESCRIPTION
This should make it easier to reuse a ZiplineLoader across
applications, even if they serialize differently.