### PR TITLE
Change our wrapper exception to ZiplineException

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineException.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineException.kt
@@ -23,9 +23,6 @@ package app.cash.zipline
  * process.
  */
 class ZiplineException(
-  message: String?,
-  cause: Throwable?,
-) : RuntimeException(message, cause) {
-  constructor(message: String?) : this(message, null)
-  constructor(cause: Throwable?) : this(null, cause)
-}
+  message: String? = null,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineException.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineException.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+/**
+ * Thrown by [ZiplineService] function calls when the target function threw an exception.
+ *
+ * This is similar to a wrapping exception like Java's `InvocationTargetException`, but the wrapped
+ * exception type is not generally available because its class might not exist in the catching
+ * process.
+ */
+class ZiplineException(
+  message: String?,
+  cause: Throwable?,
+) : RuntimeException(message, cause) {
+  constructor(message: String?) : this(message, null)
+  constructor(cause: Throwable?) : this(null, cause)
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.internal.bridge
 
 import app.cash.zipline.ZiplineApiMismatchException
+import app.cash.zipline.ZiplineException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encoding.Decoder
@@ -77,7 +78,7 @@ internal object ThrowableSerializer : KSerializer<Throwable> {
       surrogate.types.firstNotNullOfOrNull { typeName ->
         val constructor = knownTypeConstructor(typeName) ?: return@firstNotNullOfOrNull null
         typeName to constructor
-      } ?: ("Exception" to ::Exception)
+      } ?: ("ZiplineException" to { message -> ZiplineException(message) })
     val (typeName, constructor) = typeNameToConstructor
 
     // Strip off "ZiplineApiMismatchException: " prefix (or similar) so it isn't repeated.

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -140,7 +140,7 @@ internal class EndpointTest {
     endpointA.bind<EchoService>("helloService", service)
     val client = endpointB.take<EchoService>("helloService")
 
-    val thrownException = assertFailsWith<Exception> {
+    val thrownException = assertFailsWith<ZiplineException> {
       client.echo(EchoRequest(""))
     }
     assertTrue(thrownException.message!!.contains(".IllegalStateException: boom!"))
@@ -159,7 +159,7 @@ internal class EndpointTest {
     endpointA.bind<SuspendingEchoService>("helloService", service)
     val client = endpointB.take<SuspendingEchoService>("helloService")
 
-    val thrownException = assertFailsWith<Exception> {
+    val thrownException = assertFailsWith<ZiplineException> {
       client.suspendingEcho(EchoRequest(""))
     }
     assertTrue(thrownException.message!!.contains(".IllegalStateException: boom!"))

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/FlowTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/FlowTest.kt
@@ -132,7 +132,7 @@ internal class FlowTest {
     channel.send("C")
 
     val received = mutableListOf<String>()
-    val e = assertFailsWith<Exception> {
+    val e = assertFailsWith<ZiplineException> {
       flow.collect {
         received += it
         if (received.size == 2) channel.cancel()

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -122,7 +122,7 @@ internal class ZiplineServiceTest {
 
     assertEquals(EchoResponse("hello Jesse"), helloService.echo(EchoRequest("Jesse")))
     helloService.close()
-    val failure = assertFailsWith<Exception> {
+    val failure = assertFailsWith<ZiplineApiMismatchException> {
       helloService.echo(EchoRequest("Jake"))
     }
     assertTrue("no such service" in (failure.message ?: ""), failure.message)

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ExceptionsTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ExceptionsTest.kt
@@ -45,7 +45,7 @@ class ExceptionsTest {
 
     val service = zipline.take<EchoService>("throwingService")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineException> {
       service.echo(EchoRequest("Jake"))
     }.stackTraceToString()).apply {
       matches(
@@ -81,7 +81,7 @@ class ExceptionsTest {
 
     val service = zipline.take<EchoService>("delegatingService")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineException> {
       service.echo(EchoRequest("Jake"))
     }.stackTraceToString()).apply {
       matches(

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ThrowableSerializerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ThrowableSerializerTest.kt
@@ -49,7 +49,7 @@ class ThrowableSerializerTest {
     )
 
     val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
-    assertEquals(Exception::class, decoded::class)
+    assertEquals(ZiplineException::class, decoded::class)
     assertEquals(
       """
       |java.lang.Exception: boom
@@ -71,7 +71,7 @@ class ThrowableSerializerTest {
       """.trimMargin()
 
     val decoded = json.decodeFromString(ThrowableSerializer, exceptionJson)
-    assertEquals(Exception::class, decoded::class)
+    assertEquals(ZiplineException::class, decoded::class)
   }
 
   @Test fun ziplineApiMismatchExceptionStripsPrefix() {

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -213,7 +213,7 @@ class ZiplineTest {
   @Test fun jvmCallIncompatibleJsService() = runBlocking(dispatcher) {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareJsBridges()")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
@@ -230,7 +230,7 @@ class ZiplineTest {
   @Test fun suspendingJvmCallIncompatibleJsService() = runBlocking(dispatcher) {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareJsBridges()")
 
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       zipline.take<SuspendingPotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
@@ -284,7 +284,7 @@ class ZiplineTest {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.initZipline()")
 
     val noSuchService = zipline.take<EchoService>("noSuchService")
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       noSuchService.echo(EchoRequest("hello"))
     }).hasMessageThat().startsWith("""
       no such service (service closed?)
@@ -300,7 +300,7 @@ class ZiplineTest {
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.initZipline()")
 
     val noSuchService = zipline.take<SuspendingEchoService>("noSuchService")
-    assertThat(assertFailsWith<Exception> {
+    assertThat(assertFailsWith<ZiplineApiMismatchException> {
       noSuchService.suspendingEcho(EchoRequest("hello"))
     }).hasMessageThat().startsWith("""
       no such service (service closed?)


### PR DESCRIPTION
This should make it easier to catch exceptions thrown
across the ZiplineService boundary.

Closes: https://github.com/cashapp/zipline/issues/676