### PR TITLE
Work-around Dokka Gradle 8 issue.

### DIFF
--- a/zipline-cli/build.gradle.kts
+++ b/zipline-cli/build.gradle.kts
@@ -29,6 +29,9 @@ tasks.named("distTar").configure {
 }
 
 // https://github.com/Kotlin/dokka/issues/1833
+tasks.named("dokkaGfm").configure {
+  dependsOn(tasks.named("kaptKotlin"))
+}
 tasks.named("dokkaHtmlPartial").configure {
   dependsOn(tasks.named("kaptKotlin"))
 }

--- a/zipline-kotlin-plugin/build.gradle.kts
+++ b/zipline-kotlin-plugin/build.gradle.kts
@@ -36,6 +36,9 @@ configure<MavenPublishBaseExtension> {
 }
 
 // https://github.com/Kotlin/dokka/issues/1833
+tasks.named("dokkaGfm").configure {
+  dependsOn(tasks.named("kaptKotlin"))
+}
 tasks.named("dokkaHtmlPartial").configure {
   dependsOn(tasks.named("kaptKotlin"))
 }


### PR DESCRIPTION
Works around an [implicit dependency issue](https://github.com/cashapp/zipline/actions/runs/4727842290/jobs/8389453947).