### PR TITLE
Update ZiplineServeTask inputDir to an input directory.

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineServeTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineServeTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.deployment.internal.Deployment
@@ -43,7 +44,7 @@ import org.http4k.websocket.WsMessage
 
 abstract class ZiplineServeTask : DefaultTask() {
 
-  @get:Input
+  @get:InputDirectory
   abstract val inputDir: DirectoryProperty
 
   @get:Optional


### PR DESCRIPTION
Pretty sure this is required for compatibility with Gradle 7.6. Updating Redwood to use 7.6 caused `serveZipline` to [not watch any directories](https://github.com/cashapp/redwood/pull/554#issuecomment-1328442887).