### PR TITLE
Fix kotlin compilation issue for trivia-sample

### DIFF
--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.samples.trivia
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.LoadResult
 import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
@@ -32,5 +33,8 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
     NO_SIGNATURE_CHECKS,
     OkHttpClient(),
   )
-  return loader.loadOnce("trivia", manifestUrl).zipline
+  return when (val result = loader.loadOnce("trivia", manifestUrl)) {
+    is LoadResult.Success -> result.zipline
+    is LoadResult.Failure -> error(result.exception)
+  }
 }


### PR DESCRIPTION
This is an amazing project, When i try to compile trivia-sample using `./gradlew -p samples trivia:trivia-host:shadowJar`,  I got the following error：

> Task :trivia:trivia-host:compileKotlin FAILED
e: /Users/lenox/AndroidStudioProjects/lenox-zipline/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt: (35, 49): Unresolved reference: zipline

I fixed it and it works now，Please review the code.