### PR TITLE
Make events more complete

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -287,7 +287,7 @@ class ZiplineLoader internal constructor(
     flowOf(manifestUrl),
     serializersModule,
     initializer
-  ).firstOrNull() ?: throw IllegalStateException("loading failed; see EventListener for exceptions")
+  ).first()
 
   /**
    * After identifying a manifest to load this fetches all the code, loads it into a JS runtime,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -31,6 +31,7 @@ import app.cash.zipline.loader.internal.systemEpochMsClock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -164,51 +165,115 @@ class ZiplineLoader internal constructor(
         //  - skip if the manifest hasn't changed from the previous load.
         //  - pin the application if the load succeeded; unpin if it failed.
         val now = nowEpochMs()
-        withLifecycleEvents(applicationName, manifestUrl) {
-          val networkManifest = fetchManifestFromNetwork(applicationName, manifestUrl)
-          if (networkManifest.manifest == previousManifest) {
-            // Unchanged. Update freshness timestamp in cache DB.
-            cachingFetcher?.updateFreshAt(applicationName, networkManifest, now)
-            return@withLifecycleEvents
-          }
 
-          try {
-            val networkZipline = loadFromManifest(
-              applicationName,
-              networkManifest,
-              serializersModule,
-              now,
-              initializer,
-            )
-            cachingFetcher?.pin(applicationName, networkManifest, now) // Pin after success.
-            send(LoadResult.Success(networkZipline, networkManifest.freshAtEpochMs))
-            previousManifest = networkManifest.manifest
-          } catch (e: Exception) {
-            cachingFetcher?.unpin(applicationName, networkManifest, now) // Unpin after failure.
-            send(LoadResult.Failure(e))
-            // This thrown exception is caught and not rethrown by withLifecycleEvents
-            throw e
-          }
+        val loadedFromNetwork = loadFromNetwork(
+          previousManifest,
+          now,
+          applicationName,
+          manifestUrl,
+          serializersModule,
+          initializer,
+        )
+        if (loadedFromNetwork != null) {
+          previousManifest = loadedFromNetwork
         }
 
         // If network loading failed (due to network error, or bad code), attempt to load from the
         // cache or embedded file system. This doesn't update pins!
         if (previousManifest == null && isFirstLoad) {
           isFirstLoad = false
-          val localManifest = loadCachedOrEmbeddedManifest(applicationName, now) ?: return@collect
-          withLifecycleEvents(applicationName, manifestUrl = null) {
-            val localZipline = loadFromManifest(
-              applicationName,
-              localManifest,
-              serializersModule,
-              now,
-              initializer,
-            )
-            send(LoadResult.Success(localZipline, localManifest.freshAtEpochMs))
-            previousManifest = localManifest.manifest
+          val loadedFromLocal = loadFromLocal(
+            now,
+            applicationName,
+            serializersModule,
+            initializer,
+          )
+          if (loadedFromLocal != null) {
+            previousManifest = loadedFromLocal
           }
         }
       }
+    }
+  }
+
+  private suspend fun ProducerScope<LoadResult>.loadFromNetwork(
+    previousManifest: ZiplineManifest?,
+    now: Long,
+    applicationName: String,
+    manifestUrl: String,
+    serializersModule: SerializersModule,
+    initializer: (Zipline) -> Unit,
+  ): ZiplineManifest? {
+    val startValue = eventListener.applicationLoadStart(applicationName, manifestUrl)
+    var loadedManifest: LoadedManifest? = null
+
+    try {
+      loadedManifest = fetchManifestFromNetwork(applicationName, manifestUrl)
+      if (loadedManifest.manifest == previousManifest) {
+        // Unchanged. Update freshness timestamp in cache DB.
+        cachingFetcher?.updateFreshAt(applicationName, loadedManifest, now)
+        eventListener.applicationLoadSkipped(applicationName, manifestUrl, startValue)
+        return null
+      }
+
+      val zipline = loadFromManifest(
+        applicationName,
+        loadedManifest,
+        serializersModule,
+        now,
+        initializer,
+      )
+      cachingFetcher?.pin(applicationName, loadedManifest, now) // Pin after success.
+      eventListener.applicationLoadSuccess(applicationName, manifestUrl, zipline, startValue)
+      send(LoadResult.Success(zipline, loadedManifest.freshAtEpochMs))
+      return loadedManifest.manifest
+
+    } catch (e: CancellationException) {
+      // If emit() threw a CancellationException, consider that emit to be successful.
+      // That's 'cause loadOnce() accepts an element and then immediately cancels the flow.
+      throw e
+
+    } catch (e: Exception) {
+      eventListener.applicationLoadFailed(applicationName, manifestUrl, e, startValue)
+      if (loadedManifest != null) {
+        cachingFetcher?.unpin(applicationName, loadedManifest, now) // Unpin after failure.
+      }
+      send(LoadResult.Failure(e))
+      return null
+    }
+  }
+
+  private suspend fun ProducerScope<LoadResult>.loadFromLocal(
+    now: Long,
+    applicationName: String,
+    serializersModule: SerializersModule,
+    initializer: (Zipline) -> Unit,
+  ): ZiplineManifest? {
+    val loadedManifest = loadCachedOrEmbeddedManifest(applicationName, now)
+      ?: return null
+
+    val startValue = eventListener.applicationLoadStart(applicationName, null)
+    try {
+      val zipline = loadFromManifest(
+        applicationName,
+        loadedManifest,
+        serializersModule,
+        now,
+        initializer,
+      )
+      eventListener.applicationLoadSuccess(applicationName, null, zipline, startValue)
+      send(LoadResult.Success(zipline, loadedManifest.freshAtEpochMs))
+      return loadedManifest.manifest
+
+    } catch (e: CancellationException) {
+      // If emit() threw a CancellationException, consider that emit to be successful.
+      // That's 'cause loadOnce() accepts an element and then immediately cancels the flow.
+      throw e
+
+    } catch (e: Exception) {
+      send(LoadResult.Failure(e))
+      eventListener.applicationLoadFailed(applicationName, null, e, startValue)
+      return null
     }
   }
 
@@ -341,26 +406,6 @@ class ZiplineLoader internal constructor(
       withContext(dispatcher) {
         receiver.receive(byteString, id, module.sha256)
       }
-    }
-  }
-
-  /** Wrap [block] in start/end/failed events, recovering gracefully if a flow is canceled. */
-  private suspend fun withLifecycleEvents(
-    applicationName: String,
-    manifestUrl: String?,
-    block: suspend () -> Unit,
-  ) {
-    val startValue = eventListener.applicationLoadStart(applicationName, manifestUrl)
-    try {
-      block()
-      eventListener.applicationLoadEnd(applicationName, manifestUrl, startValue)
-    } catch (e: CancellationException) {
-      // If emit() threw a CancellationException, consider that emit to be successful.
-      // That's 'cause loadOnce() accepts an element and then immediately cancels the flow.
-      eventListener.applicationLoadEnd(applicationName, manifestUrl, startValue)
-      throw e
-    } catch (e: Exception) {
-      eventListener.applicationLoadFailed(applicationName, manifestUrl, e, startValue)
     }
   }
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import okio.IOException
 
