### PR TITLE
Use ZiplineScope (only) to close flows

### DIFF
--- a/zipline/src/engineTest/kotlin/app/cash/zipline/testUtilEngine.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/testUtilEngine.kt
@@ -21,17 +21,22 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Yields until [condition] returns true.
+ * Yields until [expected] equals the result of [actual].
  *
  * Use this to assert asynchronously triggered side effects, such as resource cleanups.
  */
-suspend fun awaitCondition(condition: () -> Boolean) {
-  if (condition()) return
+suspend fun awaitEquals(
+  expected: Any?,
+  actual: () -> Any?
+) {
+  var actualValue = actual()
+  if (expected == actualValue) return
   for (i in 0 until 5) {
     yield()
-    if (condition()) return
+    actualValue = actual()
+    if (expected == actualValue) return
   }
-  throw AssertionError("gave up waiting for condition")
+  throw AssertionError("$expected != $actualValue")
 }
 
 fun prettyPrint(jsonString: String): String {


### PR DESCRIPTION
Previously we required Flows to be collected exactly 1x. This ends up being a challenge at the application layer, where the Flow interface doesn't generally make such a requirement.

With this change flows can be collected any number of times, including zero. Callers are responsible for closing the scopes.