### PR TITLE
[#602] Add contextual serializers test

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -122,7 +122,7 @@ internal class BridgedInterface(
         type = requiredType,
         serializersModuleParameter = serializersModuleParameter,
         serializersExpression = serializersExpression,
-        contextual = false,
+        contextual = requiredType.isContextual,
       )
       result[requiredType] = irTemporary(
         value = serializerExpression.expression,
@@ -132,6 +132,9 @@ internal class BridgedInterface(
     }
     return result
   }
+
+  private val IrType.isContextual
+    get() = annotations.any { it.type.classFqName == ziplineApis.contextualFqName }
 
   class SerializerExpression(
     val expression: IrExpression,
@@ -160,7 +163,7 @@ internal class BridgedInterface(
         type = argumentType,
         serializersModuleParameter = serializersModuleParameter,
         serializersExpression = serializersExpression,
-        contextual = false,
+        contextual = argumentType.isContextual,
       )
     }
     val parameterList = irCall(ziplineApis.listOfFunction).apply {

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -35,6 +35,7 @@ internal class ZiplineApis(
   private val packageFqName = FqName("app.cash.zipline")
   private val bridgeFqName = FqName("app.cash.zipline.internal.bridge")
   private val serializationFqName = FqName("kotlinx.serialization")
+  val contextualFqName = serializationFqName.child("Contextual")
   private val serializationModulesFqName = FqName("kotlinx.serialization.modules")
   private val serializersModuleFqName = serializationModulesFqName.child("SerializersModule")
   private val ziplineFqName = packageFqName.child("Zipline")

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/NewServicesTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/NewServicesTest.kt
@@ -1,0 +1,478 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.internal.bridge.FlowSerializer
+import app.cash.zipline.internal.bridge.FlowZiplineService
+import app.cash.zipline.internal.bridge.ReturningZiplineFunction
+import app.cash.zipline.internal.bridge.SuspendCallback
+import app.cash.zipline.internal.bridge.SuspendingZiplineFunction
+import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
+import app.cash.zipline.testing.EchoService
+import app.cash.zipline.testing.kotlinBuiltInSerializersModule
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+import org.junit.Ignore
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NewSerializersTest {
+  private val dispatcher = TestCoroutineDispatcher()
+  private val zipline = Zipline.create(dispatcher, kotlinBuiltInSerializersModule)
+  private val json = zipline.json
+
+  @Test
+  fun stringParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<StringParameter>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      String.serializer(),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface StringParameter : ZiplineService {
+    fun onlyFunction(string: String)
+  }
+
+  @Test
+  fun stringReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<StringReturnValue>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      String.serializer(),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface StringReturnValue : ZiplineService {
+    fun onlyFunction(): String
+  }
+
+  @Test
+  fun stringSuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<StringSuspendResult>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      ziplineServiceSerializer<SuspendCallback<String>>(),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface StringSuspendResult : ZiplineService {
+    suspend fun onlyFunction(): String
+  }
+
+  @Test
+  fun byteArrayParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ByteArrayParameter>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      ByteArraySerializer(),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface ByteArrayParameter : ZiplineService {
+    fun onlyFunction(value: ByteArray)
+  }
+
+  @Test
+  fun byteArrayReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ByteArrayReturnValue>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      ByteArraySerializer(),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface ByteArrayReturnValue : ZiplineService {
+    fun onlyFunction(): ByteArray
+  }
+
+  @Test
+  fun byteArraySuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ByteArraySuspendResult>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      ziplineServiceSerializer<SuspendCallback<ByteArray>>(),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface ByteArraySuspendResult : ZiplineService {
+    suspend fun onlyFunction(): ByteArray
+  }
+
+  @Test
+  fun genericParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericParameter<String>>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      String.serializer(),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface GenericParameter<T> : ZiplineService {
+    fun onlyFunction(value: T)
+  }
+
+  @Test
+  fun genericReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericReturnValue<String>>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      String.serializer(),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface GenericReturnValue<T> : ZiplineService {
+    fun onlyFunction(): T
+  }
+
+  @Test
+  fun genericSuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericSuspendResult<String>>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      ziplineServiceSerializer<SuspendCallback<String>>(),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface GenericSuspendResult<T> : ZiplineService {
+    suspend fun onlyFunction(): T
+  }
+
+  @Test
+  fun genericParameterInList() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericParameterInList<String>>(),
+    ) as ReturningZiplineFunction
+    assertSerializersEqual(
+      ListSerializer(String.serializer()),
+      function.argsListSerializer.serializers[0],
+      listOf("a", "b", "c")
+    )
+  }
+
+  interface GenericParameterInList<T> : ZiplineService {
+    fun onlyFunction(value: List<T>)
+  }
+
+  @Test
+  fun genericReturnValueInList() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericReturnValueInList<String>>(),
+    ) as ReturningZiplineFunction
+    assertSerializersEqual(
+      ListSerializer(String.serializer()),
+      function.kotlinResultSerializer.successSerializer,
+      listOf("a", "b", "c"),
+    )
+  }
+
+  interface GenericReturnValueInList<T> : ZiplineService {
+    fun onlyFunction(): List<T>
+  }
+
+  @Ignore("No equals function for these")
+  @Test
+  fun genericSuspendResultInList() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericSuspendResultInList<String>>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      suspendCallbackSerializer(ListSerializer(String.serializer())),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface GenericSuspendResultInList<T> : ZiplineService {
+    suspend fun onlyFunction(): List<T>
+  }
+
+  @Test
+  fun flowParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<FlowParameter>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      FlowSerializer(ziplineServiceSerializer<FlowZiplineService<String>>()),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface FlowParameter : ZiplineService {
+    fun onlyFunction(value: Flow<String>)
+  }
+
+  @Test
+  fun flowReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<FlowReturnValue>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      FlowSerializer(ziplineServiceSerializer<FlowZiplineService<String>>()),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface FlowReturnValue : ZiplineService {
+    fun onlyFunction(): Flow<String>
+  }
+
+  @Test
+  fun flowSuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<FlowSuspendResult>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      suspendCallbackSerializer(flowSerializer(String.serializer())),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface FlowSuspendResult : ZiplineService {
+    suspend fun onlyFunction(): Flow<String>
+  }
+
+  @Test
+  fun genericFlowParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericFlowParameter<String>>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      FlowSerializer(ziplineServiceSerializer<FlowZiplineService<String>>()),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface GenericFlowParameter<T> : ZiplineService {
+    fun onlyFunction(value: Flow<T>)
+  }
+
+  @Test
+  fun genericFlowReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericFlowReturnValue<String>>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      FlowSerializer(ziplineServiceSerializer<FlowZiplineService<String>>()),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface GenericFlowReturnValue<T> : ZiplineService {
+    fun onlyFunction(): Flow<T>
+  }
+
+  @Test
+  fun genericFlowSuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<GenericFlowSuspendResult<String>>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      suspendCallbackSerializer(flowSerializer(String.serializer())),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface GenericFlowSuspendResult<T> : ZiplineService {
+    suspend fun onlyFunction(): Flow<T>
+  }
+
+  @Test
+  fun serviceParameter() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ServiceParameter>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      ziplineServiceSerializer<EchoService>(),
+      function.argsListSerializer.serializers[0],
+    )
+  }
+
+  interface ServiceParameter : ZiplineService {
+    fun onlyFunction(value: EchoService)
+  }
+
+  @Test
+  fun serviceReturnValue() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ServiceReturnValue>(),
+    ) as ReturningZiplineFunction
+    assertEquals(
+      ziplineServiceSerializer<EchoService>(),
+      function.kotlinResultSerializer.successSerializer,
+    )
+  }
+
+  interface ServiceReturnValue : ZiplineService {
+    fun onlyFunction(): EchoService
+  }
+
+  @Test
+  fun serviceSuspendResult() = runBlocking {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ServiceSuspendResult>(),
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      suspendCallbackSerializer(ziplineServiceSerializer<EchoService>()),
+      function.suspendCallbackSerializer,
+    )
+  }
+
+  interface ServiceSuspendResult : ZiplineService {
+    suspend fun onlyFunction(): EchoService
+  }
+
+  @Test
+  fun contextualServiceParameter() {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ContextualParameter>(),
+      serializersModule = requiresContextualSerializersModule,
+    ) as ReturningZiplineFunction<*>
+    assertEquals(
+      RequiresContextualSerializer,
+      function.argsListSerializer.serializers.first()
+    )
+  }
+
+  interface ContextualParameter : ZiplineService {
+    fun echo(request: @Contextual RequiresContextual)
+  }
+
+  @Test
+  fun contextualReturnValueService() {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ContextualReturnValue>(),
+      serializersModule = requiresContextualSerializersModule,
+    ) as ReturningZiplineFunction<*>
+    assertEquals(
+      RequiresContextualSerializer,
+      function.kotlinResultSerializer.successSerializer
+    )
+  }
+
+  interface ContextualReturnValue : ZiplineService {
+    fun echo(): @Contextual RequiresContextual
+  }
+
+  @Test
+  fun contextualSuspendingReturnValue() {
+    val function = onlyZiplineFunction(
+      serviceSerializer = ziplineServiceSerializer<ContextualSuspendingReturnValue>(),
+      serializersModule = requiresContextualSerializersModule,
+    ) as SuspendingZiplineFunction<*>
+    assertEquals(
+      suspendCallbackSerializer(RequiresContextualSerializer),
+      function.suspendCallbackSerializer
+    )
+  }
+
+  interface ContextualSuspendingReturnValue : ZiplineService {
+    suspend fun echo(): @Contextual RequiresContextual
+  }
+
+  private fun <T> suspendCallbackSerializer(
+    resultSerializer: KSerializer<T>
+  ): KSerializer<SuspendCallback<T>> {
+    return ziplineServiceSerializer(
+      SuspendCallback::class,
+      listOf(resultSerializer)
+    )
+  }
+
+  private fun <T> flowSerializer(elementSerializer: KSerializer<T>): KSerializer<Flow<T>> {
+    return FlowSerializer(
+      ziplineServiceSerializer(FlowZiplineService::class, listOf(elementSerializer))
+    )
+  }
+
+  private fun <T : ZiplineService> onlyZiplineFunction(
+    serviceSerializer: KSerializer<T>,
+    serializersModule: SerializersModule = json.serializersModule,
+  ): ZiplineFunction<T> {
+    val serializer = serviceSerializer as ZiplineServiceAdapter<T>
+    val functions = serializer.ziplineFunctions(serializersModule)
+    return functions.single { !it.isClose }
+  }
+
+  private val requiresContextualSerializersModule = SerializersModule {
+    contextual(RequiresContextual::class, RequiresContextualSerializer)
+  }
+
+  // Note: no @Serializable.
+  class RequiresContextual(
+    val string: String
+  )
+
+  object RequiresContextualSerializer : KSerializer<RequiresContextual> {
+    override val descriptor = String.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): RequiresContextual {
+      return RequiresContextual(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: RequiresContextual) {
+      encoder.encodeString(value.string)
+    }
+  }
+
+  /**
+   * Confirm [expected] and [actual] encode and decode the same. This is necessary to check equality
+   * on serializers that don't implement [Any.equals].
+   */
+  private fun assertSerializersEqual(
+    expected: KSerializer<*>,
+    actual: KSerializer<*>,
+    sampleValue: Any?,
+  ) {
+    assertEquals(actual.descriptor, expected.descriptor)
+    assertEquals(
+      json.encodeToString(expected as KSerializer<Any?>, sampleValue),
+      json.encodeToString(actual as KSerializer<Any?>, sampleValue),
+    )
+    assertEquals(
+      sampleValue,
+      json.decodeFromString(actual, json.encodeToString(expected, sampleValue)),
+    )
+  }
+}


### PR DESCRIPTION
Paired with @swankjesse on adding test coverage for serializers and better support for `@Contextual` annotation in different parts of service signature.