### PR TITLE
Support Webpack builds

### DIFF
--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
@@ -29,6 +29,7 @@ internal data class SourceMapJson(
   val sourcesContent: List<String?>,
   val names: List<String>,
   val mappings: String,
+  val sourceRoot: String? = null,
 )
 
 data class Group(

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.gradle
+
+import java.io.File
+import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBinaryMode
+import org.jetbrains.kotlin.gradle.targets.js.ir.JsIrBinary
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
+
+/**
+ * A task that produces `.js` files.
+ *
+ * This is used to create a [ZiplineCompileTask] that uses the produced JS as input.
+ */
+internal interface JsProductionTask {
+  /** Like 'compileDevelopmentExecutableKotlinJsZipline'. */
+  val name: String
+
+  /** Like "js" or "blue". */
+  val targetName: String
+
+  /** Either "Webpack" or null. */
+  val toolName: String?
+
+  val mode: KotlinJsBinaryMode
+
+  val outputFile: Provider<File>
+}
+
+/** Output of the Kotlin compiler. */
+internal fun JsIrBinary.asJsProductionTask(): JsProductionTask {
+  return object : JsProductionTask {
+    override val name get() = linkTaskName
+    override val targetName get() = target.name
+    override val toolName = null
+    override val mode get() = this@asJsProductionTask.mode
+    override val outputFile get() = linkTask.map { File(it.kotlinOptions.outputFile!!) }
+  }
+}
+
+/** Output of the Kotlin compiler, post-processed by a Webpack toolchain. */
+internal fun KotlinWebpack.asJsProductionTask(): JsProductionTask {
+  return object : JsProductionTask {
+    override val name = this@asJsProductionTask.name
+    override val targetName = compilation.target.name
+    override val toolName = "Webpack"
+    override val mode = when {
+      name.endsWith("DevelopmentWebpack") -> KotlinJsBinaryMode.DEVELOPMENT
+      name.endsWith("ProductionWebpack") -> KotlinJsBinaryMode.PRODUCTION
+      else -> error("unexpected KotlinWebpack task name: $name")
+    }
+    override val outputFile get() = DefaultProvider { this@asJsProductionTask.outputFile }
+  }
+}

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/util.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/util.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.gradle
+
+import java.util.Locale
+import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.provider.Provider
+
+internal fun <T> Iterable<Provider<T>>.flatten(): Provider<List<T>> {
+  val empty: Provider<List<T>> = DefaultProvider { emptyList() }
+  return fold(empty) { listProvider, elementProvider ->
+    listProvider.zip(elementProvider, Collection<T>::plus)
+  }
+}
+
+internal fun String.capitalize(): String {
+  return lowercase(locale = Locale.US)
+    .replaceFirstChar { it.titlecase(locale = Locale.US) }
+}

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
@@ -76,6 +76,7 @@ class ZiplinePluginTest {
     val ziplineOut = projectDir.resolve(
       "lib/build/distributionsZipline"
     )
+    assertThat(ziplineOut.listFiles()?.size).isEqualTo(2)
     assertThat(ziplineOut.resolve(MANIFEST_FILE_NAME).exists()).isTrue()
     assertThat(ziplineOut.resolve("lib.zipline").exists()).isTrue()
   }

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
@@ -61,6 +61,26 @@ class ZiplinePluginTest {
   }
 
   /**
+   * Run the Zipline compiler on the Webpack output. It's flattened into a single module and
+   * minified.
+   */
+  @Test
+  fun webpackBuild() {
+    val projectDir = File("src/test/projects/basic")
+
+    val taskName = ":lib:jsBrowserProductionWebpackZipline"
+    val result = createRunner(projectDir, "clean", taskName).build()
+    assertThat(SUCCESS_OUTCOMES)
+      .contains(result.task(taskName)!!.outcome)
+
+    val ziplineOut = projectDir.resolve(
+      "lib/build/distributionsZipline"
+    )
+    assertThat(ziplineOut.resolve(MANIFEST_FILE_NAME).exists()).isTrue()
+    assertThat(ziplineOut.resolve("lib.zipline").exists()).isTrue()
+  }
+
+  /**
    * This confirms these plugin features are working:
    *
    *  - IR rewriting in JS and JVM


### PR DESCRIPTION
These give up the benefits of modules (independent caching, pipelined download and code-load), in exchange for the benefits of Webpack (minification, fewer downloads).