### PR TITLE
Switch the sample to use Kotlin's new memory model

### DIFF
--- a/samples/gradle.properties
+++ b/samples/gradle.properties
@@ -10,3 +10,4 @@ android.defaults.buildfeatures.shaders=false
 
 kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true
+kotlin.native.binary.memoryModel=experimental


### PR DESCRIPTION
The old memory model was crashing because the HTTP client
was freezing a continuation and that doesn't end well.