### PR TITLE
Fix a couple Gradle deprecations.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 buildscript {
@@ -104,9 +105,13 @@ allprojects {
 
   plugins.withId("org.jetbrains.kotlin.multiplatform") {
     configure<KotlinMultiplatformExtension> {
-      jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-      }
+      jvmToolchain(11)
+    }
+  }
+
+  plugins.withId("org.jetbrains.kotlin.jvm") {
+    configure<KotlinJvmProjectExtension> {
+      jvmToolchain(11)
     }
   }
 

--- a/zipline-bytecode/build.gradle.kts
+++ b/zipline-bytecode/build.gradle.kts
@@ -19,11 +19,6 @@ dependencies {
   testImplementation(libs.truth)
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
-
 configure<MavenPublishBaseExtension> {
   configure(
     KotlinJvm(

--- a/zipline-gradle-plugin/build.gradle.kts
+++ b/zipline-gradle-plugin/build.gradle.kts
@@ -29,11 +29,6 @@ dependencies {
   testImplementation(libs.truth)
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
-
 buildConfig {
   useKotlinOutput {
     internalVisibility = true

--- a/zipline-gradle-plugin/src/test/projects/multipleJsTargets/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/multipleJsTargets/lib/build.gradle.kts
@@ -9,11 +9,17 @@ kotlin {
   js("blue") {
     browser()
     binaries.executable()
+    attributes {
+      attribute(Attribute.of(String::class.java), "blue")
+    }
   }
 
   js("red") {
     browser()
     binaries.executable()
+    attributes {
+      attribute(Attribute.of(String::class.java), "red")
+    }
   }
 
   sourceSets {


### PR DESCRIPTION
Fixes a couple Gradle deprecations that become errors in Gradle 8.0.

The remaining exception blocking updating to Gradle 8.0 (below) appears to be fixed by Kotlin 1.8.10 (tested locally) so we can just wait until 1.8.20.

```
* What went wrong:
A problem was found with the configuration of task ':zipline:testing:jsBrowserProductionWebpack' (type 'KotlinWebpack').
  - Gradle detected a problem with the following location: '/home/runner/work/zipline/zipline/build/js/packages/zipline-root-testing/kotlin/zipline-root-testing.js'.
    
    Reason: Task ':zipline:testing:jsBrowserProductionWebpack' uses this output of task ':zipline:testing:jsDevelopmentLibraryCompileSync' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':zipline:testing:jsDevelopmentLibraryCompileSync' as an input of ':zipline:testing:jsBrowserProductionWebpack'.
      2. Declare an explicit dependency on ':zipline:testing:jsDevelopmentLibraryCompileSync' from ':zipline:testing:jsBrowserProductionWebpack' using Task#dependsOn.
      3. Declare an explicit dependency on ':zipline:testing:jsDevelopmentLibraryCompileSync' from ':zipline:testing:jsBrowserProductionWebpack' using Task#mustRunAfter.
    

    Please refer to https://docs.gradle.org/8.0/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```