### PR TITLE
Don't store .zipline files in the HTTP cache

### DIFF
--- a/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
@@ -34,7 +34,10 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   // A fake HTTP client that returns files as the Webpack dev server would return them.
   val localDirectoryHttpClient = object : ZiplineHttpClient {
     val base = "build/compileSync/main/productionExecutable/kotlinZipline".toPath()
-    override suspend fun download(url: String): ByteString {
+    override suspend fun download(
+      url: String,
+      requestHeaders: List<Pair<String, String>>,
+    ): ByteString {
       val file = url.substringAfterLast("/")
       return FileSystem.SYSTEM.read(base / file) { readByteString() }
     }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
@@ -18,5 +18,5 @@ package app.cash.zipline.loader
 import okio.ByteString
 
 interface ZiplineHttpClient {
-  suspend fun download(url: String): ByteString
+  suspend fun download(url: String, requestHeaders: List<Pair<String, String>>): ByteString
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineHttpClient.kt
@@ -18,5 +18,8 @@ package app.cash.zipline.loader
 import okio.ByteString
 
 interface ZiplineHttpClient {
-  suspend fun download(url: String, requestHeaders: List<Pair<String, String>>): ByteString
+  suspend fun download(
+    url: String,
+    requestHeaders: List<Pair<String, String>>,
+  ): ByteString
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
@@ -22,7 +22,10 @@ import okio.IOException
 class FakeZiplineHttpClient: ZiplineHttpClient {
   var filePathToByteString: Map<String, ByteString> = mapOf()
 
-  override suspend fun download(url: String): ByteString {
+  override suspend fun download(
+    url: String,
+    requestHeaders: List<Pair<String, String>>,
+  ): ByteString {
     return filePathToByteString[url] ?: throw IOException("404: $url not found")
   }
 }

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/OkHttpZiplineHttpClient.kt
@@ -29,11 +29,19 @@ import okio.ByteString
 internal class OkHttpZiplineHttpClient(
   private val okHttpClient: OkHttpClient
 ) : ZiplineHttpClient {
-  override suspend fun download(url: String): ByteString {
+  override suspend fun download(
+    url: String,
+    requestHeaders: List<Pair<String, String>>,
+  ): ByteString {
     return suspendCancellableCoroutine { continuation ->
       val call = okHttpClient.newCall(
         Request.Builder()
           .url(url)
+          .apply {
+            for ((name, value) in requestHeaders) {
+              addHeader(name, value)
+            }
+          }
           .build()
       )
 

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/URLSessionZiplineHttpClientTest.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/URLSessionZiplineHttpClientTest.kt
@@ -35,7 +35,21 @@ class URLSessionZiplineHttpClientTest {
     if (!enabled) return@runBlocking
 
     val httpClient = URLSessionZiplineHttpClient(NSURLSession.sharedSession)
-    val download = httpClient.download("https://squareup.com/robots.txt")
+    val download = httpClient.download("https://squareup.com/robots.txt", listOf())
+    println(download.utf8())
+  }
+
+  @Test
+  fun requestHeaders(): Unit = runBlocking {
+    val httpClient = URLSessionZiplineHttpClient(NSURLSession.sharedSession)
+    val download = httpClient.download(
+      "https://squareup.com/robots.txt",
+      listOf(
+        "Header-One" to "a",
+        "Header-Two" to "b",
+        "Header-One" to "c",
+      ),
+    )
     println(download.utf8())
   }
 
@@ -45,7 +59,7 @@ class URLSessionZiplineHttpClientTest {
 
     val httpClient = URLSessionZiplineHttpClient(NSURLSession.sharedSession)
     val exception = assertFailsWith<IOException> {
-      httpClient.download("https://198.51.100.1/robots.txt") // Unreachable IP address.
+      httpClient.download("https://198.51.100.1/robots.txt", listOf()) // Unreachable IP address.
     }
     assertTrue("The request timed out." in exception.message!!, exception.message)
   }
@@ -56,7 +70,7 @@ class URLSessionZiplineHttpClientTest {
 
     val httpClient = URLSessionZiplineHttpClient(NSURLSession.sharedSession)
     val exception = assertFailsWith<IOException> {
-      httpClient.download("https://squareup.com/.well-known/404")
+      httpClient.download("https://squareup.com/.well-known/404", listOf())
     }
     assertEquals(
       "failed to fetch https://squareup.com/.well-known/404: 404",

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/URLSessionZiplineHttpClientTest.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/URLSessionZiplineHttpClientTest.kt
@@ -41,6 +41,8 @@ class URLSessionZiplineHttpClientTest {
 
   @Test
   fun requestHeaders(): Unit = runBlocking {
+    if (!enabled) return@runBlocking
+
     val httpClient = URLSessionZiplineHttpClient(NSURLSession.sharedSession)
     val download = httpClient.download(
       "https://squareup.com/robots.txt",


### PR DESCRIPTION
We're storing it in a more application-specific cache already.

Closes: https://github.com/cashapp/zipline/issues/735