### PR TITLE
Fix the jar name of trivia-host in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ development server!
 
 ```console
 $ ./gradlew -p samples trivia:trivia-host:shadowJar
-java -jar samples/trivia/trivia-host/build/libs/trivia-host-1.0.0-SNAPSHOT-all.jar
+java -jar samples/trivia/trivia-host/build/libs/trivia-host-all.jar
 ```
 
 


### PR DESCRIPTION
When running `./gradlew -p samples trivia:trivia-host:shadowJar`, **trivia-host-all.jar** is generated instead of **trivia-host-1.0.0-SNAPSHOT-all.jar**.