### PR TITLE
Workaround missing libtinfo.so.5 on Ubuntu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,10 +53,12 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: ./.github/workflows/build-mac.sh -a ${{ matrix.arch }} -c ${{ matrix.cmake-arch }}
 
+      - name: Install libtinfo5
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y libtinfo5
+
       # Build unless this is a cross-compile.
-      - run: |
-          sudo apt-get install -y libtinfo5
-          ./gradlew build --stacktrace
+      - run: ./gradlew build --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,9 @@ jobs:
         run: ./.github/workflows/build-mac.sh -a ${{ matrix.arch }} -c ${{ matrix.cmake-arch }}
 
       # Build unless this is a cross-compile.
-      - run: ./gradlew build --stacktrace
+      - run: |
+          sudo apt-get install -y libtinfo5
+          ./gradlew build --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,10 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: ./.github/workflows/build-mac.sh -a ${{ matrix.arch }} -c ${{ matrix.cmake-arch }}
 
+      - name: Install libtinfo5
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y libtinfo5
+
       # Build unless this is a cross-compile.
       - run: ./gradlew build --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'


### PR DESCRIPTION
We're getting this crash in our cklib builds:

    /home/runner/.cklib/clang-llvm-8.0.0-linux-x86-64/bin/clang: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory

StackOverflow suggests this might fix.