### PR TITLE
Add test that 0 leaks are reported after collecting Flow, closing service

### DIFF
--- a/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/internal/bridge/leakCanaryJni.kt
@@ -37,7 +37,7 @@ internal actual fun detectLeaks() {
 }
 
 /** Keep every [ZiplineServiceReference] reachable until its target is GC'd. */
-private val allReferencesSet = synchronizedSet(mutableSetOf<ZiplineServiceReference>())
+internal val allReferencesSet = synchronizedSet(mutableSetOf<PhantomReference<ZiplineService>>())
 
 /** The VM adds each [ZiplineServiceReference] here when its target is GC'd. */
 private val allReferencesQueue = ReferenceQueue<ZiplineService>()

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/FlowJvmTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/FlowJvmTest.kt
@@ -1,0 +1,68 @@
+package app.cash.zipline
+
+import app.cash.zipline.internal.bridge.EndpointEventListener
+import app.cash.zipline.internal.bridge.allReferencesSet
+import app.cash.zipline.internal.bridge.detectLeaks
+import app.cash.zipline.testing.newEndpointPair
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ErrorCollector
+
+class FlowJvmTest {
+  class LeakListener : EndpointEventListener {
+
+    val leaks = mutableListOf<String>()
+
+    override fun serviceLeaked(name: String) {
+      leaks += name
+    }
+
+    override fun bindService(name: String, service: ZiplineService) {
+    }
+
+    override fun takeService(name: String, service: ZiplineService) {
+    }
+
+    override fun callStart(call: Call): Any? = null
+
+    override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
+    }
+  }
+
+  @[JvmField Rule]
+  val errorCollector = ErrorCollector()
+
+  @Test
+  @Ignore("https://github.com/cashapp/zipline/issues/828")
+  fun flowCollectionReportsZeroLeaks() = runBlocking(Dispatchers.Unconfined) {
+    val scope = ZiplineScope()
+    val listenerA = LeakListener()
+    val listenerB = LeakListener()
+    val (endpointA, endpointB) = newEndpointPair(this, listenerA = listenerA, listenerB = listenerB)
+    val service = FlowTest.RealFlowEchoService()
+
+    endpointA.bind<FlowTest.FlowEchoService>("service", service)
+    val client = endpointB.take<FlowTest.FlowEchoService>("service", scope)
+
+    val flow = client.createFlow("hello", 3)
+    errorCollector.checkThat(flow.toList(), equalTo(listOf("0 hello", "1 hello", "2 hello")))
+
+    // Confirm that no services or clients were leaked.
+    scope.close()
+    errorCollector.checkThat(endpointA.serviceNames, equalTo(emptySet()))
+    errorCollector.checkThat(endpointA.clientNames, equalTo(emptySet()))
+
+    // Confirm that no services were reported as leaking.
+    for (reference in allReferencesSet) {
+      check(reference.enqueue())
+    }
+    detectLeaks()
+    errorCollector.checkThat("endpointA reported zero leaks", listenerA.leaks, equalTo(emptyList()))
+    errorCollector.checkThat("endpointB reported zero leaks", listenerB.leaks, equalTo(emptyList()))
+  }
+}


### PR DESCRIPTION
This adds a test for the behavior being discussed in #828. As I looked over `FlowTest`, I came to the suspicion that this issue is not about whether something leaks, but rather whether it gets reported as leaking. I'm not sure if anything is really leaking, but the listener says so.

The test is currently ignored. To make this work, I made `allReferencesSet` `internal` in order to manually enqueue the references. That's probably not the best, so let me know if you have other suggestions. If you don't think this is the same bug as #828, I can file a separate issue and update the `Ignore` reason.