### PR TITLE
Add test tasks for release mode

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -4,6 +4,9 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 
 plugins {
   kotlin("multiplatform")
@@ -109,6 +112,18 @@ kotlin {
 
       val test by compilations.getting
       test.defaultSourceSet.dependsOn(nativeTest)
+    }
+
+    targets.withType<KotlinNativeTargetWithTests<*>> {
+      binaries {
+        // Configure a separate test where code is compiled in release mode.
+        test(setOf(NativeBuildType.RELEASE))
+      }
+      testRuns {
+        create("release") {
+          setExecutionSourceFrom(binaries.getByName("releaseTest") as TestExecutable)
+        }
+      }
     }
 
     targets.all {


### PR DESCRIPTION
This ensures we do not regress generating code which will not link for release builds. Default tests run in debug mode.

Closes #347 