### PR TITLE
Add serviceName to ZiplineApiMismatchException message.

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
@@ -192,6 +192,9 @@ internal class RealCallSerializer(
         endpoint.inboundServices.keys.joinTo(this, separator = "\n") { "\t\t$it" }
       } else {
         appendLine("no such method (incompatible API versions?)")
+        appendLine("\tcalled service:")
+        append("\t\t")
+        appendLine(serviceName)
         appendLine("\tcalled function:")
         append("\t\t")
         appendLine(functionName)

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -125,7 +125,7 @@ internal class ZiplineServiceTest {
     val failure = assertFailsWith<ZiplineApiMismatchException> {
       helloService.echo(EchoRequest("Jake"))
     }
-    assertTrue("no such service" in (failure.message ?: ""), failure.message)
+    assertTrue("no such service" in failure.message, failure.message)
     assertEquals(setOf("factory"), endpointA.serviceNames)
   }
 

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
@@ -132,6 +132,8 @@ class EventListenerTest {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
+      	called service:
+      		helloService
       	called function:
       		fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -217,8 +217,8 @@ class ZiplineTest {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
-        called service:
-          helloService
+      	called service:
+      		helloService
       	called function:
       		fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -236,8 +236,8 @@ class ZiplineTest {
       zipline.take<SuspendingPotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
-        called service:
-          helloService
+      	called service:
+      		helloService
       	called function:
       		suspend fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -255,8 +255,8 @@ class ZiplineTest {
       zipline.quickJs.evaluate("testing.app.cash.zipline.testing.callSupService('homie')")
     }).hasMessageThat().startsWith("""
       app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
-        called service:
-          supService
+      	called service:
+      		supService
       	called function:
       		fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -276,8 +276,8 @@ class ZiplineTest {
     assertThat(zipline.quickJs.evaluate("testing.app.cash.zipline.testing.suspendingPotatoException") as String?)
       .startsWith("""
         ZiplineApiMismatchException: app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
-          called service:
-            jvmSuspendingPotatoService
+        	called service:
+        		jvmSuspendingPotatoService
         	called function:
         		suspend fun echo(): app.cash.zipline.testing.EchoResponse
         	available functions:

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -217,6 +217,8 @@ class ZiplineTest {
       zipline.take<PotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
+        called service:
+          helloService
       	called function:
       		fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -234,6 +236,8 @@ class ZiplineTest {
       zipline.take<SuspendingPotatoService>("helloService").echo()
     }).hasMessageThat().startsWith("""
       no such method (incompatible API versions?)
+        called service:
+          helloService
       	called function:
       		suspend fun echo(): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -251,6 +255,8 @@ class ZiplineTest {
       zipline.quickJs.evaluate("testing.app.cash.zipline.testing.callSupService('homie')")
     }).hasMessageThat().startsWith("""
       app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
+        called service:
+          supService
       	called function:
       		fun echo(app.cash.zipline.testing.EchoRequest): app.cash.zipline.testing.EchoResponse
       	available functions:
@@ -270,6 +276,8 @@ class ZiplineTest {
     assertThat(zipline.quickJs.evaluate("testing.app.cash.zipline.testing.suspendingPotatoException") as String?)
       .startsWith("""
         ZiplineApiMismatchException: app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
+          called service:
+            jvmSuspendingPotatoService
         	called function:
         		suspend fun echo(): app.cash.zipline.testing.EchoResponse
         	available functions:


### PR DESCRIPTION
Adds the service name to the `ZiplineApiMismatchException`. I can change this to use the class name instead, though we'll have to serialize the class name for that. Wanted to double check before making that change.

Resolves https://github.com/cashapp/zipline/issues/770.