### PR TITLE
Only build branches on manual dispatch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,10 @@ name: build
 
 on:
   pull_request: {}
+  workflow_dispatch: {}
   push:
     branches:
-      - '**'
+      - 'trunk'
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
Save some CI minutes while retaining the ability to test branches without a PR.

Same thing we're doing on every other project now...