### PR TITLE
Do not set `-Xir-per-module`

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -20,7 +20,6 @@ import app.cash.zipline.loader.internal.generateKeyPair
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
@@ -110,15 +109,7 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
   override fun applyToCompilation(
     kotlinCompilation: KotlinCompilation<*>
   ): Provider<List<SubpluginOption>> {
-    val project = kotlinCompilation.target.project
-
-    // Configure Kotlin JS to generate modular JS files
-    project.tasks.withType(KotlinJsCompile::class.java).configureEach { task ->
-      task.kotlinOptions {
-        freeCompilerArgs += listOf("-Xir-per-module")
-      }
-    }
-    return project.provider {
+    return kotlinCompilation.target.project.provider {
       listOf() // No options.
     }
   }


### PR DESCRIPTION
For one, this is the default behavior now as of Kotlin 1.6.20 (per https://kotlinlang.org/docs/whatsnew1620.html#separate-js-files-for-project-modules-by-default-with-ir-compiler). But having this explicitly defined prevents the ability to use whole-program module generation (per https://kotlinlang.org/docs/js-ir-compiler.html#output-js-files-one-per-module-or-one-for-the-whole-project).