### PR TITLE
Make close idempotent from the outbound side

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -54,9 +54,13 @@ internal class OutboundCallHandler(
   ): Any? {
     val function = functionsList[functionIndex] as ReturningZiplineFunction<*>
     if (function.isClose) {
+      if (closed) return Unit // ZiplineService.close() is idempotent.
       closed = true
       scope.remove(this)
+    } else {
+      check(!closed) { "$serviceName is closed" }
     }
+
     val argsList = args.toList()
     val internalCall = InternalCall(
       serviceName = serviceName,
@@ -89,6 +93,8 @@ internal class OutboundCallHandler(
     functionIndex: Int,
     vararg args: Any?,
   ): Any? {
+    check(!closed) { "$serviceName is closed" }
+
     val function = functionsList[functionIndex] as SuspendingZiplineFunction<*>
     val argsList = args.toList()
     val suspendCallback = RealSuspendCallback<Any?>()

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -24,7 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
@@ -122,10 +121,10 @@ internal class ZiplineServiceTest {
 
     assertEquals(EchoResponse("hello Jesse"), helloService.echo(EchoRequest("Jesse")))
     helloService.close()
-    val failure = assertFailsWith<ZiplineApiMismatchException> {
+    val failure = assertFailsWith<IllegalStateException> {
       helloService.echo(EchoRequest("Jake"))
     }
-    assertTrue("no such service" in failure.message, failure.message)
+    assertEquals("zipline/host-1 is closed", failure.message)
     assertEquals(setOf("factory"), endpointA.serviceNames)
   }
 


### PR DESCRIPTION
This improves the error messages, which otherwise say "unknown service" when they should say "closed service".