### PR TITLE
Don't crash in RealSuspendCallback.toString()

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/EventListener.kt
@@ -162,8 +162,8 @@ abstract class EventListener {
   /**
    * Invoked when a module load starts. This is the process of loading code into QuickJS.
    *
-   * @return any object. This value will be passed back to [callEnd] when the call is completed. The
-   *   base function always returns null.
+   * @return any object. This value will be passed back to [moduleLoadEnd] when the call is
+   *   completed. The base function always returns null.
    */
   open fun moduleLoadStart(zipline: Zipline, moduleId: String): Any? {
     return null

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -79,8 +79,8 @@ internal class OutboundCallHandler(
       suspendCallback = suspendCallback,
       args = argsList,
     )
-    val externalCall = endpoint.callCodec.encodeCall(internalCall, service)
     suspendCallback.internalCall = internalCall
+    val externalCall = endpoint.callCodec.encodeCall(internalCall, service)
     suspendCallback.externalCall = externalCall
     suspendCallback.callStart = endpoint.eventListener.callStart(externalCall)
 

--- a/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline/testing/src/engineMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -177,6 +177,21 @@ class LoggingEventListener : EventListener() {
     skipApplicationEvents: Boolean = false,
     skipInternalServices: Boolean = true,
   ): String {
+    val entry = takeEntry(
+      skipModuleEvents,
+      skipServiceEvents,
+      skipApplicationEvents,
+      skipInternalServices,
+    )
+    return entry.log
+  }
+
+  fun takeEntry(
+    skipModuleEvents: Boolean = false,
+    skipServiceEvents: Boolean = false,
+    skipApplicationEvents: Boolean = false,
+    skipInternalServices: Boolean = true,
+  ): LogEntry {
     while (true) {
       val entry = log.removeFirst()
       if (
@@ -187,7 +202,7 @@ class LoggingEventListener : EventListener() {
           skipInternalServices = skipInternalServices,
         )
       ) {
-        return entry.log
+        return entry
       }
     }
   }
@@ -231,14 +246,24 @@ class LoggingEventListener : EventListener() {
     exception: Exception? = null,
     log: String,
   ) {
+    service.toString()
     val isInternalService = service is CancelCallback ||
       service is SuspendCallback<*> ||
       serviceName?.startsWith(ziplineInternalPrefix) == true
-    this.log += LogEntry(moduleId, serviceName, applicationName, isInternalService, exception, log)
+    this.log += LogEntry(
+      moduleId = moduleId,
+      serviceToString = service?.toString(),
+      serviceName = serviceName,
+      applicationName = applicationName,
+      isInternalService = isInternalService,
+      exception = exception,
+      log = log,
+    )
   }
 
   data class LogEntry(
     val moduleId: String?,
+    val serviceToString: String?,
     val serviceName: String?,
     val applicationName: String?,
     val isInternalService: Boolean,


### PR DESCRIPTION
It was attempting to toString() the lateInit internalCall.