### PR TITLE
Add websocket for hot reload

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,9 +29,9 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.2.0" }
 cklib-gradle-plugin = { module = "co.touchlab:cklib-gradle-plugin", version = "0.2.4" }
 coil-compose = { module = "io.coil-kt:coil-compose", version = "1.3.2" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
-duktape = { module = "com.squareup.duktape:duktape-android", version = "1.4.0" }
-http4k-core = { module = "org.http4k:http4k-core", version = "http4k" }
-http4k-server-jetty = { module = "org.http4k:http4k-server-jetty", version = "http4k" }
+duktape = { module = "com.squareup.duktape:duktape-android", version.ref = "1.4.0" }
+http4k-core = { module = "org.http4k:http4k-core", version.ref = "http4k" }
+http4k-server-jetty = { module = "org.http4k:http4k-server-jetty", version.ref = "http4k" }
 http4k-client-websocket = { module = "org.http4k:http4k-client-websocket", version = "http4k" }
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidx-compose = "1.3.0-alpha01"
 androidx-compose-compiler = "1.3.0-beta01"
 compileSdk = "32"
+http4k = "4.27.4.0"
 kotlin = "1.7.10"
 kotlinx-coroutines = "1.6.3-native-mt"
 kotlinx-serialization = "1.4.0"
@@ -29,7 +30,9 @@ cklib-gradle-plugin = { module = "co.touchlab:cklib-gradle-plugin", version = "0
 coil-compose = { module = "io.coil-kt:coil-compose", version = "1.3.2" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
 duktape = { module = "com.squareup.duktape:duktape-android", version = "1.4.0" }
-http4k-core = { module = "org.http4k:http4k-core", version = "4.27.4.0" }
+http4k-core = { module = "org.http4k:http4k-core", version = "http4k" }
+http4k-server-jetty = { module = "org.http4k:http4k-server-jetty", version = "http4k" }
+http4k-client-websocket = { module = "org.http4k:http4k-client-websocket", version = "http4k" }
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,10 +29,10 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.2.0" }
 cklib-gradle-plugin = { module = "co.touchlab:cklib-gradle-plugin", version = "0.2.4" }
 coil-compose = { module = "io.coil-kt:coil-compose", version = "1.3.2" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.10" }
-duktape = { module = "com.squareup.duktape:duktape-android", version.ref = "1.4.0" }
+duktape = { module = "com.squareup.duktape:duktape-android", version = "1.4.0" }
 http4k-core = { module = "org.http4k:http4k-core", version.ref = "http4k" }
 http4k-server-jetty = { module = "org.http4k:http4k-server-jetty", version.ref = "http4k" }
-http4k-client-websocket = { module = "org.http4k:http4k-client-websocket", version = "http4k" }
+http4k-client-websocket = { module = "org.http4k:http4k-client-websocket", version.ref = "http4k" }
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }

--- a/zipline-gradle-plugin/build.gradle.kts
+++ b/zipline-gradle-plugin/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
   implementation(projects.ziplineBytecode)
   implementation(projects.ziplineLoader)
   implementation(libs.http4k.core)
+  implementation(libs.http4k.server.jetty)
+  implementation(libs.http4k.client.websocket)
   implementation(libs.kotlin.gradle.plugin)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.okHttp.core)


### PR DESCRIPTION
Switches from Sun to Jetty server to add websocket serve capabilities. When a Kotlin file is changed a build will be triggered, executing this task. If the server hasn't been started, we will start it. If the server is up already, then we will instead send a websocket message to all connections letting them know that an update is available and they should reload the manifest.

Use of the websocket connection is entirely optional and will just provide a slightly faster hot reload experience. Callers can still poll the manifest (and should fall back to this if the websocket connection fails).