### PR TITLE
Update Kotlin to 1.8.10.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 androidx-compose = "1.3.3"
-androidx-compose-compiler = "1.4.0"
+androidx-compose-compiler = "1.4.2"
 auto-service="1.0.1"
 compileSdk = "33"
 http4k = "4.40.1.0"
-kotlin = "1.8.0"
+kotlin = "1.8.10"
 kotlinx-coroutines = "1.6.4"
 kotlinx-serialization = "1.5.0"
 okHttp = "4.10.0"


### PR DESCRIPTION
This isn't strictly necessary as Zipline is already compatible with 1.8.10 as there weren't any compiler changes that affected Zipline, however it's probably still worthwhile to bump to stay in [sync with Redwood](https://github.com/cashapp/redwood/pull/850).