### PR TITLE
Replace deprecated property.

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
@@ -49,7 +49,7 @@ internal fun JsIrBinary.asJsProductionTask(): JsProductionTask {
     override val targetName get() = target.name
     override val toolName = null
     override val mode get() = this@asJsProductionTask.mode
-    override val outputFile get() = linkTask.map { File(it.kotlinOptions.outputFile!!) }
+    override val outputFile get() = linkTask.flatMap { it.outputFileProperty }
   }
 }
 

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
@@ -49,7 +49,7 @@ internal fun JsIrBinary.asJsProductionTask(): JsProductionTask {
     override val targetName get() = target.name
     override val toolName = null
     override val mode get() = this@asJsProductionTask.mode
-    override val outputFile get() = linkTask.flatMap { it.outputFileProperty }
+    override val outputFile get() = linkTask.map { it.outputFileProperty.get() }
   }
 }
 


### PR DESCRIPTION
Missed this as part of the Kotlin 1.8 update.