### PR TITLE
Unhack serializer lookups

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
 import org.jetbrains.kotlin.backend.common.ir.createImplicitParameterDeclarationWithWrappedDescriptor
 import org.jetbrains.kotlin.backend.common.ir.isSuspend
 import org.jetbrains.kotlin.backend.common.ir.remapTypeParameters
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.declarations.addConstructor
@@ -48,13 +47,12 @@ import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrTypeParametersContainer
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContextImpl
 import org.jetbrains.kotlin.ir.types.defaultType
-import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.types.typeWith
@@ -62,7 +60,6 @@ import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.patchDeclarationParents
-import org.jetbrains.kotlin.ir.util.substitute
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -72,7 +69,6 @@ import org.jetbrains.kotlin.name.Name
  */
 internal class AdapterGenerator(
   private val pluginContext: IrPluginContext,
-  private val messageCollector: MessageCollector,
   private val ziplineApis: ZiplineApis,
   private val scope: ScopeWithIr,
   private val original: IrClass
@@ -82,7 +78,6 @@ internal class AdapterGenerator(
 
   private val bridgedInterface = BridgedInterface.create(
     pluginContext,
-    messageCollector,
     ziplineApis,
     scope,
     original,
@@ -90,61 +85,32 @@ internal class AdapterGenerator(
     original.defaultType
   )
 
-  /** Returns an expression that references the adapter, creating it if necessary. */
+  /** Returns an expression that references the adapter, generating it if necessary. */
   fun adapterExpression(type: IrSimpleType): IrExpression {
     val adapterClass = generateAdapterIfAbsent()
     val irBlockBodyBuilder = irBlockBodyBuilder(pluginContext, scope, original)
     return irBlockBodyBuilder.adapterExpression(adapterClass, type)
   }
 
+  /**
+   * Given a type like `GenericEchoService<String, Long>`, this generates a call to the constructor
+   * of that type.
+   */
   private fun IrBuilderWithScope.adapterExpression(
     adapterClass: IrClass,
     adapterType: IrSimpleType,
   ): IrExpression {
-    // Given a declaration like this: interface SampleService<K, V> : ZiplineService
-    //     and an instance like this: SampleService<String, Long>
-    // Creates a map from the type parameters to their concrete types.
-    val substitutionMap = mutableMapOf<IrTypeParameterSymbol, IrType>()
-    for (i in original.typeParameters.indices) {
-      substitutionMap[original.typeParameters[i].symbol] = adapterType.arguments[i] as IrType
-    }
-
     // listOf(
-    //   typeOf<SampleRequest<String>>(),
-    //   typeOf<SampleResponse<Long>>(),
+    //   serializer<String>(),
+    //   serializer<Long>(),
     // )
-    val constructorArguments = bridgedInterface.adapterConstructorArguments()
-    val typesExpressions = constructorArguments.reifiedTypes.map { serializedType ->
+    val serializersExpressions = adapterType.arguments.map { argumentType ->
       irCall(
-        callee = ziplineApis.typeOfFunction,
-        type = ziplineApis.kType.defaultType,
+        callee = ziplineApis.serializerFunctionNoReceiver,
+        type = ziplineApis.kSerializer.typeWith(argumentType as IrType),
       ).apply {
-        putTypeArgument(0, serializedType.substitute(substitutionMap))
+        putTypeArgument(0, argumentType as IrType)
       }
-    }
-    val typesList = irCall(ziplineApis.listOfFunction).apply {
-      type = ziplineApis.listOfKType
-      putTypeArgument(0, ziplineApis.kType.defaultType)
-      putValueArgument(
-        0,
-        irVararg(
-          ziplineApis.kType.defaultType,
-          typesExpressions,
-        )
-      )
-    }
-
-    // listOf(
-    //   SampleService.Adapter<T>(...)
-    // )
-    val serializersExpressions = constructorArguments.ziplineServiceTypes.map { serviceType ->
-      AdapterGenerator(
-        pluginContext,
-        messageCollector,
-        ziplineApis,
-        this@AdapterGenerator.scope,
-        serviceType.getClass()!!,
-      ).adapterExpression(serviceType.substitute(substitutionMap) as IrSimpleType)
     }
     val serializersList = irCall(ziplineApis.listOfFunction).apply {
       type = ziplineApis.listOfKSerializerStar
@@ -163,8 +129,28 @@ internal class AdapterGenerator(
       callee = adapterClass.constructors.single().symbol,
       typeArguments = adapterType.arguments.map { it as IrType },
     ).apply {
-      putValueArgument(0, typesList)
-      putValueArgument(1, serializersList)
+      putValueArgument(0, serializersList)
+    }
+  }
+
+  /**
+   * Given a type like `GenericEchoService` and a list of type parameters like
+   * `listOf(String.serializer(), Long.serializer())`, this generates a call to the constructor
+   * of that type.
+   */
+  fun adapterExpression(
+    serializersListExpression: IrExpression
+  ): IrFunctionAccessExpression {
+    val adapterClass = generateAdapterIfAbsent()
+    return with(irBlockBodyBuilder(pluginContext, scope, original)) {
+      irCall(
+        callee = adapterClass.constructors.single(),
+      ).apply {
+        putValueArgument(
+          0,
+          serializersListExpression
+        )
+      }
     }
   }
 
@@ -196,7 +182,7 @@ internal class AdapterGenerator(
     companion: IrClass
   ): IrClass {
     // class Adapter : ZiplineServiceAdapter<SampleService>(
-    //   val types: List<KType>,
+    //   val serializers: List<KSerializer<*>>,
     // ), KSerializer<SampleService> {
     //   ...
     // }
@@ -226,11 +212,6 @@ internal class AdapterGenerator(
     }.apply {
       addValueParameter {
         initDefaults(original)
-        name = Name.identifier("types")
-        type = ziplineApis.listOfKType
-      }
-      addValueParameter {
-        initDefaults(original)
         name = Name.identifier("serializers")
         type = ziplineApis.listOfKSerializerStar
       }
@@ -249,15 +230,10 @@ internal class AdapterGenerator(
       }
     }
 
-    // override val types: List<Ktype> = types
-    val typesProperty = adapterClass.addPropertyFromConstructorParameter(
-      "types",
-      adapterClass.constructors.single().valueParameters[0]
-    )
     // override val serializers: List<KSerializer<*>> = serializers
     val serializersProperty = adapterClass.addPropertyFromConstructorParameter(
       "serializers",
-      adapterClass.constructors.single().valueParameters[1]
+      adapterClass.constructors.single().valueParameters[0]
     )
 
     val serialNameProperty = irSerialNameProperty(adapterClass)
@@ -279,7 +255,6 @@ internal class AdapterGenerator(
       bridgedInterface = bridgedInterface,
       adapterClass = adapterClass,
       ziplineFunctionClasses = ziplineFunctionClasses,
-      typesProperty = typesProperty,
       serializersProperty = serializersProperty,
     )
 
@@ -327,7 +302,6 @@ internal class AdapterGenerator(
     bridgedInterface: BridgedInterface,
     adapterClass: IrClass,
     ziplineFunctionClasses: Map<IrSimpleFunctionSymbol, IrClass>,
-    typesProperty: IrProperty,
     serializersProperty: IrProperty,
   ): IrSimpleFunction {
     // override fun ziplineFunctions(
@@ -359,18 +333,6 @@ internal class AdapterGenerator(
       context = pluginContext,
       scopeOwnerSymbol = ziplineFunctionsFunction.symbol,
     ) {
-      val typesLocal = irTemporary(
-        value = irCall(
-          callee = typesProperty.getter!!
-        ).apply {
-          dispatchReceiver = irGet(ziplineFunctionsFunction.dispatchReceiverParameter!!)
-        },
-        nameHint = "types",
-        isMutable = false
-      ).apply {
-        origin = IrDeclarationOrigin.DEFINED
-      }
-
       val serializersLocal = irTemporary(
         value = irCall(
           callee = serializersProperty.getter!!
@@ -386,7 +348,6 @@ internal class AdapterGenerator(
       val serializers = bridgedInterface.declareSerializerTemporaries(
         statementsBuilder = this@irFunctionBody,
         serializersModuleParameter = ziplineFunctionsFunction.valueParameters[0],
-        typesExpression = typesLocal,
         serializersExpression = serializersLocal,
       )
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AddAdapterArgumentRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AddAdapterArgumentRewriter.kt
@@ -17,7 +17,6 @@ package app.cash.zipline.kotlin
 
 import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -51,7 +50,6 @@ import org.jetbrains.kotlin.ir.util.patchDeclarationParents
  */
 internal class AddAdapterArgumentRewriter(
   private val pluginContext: IrPluginContext,
-  private val messageCollector: MessageCollector,
   private val ziplineApis: ZiplineApis,
   private val scope: ScopeWithIr,
   private val declarationParent: IrDeclarationParent,
@@ -63,7 +61,6 @@ internal class AddAdapterArgumentRewriter(
 
   private val bridgedInterface = BridgedInterface.create(
     pluginContext,
-    messageCollector,
     ziplineApis,
     scope,
     original,
@@ -74,7 +71,6 @@ internal class AddAdapterArgumentRewriter(
   fun rewrite(): IrCall {
     val adapterExpression = AdapterGenerator(
       pluginContext,
-      messageCollector,
       ziplineApis,
       scope,
       bridgedInterface.typeIrClass

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/CallAdapterConstructorRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/CallAdapterConstructorRewriter.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.kotlin
+
+import org.jetbrains.kotlin.backend.common.ScopeWithIr
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
+import org.jetbrains.kotlin.ir.util.patchDeclarationParents
+
+/**
+ * Rewrites calls to `ziplineServiceSerializer(KClass<SampleService>, List<KSerializer<*>>)` to
+ * directly call the constructor of the generated adapter class.
+ *
+ * This call:
+ *
+ * ```
+ * val serializer = ziplineServiceSerializer(SampleService::class, serializers)
+ * ```
+ *
+ * is rewritten to:
+ *
+ * ```
+ * val serializer = SampleService.Companion.Adapter(serializers)
+ * ```
+ *
+ * Note this only works if the `KClass` argument is a constant, as that's how this decides which
+ * constructor to invoke.
+ */
+internal class CallAdapterConstructorRewriter(
+  private val pluginContext: IrPluginContext,
+  private val ziplineApis: ZiplineApis,
+  private val scope: ScopeWithIr,
+  private val declarationParent: IrDeclarationParent,
+  private val original: IrCall,
+) {
+  fun rewrite(): IrExpression {
+    val kClassArgument = original.getValueArgument(0) ?: return original
+    val serializersListExpression = original.getValueArgument(1) ?: return original
+
+    val bridgedInterfaceType = when (kClassArgument) {
+      is IrClassReference -> kClassArgument.classType
+      else -> return original
+    }
+
+    if (!bridgedInterfaceType.isSubtypeOfClass(ziplineApis.ziplineService)) return original
+
+    val bridgedInterface = BridgedInterface.create(
+      pluginContext,
+      ziplineApis,
+      scope,
+      original,
+      "ziplineServiceSerializer()",
+      bridgedInterfaceType
+    )
+
+    val result = AdapterGenerator(
+      pluginContext,
+      ziplineApis,
+      scope,
+      bridgedInterface.typeIrClass
+    ).adapterExpression(serializersListExpression)
+    result.patchDeclarationParents(declarationParent)
+    return result
+  }
+}

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.classFqName
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.functions
@@ -48,6 +47,7 @@ internal class ZiplineApis(
   private val suspendCallbackFqName = bridgeFqName.child("SuspendCallback")
   val flowFqName = FqName("kotlinx.coroutines.flow").child("Flow")
   private val collectionsFqName = FqName("kotlin.collections")
+  private val listFqName = collectionsFqName.child("List")
   private val reflectFqName = FqName("kotlin.reflect")
   private val ktypeFqName = reflectFqName.child("KType")
 
@@ -67,13 +67,10 @@ internal class ZiplineApis(
     get() = pluginContext.referenceClass(collectionsFqName.child("Map"))!!
 
   val list: IrClassSymbol
-    get() = pluginContext.referenceClass(collectionsFqName.child("List"))!!
+    get() = pluginContext.referenceClass(listFqName)!!
 
   val listOfKSerializerStar: IrSimpleType
     get() = list.typeWith(kSerializer.starProjectedType)
-
-  val listOfKType: IrSimpleType
-    get() = list.typeWith(kType.defaultType)
 
   val serializerFunctionTypeParam: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(serializationFqName.child("serializer"))
@@ -83,28 +80,26 @@ internal class ZiplineApis(
           it.owner.typeParameters.size == 1
       }
 
-  val serializerFunctionValueParam: IrSimpleFunctionSymbol
+  val serializerFunctionNoReceiver: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(serializationFqName.child("serializer"))
       .single {
-        it.owner.extensionReceiverParameter?.type?.classFqName == serializersModuleFqName &&
-          it.owner.valueParameters.size == 1 &&
-          it.owner.valueParameters[0].type.classFqName == ktypeFqName &&
-          it.owner.typeParameters.isEmpty()
+        it.owner.extensionReceiverParameter == null &&
+          it.owner.valueParameters.isEmpty() &&
+          it.owner.typeParameters.size == 1
       }
 
-  val flowSerializer: IrClassSymbol
-    get() = pluginContext.referenceClass(bridgeFqName.child("FlowSerializer"))!!
+  val requireContextual: IrSimpleFunctionSymbol
+    get() = pluginContext.referenceFunctions(bridgeFqName.child("requireContextual"))
+      .single()
 
-  val flowZiplineService: IrClassSymbol
-    get() = pluginContext.referenceClass(bridgeFqName.child("FlowZiplineService"))!!
+  /** This symbol for `ziplineServiceSerializer(KClass<*>, List<KSerializer<*>>)`. */
+  val ziplineServiceSerializerTwoArg: IrSimpleFunctionSymbol
+    get() = pluginContext.referenceFunctions(ziplineServiceSerializerFunctionFqName)
+      .single { it.owner.valueParameters.size == 2 }
 
   val listOfFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(collectionsFqName.child("listOf"))
       .single { it.owner.valueParameters.firstOrNull()?.isVararg == true }
-
-  val typeOfFunction: IrSimpleFunctionSymbol
-    get() = pluginContext.referenceFunctions(reflectFqName.child("typeOf"))
-      .single()
 
   val listGetFunction: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
@@ -190,7 +185,9 @@ internal class ZiplineApis(
     val rewriteTarget = overloads.single {
       it.owner.valueParameters.lastOrNull()?.type?.classFqName == ziplineServiceAdapterFqName
     }
-    val original = overloads.single { it != rewriteTarget }
+    val original = overloads.single {
+      it.owner.valueParameters.size + 1 == rewriteTarget.owner.valueParameters.size
+    }
     return original to rewriteTarget
   }
 }

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -156,6 +156,11 @@ internal class ZiplineApis(
       ziplineServiceAdapterFqName.child("serialName")
     ).single()
 
+  val ziplineServiceAdapterSerializers: IrPropertySymbol
+    get() = pluginContext.referenceProperties(
+      ziplineServiceAdapterFqName.child("serializers")
+    ).single()
+
   val ziplineServiceAdapterZiplineFunctions: IrSimpleFunctionSymbol
     get() = ziplineServiceAdapter.functions.single {
       it.owner.name.identifier == "ziplineFunctions"

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineIrGenerationExtension.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineIrGenerationExtension.kt
@@ -43,7 +43,6 @@ class ZiplineIrGenerationExtension(
           ) {
             AdapterGenerator(
               pluginContext,
-              messageCollector,
               ziplineApis,
               currentScope!!,
               declaration
@@ -64,12 +63,25 @@ class ZiplineIrGenerationExtension(
           if (takeOrBindFunction != null) {
             return AddAdapterArgumentRewriter(
               pluginContext,
-              messageCollector,
               ziplineApis,
               currentScope!!,
               currentDeclarationParent!!,
               expression,
               takeOrBindFunction,
+            ).rewrite()
+          }
+        } catch (e: ZiplineCompilationException) {
+          messageCollector.report(e.severity, e.message, currentFile.locationOf(e.element))
+        }
+
+        try {
+          if (expression.symbol == ziplineApis.ziplineServiceSerializerTwoArg) {
+            return CallAdapterConstructorRewriter(
+              pluginContext,
+              ziplineApis,
+              currentScope!!,
+              currentDeclarationParent!!,
+              expression,
             ).rewrite()
           }
         } catch (e: ZiplineCompilationException) {

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -335,10 +335,10 @@ fun irBlockBodyBuilder(
   original: IrElement
 ): IrBlockBodyBuilder {
   return IrBlockBodyBuilder(
-    irPluginContext,
-    scopeWithIr.scope,
-    original.startOffset,
-    original.endOffset
+    context = irPluginContext,
+    scope = scopeWithIr.scope,
+    startOffset = original.startOffset.toSyntheticIfUnknown(),
+    endOffset = original.endOffset.toSyntheticIfUnknown(),
   )
 }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -53,6 +53,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrExpressionBody
 import org.jetbrains.kotlin.ir.expressions.IrInstanceInitializerCall
 import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrDelegatingConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
@@ -67,8 +68,10 @@ import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -312,6 +315,18 @@ fun irVal(
   }
 
   return result
+}
+
+internal fun IrBuilderWithScope.irKClass(
+  containerClass: IrClass,
+): IrClassReferenceImpl {
+  return IrClassReferenceImpl(
+    startOffset = startOffset,
+    endOffset = endOffset,
+    type = context.irBuiltIns.kClassClass.typeWith(containerClass.defaultType),
+    symbol = containerClass.symbol,
+    classType = containerClass.defaultType
+  )
 }
 
 fun irBlockBodyBuilder(

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -15,17 +15,19 @@
  */
 package app.cash.zipline.kotlin;
 
+import app.cash.zipline.ZiplineFunction;
 import app.cash.zipline.internal.bridge.Endpoint;
 import app.cash.zipline.internal.bridge.OutboundCallHandler;
 import app.cash.zipline.internal.bridge.ReturningZiplineFunction;
-import app.cash.zipline.ZiplineFunction;
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter;
 import app.cash.zipline.testing.EchoRequest;
 import app.cash.zipline.testing.EchoResponse;
 import app.cash.zipline.testing.EchoService;
 import app.cash.zipline.testing.EchoZiplineService;
 import app.cash.zipline.testing.GenericEchoService;
+import app.cash.zipline.testing.KotlinSerializersKt;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import kotlin.Pair;
 import kotlin.PublishedApi;
@@ -60,7 +62,8 @@ public final class ZiplineTestInternals {
 
   public static Pair<Endpoint, Endpoint> newEndpointPair() {
     CoroutineScope scope = CoroutineScopeKt.CoroutineScope(EmptyCoroutineContext.INSTANCE);
-    return app.cash.zipline.testing.EndpointsKt.newEndpointPair(scope);
+    return app.cash.zipline.testing.EndpointsKt.newEndpointPair(
+      scope, KotlinSerializersKt.getKotlinBuiltInSerializersModule());
   }
 
   /** Simulate generated code for outbound calls. */
@@ -90,6 +93,10 @@ public final class ZiplineTestInternals {
 
     @Override public String getSerialName() {
       return "EchoService";
+    }
+
+    @Override public List<KSerializer<?>> getSerializers() {
+      return Collections.emptyList();
     }
 
     @Override public List<ZiplineFunction<EchoService>> ziplineFunctions(
@@ -139,6 +146,10 @@ public final class ZiplineTestInternals {
       return "GenericEchoService";
     }
 
+    @Override public List<KSerializer<?>> getSerializers() {
+      return Collections.emptyList();
+    }
+
     @Override
     public List<ZiplineFunction<GenericEchoService<String>>> ziplineFunctions(
         SerializersModule serializersModule) {
@@ -182,6 +193,10 @@ public final class ZiplineTestInternals {
 
     @Override public String getSerialName() {
       return "EchoZiplineService";
+    }
+
+    @Override public List<KSerializer<?>> getSerializers() {
+      return Collections.emptyList();
     }
 
     @Override

--- a/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin/tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -294,6 +294,31 @@ class ZiplineKotlinPluginTest {
     )
     assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
   }
+
+  @Test
+  fun `get service serializer with a kclass`() {
+    val result = compile(
+      sourceFile = SourceFile.kotlin(
+        "main.kt",
+        """
+        package app.cash.zipline.testing
+
+        import kotlinx.serialization.KSerializer
+        import app.cash.zipline.ziplineServiceSerializer
+
+        fun createServiceSerializer(): KSerializer<EchoZiplineService> {
+          return ziplineServiceSerializer(EchoZiplineService::class, listOf())
+        }
+        """
+      )
+    )
+    assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+
+    val mainKt = result.classLoader.loadClass("app.cash.zipline.testing.MainKt")
+    val serializer = mainKt.getDeclaredMethod("createServiceSerializer")
+      .invoke(null)
+    assertThat(serializer).isInstanceOf(KSerializer::class.java)
+  }
 }
 
 fun compile(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -18,8 +18,10 @@ package app.cash.zipline.internal.bridge
 import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.passByReferencePrefix
+import app.cash.zipline.ziplineServiceSerializer
 import kotlin.coroutines.Continuation
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
@@ -60,6 +62,14 @@ class Endpoint internal constructor(
     serializersModule = SerializersModule {
       contextual(PassByReference::class, PassByReferenceSerializer(this@Endpoint))
       contextual(Throwable::class, ThrowableSerializer)
+      contextual(Flow::class) { serializers ->
+        FlowSerializer(
+          ziplineServiceSerializer<FlowZiplineService<Any?>>(
+            FlowZiplineService::class,
+            serializers
+          )
+        )
+      }
       include(userSerializersModule)
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.modules.SerializersModule
 @PublishedApi
 internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<T> {
   private val contextualSerializer = ContextualSerializer(PassByReference::class)
+  abstract val serializers: List<KSerializer<*>>
   abstract val serialName: String
 
   override val descriptor = contextualSerializer.descriptor
@@ -52,6 +53,13 @@ internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<
     val reference = contextualSerializer.deserialize(decoder) as ReceiveByReference
     return reference.take(this)
   }
+
+  override fun equals(other: Any?) =
+    other is ZiplineServiceAdapter<*> &&
+    this::class == other::class &&
+    serializers == other.serializers
+
+  override fun hashCode() = this::class.hashCode()
 }
 
 @PublishedApi

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
@@ -221,7 +221,7 @@ internal class RealCallSerializer(
 }
 
 internal class ArgsListSerializer(
-  private val serializers: List<KSerializer<*>>,
+  internal val serializers: List<KSerializer<*>>,
 ) : KSerializer<List<*>> {
   override val descriptor = argsListDescriptor
 
@@ -250,7 +250,7 @@ internal class ArgsListSerializer(
 
 
 internal class ResultSerializer<T>(
-  private val successSerializer: KSerializer<T>,
+  internal val successSerializer: KSerializer<T>,
 ) : KSerializer<Result<T>> {
 
   override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Result") {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
@@ -83,4 +83,9 @@ internal class FlowSerializer<T>(
       })
     }
   }
+
+  override fun equals(other: Any?) =
+    other is FlowSerializer<*> && other.delegateSerializer == delegateSerializer
+
+  override fun hashCode() = delegateSerializer.hashCode()
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/internalSerializers.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/internalSerializers.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import kotlin.reflect.KClass
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.modules.SerializersModule
+
+/**
+ * Zipline wants to use Kotlinx Serialization's [SerializersModule.getContextual] from generated
+ * code, which we avoid 'cause that's an experimental API.
+ *
+ * Instead, we route all those calls through this helper, which also handles throwing if the
+ * contextual adapter is not found.
+ */
+@Suppress("UNCHECKED_CAST")
+@OptIn(ExperimentalSerializationApi::class)
+@PublishedApi
+internal fun <T : Any> SerializersModule.requireContextual(
+  kClass: KClass<*>,
+  typeArgumentsSerializers: List<KSerializer<*>>
+) : KSerializer<T> {
+  val result = getContextual(kClass, typeArgumentsSerializers)
+    ?: error("No contextual serializer for $kClass is registered")
+  return result as KSerializer<T>
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/serializers.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/serializers.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline
 
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
+import kotlin.reflect.KClass
 import kotlinx.serialization.KSerializer
 
 /**
@@ -54,6 +55,17 @@ import kotlinx.serialization.KSerializer
  * release the held reference.
  */
 fun <T : ZiplineService> ziplineServiceSerializer() : KSerializer<T> {
+  error("unexpected call to ziplineServiceSerializer(): is the Zipline plugin configured?")
+}
+
+/**
+ * Returns a [KSerializer] for [T] that performs pass-by-reference instead of pass-by-value. Use
+ * this when implementing contextual serialization for a parameterized type.
+ */
+fun <T : ZiplineService> ziplineServiceSerializer(
+  kClass: KClass<*>,
+  typeArgumentsSerializers: List<KSerializer<*>> = emptyList()
+) : KSerializer<T> {
   error("unexpected call to ziplineServiceSerializer(): is the Zipline plugin configured?")
 }
 

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -20,6 +20,7 @@ import app.cash.zipline.testing.EchoResponse
 import app.cash.zipline.testing.EchoService
 import app.cash.zipline.testing.GenericEchoService
 import app.cash.zipline.testing.SuspendingEchoService
+import app.cash.zipline.testing.contextualListModule
 import app.cash.zipline.testing.newEndpointPair
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -284,7 +285,7 @@ internal class EndpointTest {
 
   @Test
   fun genericRequestAndResponse() = runBlocking {
-    val (endpointA, endpointB) = newEndpointPair(this)
+    val (endpointA, endpointB) = newEndpointPair(this, contextualListModule)
 
     val stringService = object : GenericEchoService<String> {
       override fun genericEcho(request: String): List<String> {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -20,7 +20,7 @@ import app.cash.zipline.testing.EchoResponse
 import app.cash.zipline.testing.EchoService
 import app.cash.zipline.testing.GenericEchoService
 import app.cash.zipline.testing.SuspendingEchoService
-import app.cash.zipline.testing.contextualListModule
+import app.cash.zipline.testing.kotlinBuiltInSerializersModule
 import app.cash.zipline.testing.newEndpointPair
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -285,7 +285,7 @@ internal class EndpointTest {
 
   @Test
   fun genericRequestAndResponse() = runBlocking {
-    val (endpointA, endpointB) = newEndpointPair(this, contextualListModule)
+    val (endpointA, endpointB) = newEndpointPair(this, kotlinBuiltInSerializersModule)
 
     val stringService = object : GenericEchoService<String> {
       override fun genericEcho(request: String): List<String> {

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -59,7 +59,7 @@ interface SampleService<T> : ZiplineService {
      * `AdapterGenerator`.
      */
     internal class ManualAdapter<TX>(
-      private val serializers: List<KSerializer<*>>,
+      override val serializers: List<KSerializer<*>>,
     ) : ZiplineServiceAdapter<SampleService<TX>>() {
       override val serialName: String = "SampleService"
 

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -20,8 +20,7 @@ import app.cash.zipline.internal.bridge.ReturningZiplineFunction
 import app.cash.zipline.internal.bridge.SuspendCallback
 import app.cash.zipline.internal.bridge.SuspendingZiplineFunction
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
+import app.cash.zipline.internal.bridge.requireContextual
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
@@ -50,15 +49,7 @@ interface SampleService<T> : ZiplineService {
     /** This function's body is what callers use to create a properly-typed adapter. */
     internal inline fun <reified T> manualAdapter(): ManualAdapter<T> {
       return ManualAdapter<T>(
-        listOf<KType>(
-          typeOf<SampleRequest>(),
-          typeOf<SampleResponse>(),
-          typeOf<List<T>>(),
-          typeOf<Unit>(),
-        ),
-        listOf<KSerializer<*>>(
-          ziplineServiceSerializer<SuspendCallback<T>>()
-        )
+        listOf(serializer<T>())
       )
     }
 
@@ -68,7 +59,6 @@ interface SampleService<T> : ZiplineService {
      * `AdapterGenerator`.
      */
     internal class ManualAdapter<TX>(
-      private val types: List<KType>,
       private val serializers: List<KSerializer<*>>,
     ) : ZiplineServiceAdapter<SampleService<TX>>() {
       override val serialName: String = "SampleService"
@@ -111,13 +101,18 @@ interface SampleService<T> : ZiplineService {
       override fun ziplineFunctions(
         serializersModule: SerializersModule,
       ): List<ZiplineFunction<SampleService<TX>>> {
-        val types = types
-        val sampleRequestSerializer = serializersModule.serializer(types[0])
-        val sampleResponseSerializer = serializersModule.serializer(types[1])
-        val listOfTSerializer = serializersModule.serializer(types[2])
-        val unitSerializer = serializersModule.serializer(types[3])
         val serializers = serializers
-        val suspendCallbackTSerializer = serializers[0]
+        val sampleRequestSerializer = serializersModule.serializer<SampleRequest>()
+        val sampleResponseSerializer = serializersModule.serializer<SampleResponse>()
+        val listOfTSerializer = serializersModule.requireContextual<List<TX>>(
+          List::class,
+          listOf(serializers[0]),
+        )
+        val unitSerializer = serializersModule.serializer<Unit>()
+        val suspendCallbackTSerializer = ziplineServiceSerializer<SuspendCallback<TX>>(
+          SuspendCallback::class,
+          listOf(serializers[0]),
+        )
         return listOf(
           ZiplineFunction0(listOf(sampleRequestSerializer), sampleResponseSerializer),
           ZiplineFunction1(listOf(listOfTSerializer), suspendCallbackTSerializer),

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/kotlinSerializers.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/kotlinSerializers.kt
@@ -3,14 +3,7 @@
  */
 package app.cash.zipline.testing
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.SerialKind
-import kotlinx.serialization.descriptors.StructureKind
-import kotlinx.serialization.encoding.CompositeDecoder
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.encodeCollection
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.modules.SerializersModule
 
 /*
@@ -35,136 +28,8 @@ import kotlinx.serialization.modules.SerializersModule
  *
  */
 
-val contextualListModule = SerializersModule {
+val kotlinBuiltInSerializersModule = SerializersModule {
   contextual(List::class) { serializers ->
-    ArrayListSerializer(serializers[0])
+    ListSerializer(serializers[0])
   }
 }
-
-private const val ARRAY_LIST_NAME = "kotlin.collections.ArrayList"
-
-private class ArrayListSerializer<E>(element: KSerializer<E>) : CollectionSerializer<E, List<E>, ArrayList<E>>(element) {
-  override val descriptor: SerialDescriptor = ArrayListClassDesc(element.descriptor)
-
-  override fun builder(): ArrayList<E> = arrayListOf()
-  override fun ArrayList<E>.builderSize(): Int = size
-  override fun ArrayList<E>.toResult(): List<E> = this
-  override fun List<E>.toBuilder(): ArrayList<E> = this as? ArrayList<E> ?: ArrayList(this)
-  override fun ArrayList<E>.checkCapacity(size: Int): Unit = ensureCapacity(size)
-  override fun ArrayList<E>.insert(index: Int, element: E) { add(index, element) }
-}
-
-private abstract class CollectionSerializer<E, C: Collection<E>, B>(element: KSerializer<E>) : CollectionLikeSerializer<E, C, B>(element) {
-  override fun C.collectionSize(): Int = size
-  override fun C.collectionIterator(): Iterator<E> = iterator()
-}
-
-private sealed class CollectionLikeSerializer<Element, Collection, Builder>(
-  private val elementSerializer: KSerializer<Element>
-) : AbstractCollectionSerializer<Element, Collection, Builder>() {
-
-  protected abstract fun Builder.insert(index: Int, element: Element)
-  abstract override val descriptor: SerialDescriptor
-
-  override fun serialize(encoder: Encoder, value: Collection) {
-    val size = value.collectionSize()
-    encoder.encodeCollection(descriptor, size) {
-      val iterator = value.collectionIterator()
-      for (index in 0 until size)
-        encodeSerializableElement(descriptor, index, elementSerializer, iterator.next())
-    }
-  }
-
-  final override fun readAll(decoder: CompositeDecoder, builder: Builder, startIndex: Int, size: Int) {
-    require(size >= 0) { "Size must be known in advance when using READ_ALL" }
-    for (index in 0 until size)
-      readElement(decoder, startIndex + index, builder, checkIndex = false)
-  }
-
-  override fun readElement(decoder: CompositeDecoder, index: Int, builder: Builder, checkIndex: Boolean) {
-    builder.insert(index, decoder.decodeSerializableElement(descriptor, index, elementSerializer))
-  }
-}
-
-private abstract class AbstractCollectionSerializer<Element, Collection, Builder> : KSerializer<Collection> {
-  protected abstract fun Collection.collectionSize(): Int
-  protected abstract fun Collection.collectionIterator(): Iterator<Element>
-  protected abstract fun builder(): Builder
-  protected abstract fun Builder.builderSize(): Int
-  protected abstract fun Builder.toResult(): Collection
-  protected abstract fun Collection.toBuilder(): Builder
-  protected abstract fun Builder.checkCapacity(size: Int)
-
-  abstract override fun serialize(encoder: Encoder, value: Collection)
-
-  fun merge(decoder: Decoder, previous: Collection?): Collection {
-    val builder = previous?.toBuilder() ?: builder()
-    val startIndex = builder.builderSize()
-    val compositeDecoder = decoder.beginStructure(descriptor)
-    if (compositeDecoder.decodeSequentially()) {
-      readAll(compositeDecoder, builder, startIndex, readSize(compositeDecoder, builder))
-    } else {
-      while (true) {
-        val index = compositeDecoder.decodeElementIndex(descriptor)
-        if (index == CompositeDecoder.DECODE_DONE) break
-        readElement(compositeDecoder, startIndex + index, builder)
-      }
-    }
-    compositeDecoder.endStructure(descriptor)
-    return builder.toResult()
-  }
-
-  override fun deserialize(decoder: Decoder): Collection = merge(decoder, null)
-
-  private fun readSize(decoder: CompositeDecoder, builder: Builder): Int {
-    val size = decoder.decodeCollectionSize(descriptor)
-    builder.checkCapacity(size)
-    return size
-  }
-
-  protected abstract fun readElement(decoder: CompositeDecoder, index: Int, builder: Builder, checkIndex: Boolean = true)
-
-  protected abstract fun readAll(decoder: CompositeDecoder, builder: Builder, startIndex: Int, size: Int)
-}
-
-private class ArrayListClassDesc(elementDesc: SerialDescriptor) : ListLikeDescriptor(elementDesc) {
-  override val serialName: String get() = ARRAY_LIST_NAME
-}
-
-private abstract class ListLikeDescriptor(val elementDescriptor: SerialDescriptor) : SerialDescriptor {
-  override val kind: SerialKind get() = StructureKind.LIST
-  override val elementsCount: Int = 1
-
-  override fun getElementName(index: Int): String = index.toString()
-  override fun getElementIndex(name: String): Int =
-    name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid list index")
-
-  override fun isElementOptional(index: Int): Boolean {
-    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
-    return false
-  }
-
-  override fun getElementAnnotations(index: Int): List<Annotation> {
-    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
-    return emptyList()
-  }
-
-  override fun getElementDescriptor(index: Int): SerialDescriptor {
-    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
-    return elementDescriptor
-  }
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is ListLikeDescriptor) return false
-    if (elementDescriptor == other.elementDescriptor && serialName == other.serialName) return true
-    return false
-  }
-
-  override fun hashCode(): Int {
-    return elementDescriptor.hashCode() * 31 + serialName.hashCode()
-  }
-
-  override fun toString(): String = "$serialName($elementDescriptor)"
-}
-

--- a/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/kotlinSerializers.kt
+++ b/zipline/testing/src/commonMain/kotlin/app/cash/zipline/testing/kotlinSerializers.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package app.cash.zipline.testing
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.encodeCollection
+import kotlinx.serialization.modules.SerializersModule
+
+/*
+ *
+ * This file contains built-in serializers from Kotlin Serialization. It's here to work around a gap
+ * in the Kotlin Serialization API - there's no public API like this:
+ *
+ *   fun serializer(
+ *     kClass: KClass<*>,
+ *     typeArgumentsSerializers: List<KSerializer<*>>
+ *   )
+ *
+ * The API gets close! There's an API to get a built-in serializer with a fully-specified KType, and
+ * there's an API to do this for a contextual serializer.
+ *
+ * There's something that's almost perfect but it's private, SerializersModule.builtinSerializer().
+ *
+ * This is used by Zipline when we have a serializer for a type parameter 'T' and need to create a
+ * serializer for a `List<T>`.
+ *
+ * TODO(jwilson): delete this once kotlinx.serialization has a public API for this.
+ *
+ */
+
+val contextualListModule = SerializersModule {
+  contextual(List::class) { serializers ->
+    ArrayListSerializer(serializers[0])
+  }
+}
+
+private const val ARRAY_LIST_NAME = "kotlin.collections.ArrayList"
+
+private class ArrayListSerializer<E>(element: KSerializer<E>) : CollectionSerializer<E, List<E>, ArrayList<E>>(element) {
+  override val descriptor: SerialDescriptor = ArrayListClassDesc(element.descriptor)
+
+  override fun builder(): ArrayList<E> = arrayListOf()
+  override fun ArrayList<E>.builderSize(): Int = size
+  override fun ArrayList<E>.toResult(): List<E> = this
+  override fun List<E>.toBuilder(): ArrayList<E> = this as? ArrayList<E> ?: ArrayList(this)
+  override fun ArrayList<E>.checkCapacity(size: Int): Unit = ensureCapacity(size)
+  override fun ArrayList<E>.insert(index: Int, element: E) { add(index, element) }
+}
+
+private abstract class CollectionSerializer<E, C: Collection<E>, B>(element: KSerializer<E>) : CollectionLikeSerializer<E, C, B>(element) {
+  override fun C.collectionSize(): Int = size
+  override fun C.collectionIterator(): Iterator<E> = iterator()
+}
+
+private sealed class CollectionLikeSerializer<Element, Collection, Builder>(
+  private val elementSerializer: KSerializer<Element>
+) : AbstractCollectionSerializer<Element, Collection, Builder>() {
+
+  protected abstract fun Builder.insert(index: Int, element: Element)
+  abstract override val descriptor: SerialDescriptor
+
+  override fun serialize(encoder: Encoder, value: Collection) {
+    val size = value.collectionSize()
+    encoder.encodeCollection(descriptor, size) {
+      val iterator = value.collectionIterator()
+      for (index in 0 until size)
+        encodeSerializableElement(descriptor, index, elementSerializer, iterator.next())
+    }
+  }
+
+  final override fun readAll(decoder: CompositeDecoder, builder: Builder, startIndex: Int, size: Int) {
+    require(size >= 0) { "Size must be known in advance when using READ_ALL" }
+    for (index in 0 until size)
+      readElement(decoder, startIndex + index, builder, checkIndex = false)
+  }
+
+  override fun readElement(decoder: CompositeDecoder, index: Int, builder: Builder, checkIndex: Boolean) {
+    builder.insert(index, decoder.decodeSerializableElement(descriptor, index, elementSerializer))
+  }
+}
+
+private abstract class AbstractCollectionSerializer<Element, Collection, Builder> : KSerializer<Collection> {
+  protected abstract fun Collection.collectionSize(): Int
+  protected abstract fun Collection.collectionIterator(): Iterator<Element>
+  protected abstract fun builder(): Builder
+  protected abstract fun Builder.builderSize(): Int
+  protected abstract fun Builder.toResult(): Collection
+  protected abstract fun Collection.toBuilder(): Builder
+  protected abstract fun Builder.checkCapacity(size: Int)
+
+  abstract override fun serialize(encoder: Encoder, value: Collection)
+
+  fun merge(decoder: Decoder, previous: Collection?): Collection {
+    val builder = previous?.toBuilder() ?: builder()
+    val startIndex = builder.builderSize()
+    val compositeDecoder = decoder.beginStructure(descriptor)
+    if (compositeDecoder.decodeSequentially()) {
+      readAll(compositeDecoder, builder, startIndex, readSize(compositeDecoder, builder))
+    } else {
+      while (true) {
+        val index = compositeDecoder.decodeElementIndex(descriptor)
+        if (index == CompositeDecoder.DECODE_DONE) break
+        readElement(compositeDecoder, startIndex + index, builder)
+      }
+    }
+    compositeDecoder.endStructure(descriptor)
+    return builder.toResult()
+  }
+
+  override fun deserialize(decoder: Decoder): Collection = merge(decoder, null)
+
+  private fun readSize(decoder: CompositeDecoder, builder: Builder): Int {
+    val size = decoder.decodeCollectionSize(descriptor)
+    builder.checkCapacity(size)
+    return size
+  }
+
+  protected abstract fun readElement(decoder: CompositeDecoder, index: Int, builder: Builder, checkIndex: Boolean = true)
+
+  protected abstract fun readAll(decoder: CompositeDecoder, builder: Builder, startIndex: Int, size: Int)
+}
+
+private class ArrayListClassDesc(elementDesc: SerialDescriptor) : ListLikeDescriptor(elementDesc) {
+  override val serialName: String get() = ARRAY_LIST_NAME
+}
+
+private abstract class ListLikeDescriptor(val elementDescriptor: SerialDescriptor) : SerialDescriptor {
+  override val kind: SerialKind get() = StructureKind.LIST
+  override val elementsCount: Int = 1
+
+  override fun getElementName(index: Int): String = index.toString()
+  override fun getElementIndex(name: String): Int =
+    name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid list index")
+
+  override fun isElementOptional(index: Int): Boolean {
+    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+    return false
+  }
+
+  override fun getElementAnnotations(index: Int): List<Annotation> {
+    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+    return emptyList()
+  }
+
+  override fun getElementDescriptor(index: Int): SerialDescriptor {
+    require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+    return elementDescriptor
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is ListLikeDescriptor) return false
+    if (elementDescriptor == other.elementDescriptor && serialName == other.serialName) return true
+    return false
+  }
+
+  override fun hashCode(): Int {
+    return elementDescriptor.hashCode() * 31 + serialName.hashCode()
+  }
+
+  override fun toString(): String = "$serialName($elementDescriptor)"
+}
+


### PR DESCRIPTION
This simplifies the internals of generated ZiplineServiceAdapter
subtypes. Instead of accepting a List<Ktype> and a List<KSerializer>
it now accepts just a List<KSerializer>, and the set of types in that
list is much simpler - one element per type parameter.

The previous definition was more complex - the types were for lazy
lookups (with a SerializersModule) and the serializers were for eager
lookups (for flows and pass-by-reference).

The next step when this is done is supporting for @Contextual and
other serialization annotations.

https://github.com/cashapp/zipline/issues/602