@@ -51,7 +52,28 @@ class LoaderEventsTest {
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/apple.zipline",
         "downloadEnd red https://example.com/files/red/apple.zipline",
-        "applicationLoadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "applicationLoadSuccess red https://example.com/files/red/red.manifest.zipline.json",
+      ),
+      eventListener.takeAll(skipServiceEvents = true)
+    )
+  }
+
+  @Test
+  fun loadSkippedIfManifestHasNotChanged() = runBlocking {
+    val flow = tester.load("red", "apple", count = 2)
+    assertEquals(1, flow.toList().size)
+    assertEquals(
+      listOf(
+        "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
+        "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
+        "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "downloadStart red https://example.com/files/red/apple.zipline",
+        "downloadEnd red https://example.com/files/red/apple.zipline",
+        "applicationLoadSuccess red https://example.com/files/red/red.manifest.zipline.json",
+        "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
+        "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
+        "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "applicationLoadSkipped red https://example.com/files/red/red.manifest.zipline.json",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )
@@ -69,7 +91,7 @@ class LoaderEventsTest {
         "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
-        "applicationLoadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "applicationLoadSuccess red https://example.com/files/red/red.manifest.zipline.json",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )
@@ -88,7 +110,7 @@ class LoaderEventsTest {
         "applicationLoadFailed red " +
           "${IOException::class.qualifiedName}: 404: https://example.com/files/red/red.manifest.zipline.json not found",
         "applicationLoadStart red null",
-        "applicationLoadEnd red null",
+        "applicationLoadSuccess red null",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )
@@ -109,7 +131,7 @@ class LoaderEventsTest {
         "applicationLoadFailed red " +
           "${IOException::class.qualifiedName}: 404: https://example.com/files/red/unreachable.zipline not found",
         "applicationLoadStart red null",
-        "applicationLoadEnd red null",
+        "applicationLoadSuccess red null",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )
@@ -128,7 +150,7 @@ class LoaderEventsTest {
         "downloadEnd red https://example.com/files/red/broken.zipline",
         "applicationLoadFailed red app.cash.zipline.QuickJsException: broken",
         "applicationLoadStart red null",
-        "applicationLoadEnd red null",
+        "applicationLoadSuccess red null",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )
@@ -147,7 +169,7 @@ class LoaderEventsTest {
         "downloadEnd red https://example.com/files/red/crashes.zipline",
         "applicationLoadFailed red ${IllegalArgumentException::class.qualifiedName}: Zipline code run failed",
         "applicationLoadStart red null",
-        "applicationLoadEnd red null",
+        "applicationLoadSuccess red null",
       ),
       eventListener.takeAll(skipServiceEvents = true)
     )

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
@@ -120,12 +120,16 @@ class ZiplineLoaderSigningTest {
       alphaUrl to testFixtures.alphaByteString,
       bravoUrl to testFixtures.bravoByteString,
     )
-    val exception = assertFailsWith<IllegalStateException> {
-      tester.loader.loadOnce("test", manifestUrl)
-    }
-    assertEquals("loading failed; see EventListener for exceptions", exception.message)
+    val loadResult = tester.loader.loadOnce("test", manifestUrl)
+    assertEquals(
+      "manifest signature for key key1 did not verify!",
+      (loadResult as LoadResult.Failure).exception.message
+    )
     val listenerException = eventListener.takeException()
     assertTrue(listenerException is IllegalStateException)
-    assertEquals("manifest signature for key key1 did not verify!", listenerException.message)
+    assertEquals(
+      "manifest signature for key key1 did not verify!",
+      listenerException.message,
+    )
   }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
@@ -24,11 +24,11 @@ package app.cash.zipline
  */
 abstract class EventListener {
   /** Invoked when something calls [Zipline.bind], or a service is sent via an API. */
-  open fun bindService(name: String, service: ZiplineService) {
+  open fun bindService(zipline: Zipline, name: String, service: ZiplineService) {
   }
 
   /** Invoked when something calls [Zipline.take], or a service is received via an API. */
-  open fun takeService(name: String, service: ZiplineService) {
+  open fun takeService(zipline: Zipline, name: String, service: ZiplineService) {
   }
 
   /**
@@ -38,7 +38,7 @@ abstract class EventListener {
    * @return any object. This value will be passed back to [callEnd] when the call is completed. The
    *   base function always returns null.
    */
-  open fun callStart(call: Call): Any? {
+  open fun callStart(zipline: Zipline, call: Call): Any? {
     return null
   }
 
@@ -48,11 +48,11 @@ abstract class EventListener {
    * @param startValue the value returned by [callStart] for the start of this call. This is null
    *   unless [callStart] is overridden to return something else.
    */
-  open fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+  open fun callEnd(zipline: Zipline, call: Call, result: CallResult, startValue: Any?) {
   }
 
   /** Invoked when a service is garbage collected without being closed. */
-  open fun serviceLeaked(name: String) {
+  open fun serviceLeaked(zipline: Zipline, name: String) {
   }
 
   /**
@@ -69,14 +69,28 @@ abstract class EventListener {
   }
 
   /**
+   * Invoked when an application load was skipped because the code is unchanged.
+   *
+   * @param startValue the value returned by [applicationLoadStart] for the start of this call. This
+   *   is null unless [applicationLoadStart] is overridden to return something else.
+   */
+  open fun applicationLoadSkipped(
+    applicationName: String,
+    manifestUrl: String,
+    startValue: Any?,
+  ) {
+  }
+
+  /**
    * Invoked when an application load succeeds.
    *
    * @param startValue the value returned by [applicationLoadStart] for the start of this call. This
    *   is null unless [applicationLoadStart] is overridden to return something else.
    */
-  open fun applicationLoadEnd(
+  open fun applicationLoadSuccess(
     applicationName: String,
     manifestUrl: String?,
+    zipline: Zipline,
     startValue: Any?,
   ) {
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.internal.bridge
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.passByReferencePrefix
 import app.cash.zipline.ziplineServiceSerializer
@@ -32,7 +31,7 @@ import kotlinx.serialization.modules.SerializersModule
 class Endpoint internal constructor(
   internal val scope: CoroutineScope,
   internal val userSerializersModule: SerializersModule,
-  internal val eventListener: EventListener,
+  internal val eventListener: EndpointEventListener,
   internal val outboundChannel: CallChannel,
 ) {
   internal val inboundServices = mutableMapOf<String, InboundService<*>>()

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/events.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/events.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
+import app.cash.zipline.EventListener
+import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineService
+
+interface EndpointEventListener {
+  fun bindService(name: String, service: ZiplineService)
+  fun takeService(name: String, service: ZiplineService)
+  fun serviceLeaked(name: String)
+  fun callStart(call: Call): Any?
+  fun callEnd(call: Call, result: CallResult, startValue: Any?)
+}
+
+/** Adapts the endpoint listener to add a constant Zipline parameter. */
+class EventListenerAdapter(
+  val delegate: EventListener,
+  val zipline: Zipline,
+) : EndpointEventListener {
+  override fun bindService(name: String, service: ZiplineService) {
+    delegate.bindService(zipline, name, service)
+  }
+
+  override fun takeService(name: String, service: ZiplineService) {
+    delegate.takeService(zipline, name, service)
+  }
+
+  override fun serviceLeaked(name: String) {
+    delegate.serviceLeaked(zipline, name)
+  }
+
+  override fun callStart(call: Call): Any? {
+    return delegate.callStart(zipline, call)
+  }
+
+  override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+    delegate.callEnd(zipline, call, result, startValue)
+  }
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/leakCanary.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/leakCanary.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.internal.bridge
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 
 /**
@@ -23,7 +22,7 @@ import app.cash.zipline.ZiplineService
  * closed.
  */
 internal expect fun trackLeaks(
-  eventListener: EventListener,
+  eventListener: EndpointEventListener,
   serviceName: String,
   callHandler: OutboundCallHandler,
   service: ZiplineService

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -15,9 +15,12 @@
  */
 package app.cash.zipline.testing
 
-import app.cash.zipline.EventListener
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
+import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
+import app.cash.zipline.internal.bridge.EndpointEventListener
 import kotlin.jvm.JvmOverloads
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -28,8 +31,8 @@ import kotlinx.serialization.modules.SerializersModule
 internal fun newEndpointPair(
   scope: CoroutineScope,
   serializersModule: SerializersModule = EmptySerializersModule(),
-  listenerA: EventListener = EventListener.NONE,
-  listenerB: EventListener = EventListener.NONE,
+  listenerA: EndpointEventListener = nullEndpointEventListener,
+  listenerB: EndpointEventListener = nullEndpointEventListener,
 ): Pair<Endpoint, Endpoint> {
   val pair = object : Any() {
     val a: Endpoint = Endpoint(scope, serializersModule, listenerA, object : CallChannel {
@@ -50,4 +53,20 @@ internal fun newEndpointPair(
   }
 
   return pair.a to pair.b
+}
+
+val nullEndpointEventListener = object : EndpointEventListener {
+  override fun bindService(name: String, service: ZiplineService) {
+  }
+
+  override fun takeService(name: String, service: ZiplineService) {
+  }
+
+  override fun serviceLeaked(name: String) {
+  }
+
+  override fun callStart(call: Call): Any? = null
+
+  override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+  }
 }

--- a/zipline/src/engineMain/kotlin/app/cash/zipline/internal/HostEventListenerService.kt
+++ b/zipline/src/engineMain/kotlin/app/cash/zipline/internal/HostEventListenerService.kt
@@ -16,11 +16,13 @@
 package app.cash.zipline.internal
 
 import app.cash.zipline.EventListener
+import app.cash.zipline.Zipline
 
 internal class HostEventListenerService(
+  private val zipline: Zipline,
   private val eventListener: EventListener,
 ) : EventListenerService {
   override fun serviceLeaked(name: String) {
-    eventListener.serviceLeaked(name)
+    eventListener.serviceLeaked(zipline, name)
   }
 }

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -358,12 +358,12 @@ internal class EventListenerEndpointTest {
     val calls = ArrayDeque<Call>()
     val results = ArrayDeque<CallResult>()
 
-    override fun callStart(call: Call): Any? {
+    override fun callStart(zipline: Zipline, call: Call): Any? {
       calls += call
       return null
     }
 
-    override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+    override fun callEnd(zipline: Zipline, call: Call, result: CallResult, startValue: Any?) {
       results += result
     }
   }

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -16,6 +16,7 @@
 
 package app.cash.zipline
 
+import app.cash.zipline.internal.bridge.EndpointEventListener
 import app.cash.zipline.testing.EchoRequest
 import app.cash.zipline.testing.EchoResponse
 import app.cash.zipline.testing.EchoService
@@ -354,17 +355,26 @@ internal class EventListenerEndpointTest {
     fun transform(prefix: String, service: EchoService): EchoService
   }
 
-  class CallListener : EventListener() {
+  class CallListener : EndpointEventListener {
     val calls = ArrayDeque<Call>()
     val results = ArrayDeque<CallResult>()
 
-    override fun callStart(zipline: Zipline, call: Call): Any? {
+    override fun callStart(call: Call): Any? {
       calls += call
       return null
     }
 
-    override fun callEnd(zipline: Zipline, call: Call, result: CallResult, startValue: Any?) {
+    override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
       results += result
+    }
+
+    override fun bindService(name: String, service: ZiplineService) {
+    }
+
+    override fun takeService(name: String, service: ZiplineService) {
+    }
+
+    override fun serviceLeaked(name: String) {
     }
   }
 }

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
@@ -15,14 +15,13 @@
  */
 package app.cash.zipline.internal.bridge
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 import java.lang.ref.PhantomReference
 import java.lang.ref.ReferenceQueue
 import java.util.Collections.synchronizedSet
 
 internal actual fun trackLeaks(
-  eventListener: EventListener,
+  eventListener: EndpointEventListener,
   serviceName: String,
   callHandler: OutboundCallHandler,
   service: ZiplineService
@@ -44,7 +43,7 @@ private val allReferencesSet = synchronizedSet(mutableSetOf<ZiplineServiceRefere
 private val allReferencesQueue = ReferenceQueue<ZiplineService>()
 
 private class ZiplineServiceReference(
-  private val eventListener: EventListener,
+  private val eventListener: EndpointEventListener,
   private val serviceName: String,
   private val callHandler: OutboundCallHandler,
   service: ZiplineService

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJs.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.internal.bridge
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 
 private val referenceQueue: dynamic = js("""[]""")
@@ -33,7 +32,7 @@ internal val registry = run {
 }
 
 internal actual fun trackLeaks(
-  eventListener: EventListener,
+  eventListener: EndpointEventListener,
   serviceName: String,
   callHandler: OutboundCallHandler,
   service: ZiplineService
@@ -49,7 +48,7 @@ internal actual fun detectLeaks() {
 }
 
 private class ZiplineServiceReference(
-  private val eventListener: EventListener,
+  private val eventListener: EndpointEventListener,
   private val name: String,
   private val callHandler: OutboundCallHandler,
 ) {

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryNative.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryNative.kt
@@ -15,11 +15,10 @@
  */
 package app.cash.zipline.internal.bridge
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.ZiplineService
 
 internal actual fun trackLeaks(
-  eventListener: EventListener,
+  eventListener: EndpointEventListener,
   serviceName: String,
   callHandler: OutboundCallHandler,
   service: ZiplineService

--- a/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -18,6 +18,7 @@ package app.cash.zipline.testing
 import app.cash.zipline.Call
 import app.cash.zipline.CallResult
 import app.cash.zipline.EventListener
+import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.internal.bridge.CancelCallback
 import app.cash.zipline.internal.bridge.SuspendCallback
@@ -27,7 +28,7 @@ class LoggingEventListener : EventListener() {
   private var nextCallId = 1
   private val log = ArrayDeque<LogEntry>()
 
-  override fun bindService(name: String, service: ZiplineService) {
+  override fun bindService(zipline: Zipline, name: String, service: ZiplineService) {
     log(
       service = service,
       serviceName = name,
@@ -35,7 +36,7 @@ class LoggingEventListener : EventListener() {
     )
   }
 
-  override fun takeService(name: String, service: ZiplineService) {
+  override fun takeService(zipline: Zipline, name: String, service: ZiplineService) {
     log(
       service = service,
       serviceName = name,
@@ -43,7 +44,7 @@ class LoggingEventListener : EventListener() {
     )
   }
 
-  override fun callStart(call: Call): Any {
+  override fun callStart(zipline: Zipline, call: Call): Any {
     val callId = nextCallId++
     log(
       service = call.service,
@@ -53,7 +54,7 @@ class LoggingEventListener : EventListener() {
     return callId
   }
 
-  override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+  override fun callEnd(zipline: Zipline, call: Call, result: CallResult, startValue: Any?) {
     log(
       service = call.service,
       serviceName = call.serviceName,
@@ -62,7 +63,7 @@ class LoggingEventListener : EventListener() {
     )
   }
 
-  override fun serviceLeaked(name: String) {
+  override fun serviceLeaked(zipline: Zipline, name: String) {
     log(
       serviceName = name,
       log = "serviceLeaked $name"
@@ -76,10 +77,26 @@ class LoggingEventListener : EventListener() {
     )
   }
 
-  override fun applicationLoadEnd(applicationName: String, manifestUrl: String?, startValue: Any?) {
+  override fun applicationLoadSuccess(
+    applicationName: String,
+    manifestUrl: String?,
+    zipline: Zipline,
+    startValue: Any?
+  ) {
     log(
       applicationName = applicationName,
-      log = "applicationLoadEnd $applicationName $manifestUrl"
+      log = "applicationLoadSuccess $applicationName $manifestUrl"
+    )
+  }
+
+  override fun applicationLoadSkipped(
+    applicationName: String,
+    manifestUrl: String,
+    startValue: Any?
+  ) {
+    log(
+      applicationName = applicationName,
+      log = "applicationLoadSkipped $applicationName $manifestUrl"
     )
   }
 


### PR DESCRIPTION
This adds a new 'Zipline' parameter to the EventListener where appropriate. I'm hoping we can use this to track which Zipline instance an event came through in applications where there is more than one.

This also adds an event when the load is skipped because that code is unchanged. This fixes a small bug where we emitted a start event but not an end event.