### PR TITLE
Cache ziplineFunctions

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -249,6 +249,9 @@ internal class AdapterGenerator(
     val serialNameProperty = irSerialNameProperty(adapterClass, constructor)
     adapterClass.declarations += serialNameProperty
 
+    val simpleNameProperty = irSimpleNameProperty(adapterClass)
+    adapterClass.declarations += simpleNameProperty
+
     val serializersProperty = irSerializersProperty(adapterClass, constructor)
     adapterClass.declarations += serializersProperty
 
@@ -295,8 +298,8 @@ internal class AdapterGenerator(
   }
 
   /**
-   * Override `ZiplineServiceAdapter.serialName`. The constant value is the service's simple name,
-   * like "SampleService".
+   * Override `ZiplineServiceAdapter.serialName`. The constant value is the service's full
+   * typed name like "my.package.SampleService<package.Type1>".
    */
   private fun irSerialNameProperty(adapterClass: IrClass, value: IrConstructor): IrProperty {
     // override val serialName: String = serialName
@@ -308,6 +311,23 @@ internal class AdapterGenerator(
       overriddenProperty = ziplineApis.ziplineServiceAdapterSerialName,
     ) {
       irExprBody(irGet(value.valueParameters[1]))
+    }
+  }
+
+  /**
+   * Override `ZiplineServiceAdapter.simpleName`. The constant value is the service's simple name,
+   * like "SampleService".
+   */
+  private fun irSimpleNameProperty(adapterClass: IrClass): IrProperty {
+    // override val simpleName: String = "MyClass"
+    return irVal(
+      pluginContext = pluginContext,
+      propertyType = pluginContext.symbols.string.defaultType,
+      declaringClass = adapterClass,
+      propertyName = ziplineApis.ziplineServiceAdapterSimpleName.owner.name,
+      overriddenProperty = ziplineApis.ziplineServiceAdapterSimpleName,
+    ) {
+      irExprBody(irString(original.name.identifier))
     }
   }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -127,12 +127,15 @@ internal class AdapterGenerator(
       )
     }
 
+    val serialName = irString(adapterType.asString())
+
     // Adapter<String, Long>(...)
     return irCallConstructor(
       callee = adapterClass.constructors.single().symbol,
       typeArguments = adapterType.arguments.map { it as IrType },
     ).apply {
       putValueArgument(0, serializersList)
+      putValueArgument(1, serialName)
     }
   }
 
@@ -142,7 +145,8 @@ internal class AdapterGenerator(
    * of that type.
    */
   fun adapterExpression(
-    serializersListExpression: IrExpression
+    serializersListExpression: IrExpression,
+    serialName: String,
   ): IrFunctionAccessExpression {
     val adapterClass = generateAdapterIfAbsent()
     return with(irBlockBodyBuilder(pluginContext, scope, original)) {
@@ -152,6 +156,10 @@ internal class AdapterGenerator(
         putValueArgument(
           0,
           serializersListExpression
+        )
+        putValueArgument(
+          1,
+          irString(serialName)
         )
       }
     }
@@ -218,6 +226,11 @@ internal class AdapterGenerator(
         name = Name.identifier("serializers")
         type = ziplineApis.listOfKSerializerStar
       }
+      addValueParameter {
+        initDefaults(original)
+        name = Name.identifier("serialName")
+        type = pluginContext.symbols.string.defaultType
+      }
       irConstructorBody(pluginContext) { statements ->
         statements += irDelegatingConstructorCall(
           context = pluginContext,
@@ -233,7 +246,7 @@ internal class AdapterGenerator(
       }
     }
 
-    val serialNameProperty = irSerialNameProperty(adapterClass)
+    val serialNameProperty = irSerialNameProperty(adapterClass, constructor)
     adapterClass.declarations += serialNameProperty
 
     val serializersProperty = irSerializersProperty(adapterClass, constructor)
@@ -285,8 +298,8 @@ internal class AdapterGenerator(
    * Override `ZiplineServiceAdapter.serialName`. The constant value is the service's simple name,
    * like "SampleService".
    */
-  private fun irSerialNameProperty(adapterClass: IrClass): IrProperty {
-    // override val serialName: String = "SampleService"
+  private fun irSerialNameProperty(adapterClass: IrClass, value: IrConstructor): IrProperty {
+    // override val serialName: String = serialName
     return irVal(
       pluginContext = pluginContext,
       propertyType = pluginContext.symbols.string.defaultType,
@@ -294,12 +307,12 @@ internal class AdapterGenerator(
       propertyName = ziplineApis.ziplineServiceAdapterSerialName.owner.name,
       overriddenProperty = ziplineApis.ziplineServiceAdapterSerialName,
     ) {
-      irExprBody(irString(original.name.identifier))
+      irExprBody(irGet(value.valueParameters[1]))
     }
   }
 
   private fun irSerializersProperty(adapterClass: IrClass, value: IrConstructor): IrProperty {
-    // override val serializers: List<KSerializer<*>>
+    // override val serializers: List<KSerializer<*>> = serializers
     return irVal(
       pluginContext = pluginContext,
       propertyType = ziplineApis.listOfKSerializerStar,

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -43,10 +43,9 @@ import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.isInterface
-import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.ir.util.isSuspend
+import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.ir.util.substitute
-import org.jetbrains.kotlin.name.Name
 
 /**
  * A user-defined interface (like `EchoService` or `Callback<String>`) and support for generating
@@ -211,7 +210,10 @@ internal class BridgedInterface(
           ziplineApis,
           this@BridgedInterface.scope,
           pluginContext.referenceClass(type.getClass()!!.classId!!)!!.owner,
-        ).adapterExpression(parameterList)
+        ).adapterExpression(
+          serializersListExpression = parameterList,
+          serialName = type.asString()
+        )
       }
 
       hasTypeParameter || contextual || type.isFlow || type.isStateFlow -> {

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/CallAdapterConstructorRewriter.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/CallAdapterConstructorRewriter.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 
@@ -54,6 +55,9 @@ internal class CallAdapterConstructorRewriter(
     val kClassArgument = original.getValueArgument(0) ?: return original
     val serializersListExpression = original.getValueArgument(1) ?: return original
 
+    // my.package.AdapterClass<package.Type1, package.Type2>
+    val serialName = (original.getTypeArgument(0) as IrSimpleType).asString()
+
     val bridgedInterfaceType = when (kClassArgument) {
       is IrClassReference -> kClassArgument.classType
       else -> return original
@@ -75,7 +79,7 @@ internal class CallAdapterConstructorRewriter(
       ziplineApis,
       scope,
       bridgedInterface.typeIrClass
-    ).adapterExpression(serializersListExpression)
+    ).adapterExpression(serializersListExpression, serialName)
     result.patchDeclarationParents(declarationParent)
     return result
   }

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -164,6 +164,11 @@ internal class ZiplineApis(
       ziplineServiceAdapterClassId.callableId("serializers")
     ).single()
 
+  val ziplineServiceAdapterSimpleName: IrPropertySymbol
+    get() = pluginContext.referenceProperties(
+      ziplineServiceAdapterClassId.callableId("simpleName")
+    ).single()
+
   val ziplineServiceAdapterZiplineFunctions: IrSimpleFunctionSymbol
     get() = ziplineServiceAdapter.functions.single {
       it.owner.name.identifier == "ziplineFunctions"

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -46,6 +46,8 @@ import kotlinx.serialization.modules.SerializersModule;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import androidx.annotation.NonNull;
+
 /**
  * Call these {@link PublishedApi} internal APIs from Java rather than from Kotlin to hack around
  * visibility of internal APIs.
@@ -92,6 +94,10 @@ public final class ZiplineTestInternals {
   /** Simulate a generated subclass of ZiplineServiceAdapter. */
   public static class EchoServiceAdapter extends ZiplineServiceAdapter<EchoService> {
     public static final EchoServiceAdapter INSTANCE = new EchoServiceAdapter();
+
+    @Override public String getSimpleName() {
+      return "EchoService";
+    }
 
     @Override public String getSerialName() {
       return "app.cash.zipline.kotlin.EchoService";
@@ -149,6 +155,10 @@ public final class ZiplineTestInternals {
       extends ZiplineServiceAdapter<GenericEchoService<String>> {
     public static final GenericEchoServiceAdapter INSTANCE = new GenericEchoServiceAdapter();
 
+    @Override public String getSimpleName() {
+      return "GenericEchoService";
+    }
+
     @Override public String getSerialName() {
       return "app.cash.zipline.kotlin.GenericEchoService<kotlin.String>";
     }
@@ -203,8 +213,12 @@ public final class ZiplineTestInternals {
   public static class EchoZiplineServiceAdapter extends ZiplineServiceAdapter<EchoZiplineService> {
     public static final EchoZiplineServiceAdapter INSTANCE = new EchoZiplineServiceAdapter();
 
+    @Override public String getSimpleName() {
+      return "EchoService";
+    }
+
     @Override public String getSerialName() {
-      return "EchoZiplineService";
+      return "app.cash.zipline.kotlin.EchoZiplineService";
     }
 
     @Override public List<KSerializer<?>> getSerializers() {

--- a/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
+++ b/zipline-kotlin-plugin/tests/src/test/java/app/cash/zipline/kotlin/ZiplineTestInternals.java
@@ -94,7 +94,7 @@ public final class ZiplineTestInternals {
     public static final EchoServiceAdapter INSTANCE = new EchoServiceAdapter();
 
     @Override public String getSerialName() {
-      return "EchoService";
+      return "app.cash.zipline.kotlin.EchoService";
     }
 
     @Override public List<KSerializer<?>> getSerializers() {
@@ -150,7 +150,7 @@ public final class ZiplineTestInternals {
     public static final GenericEchoServiceAdapter INSTANCE = new GenericEchoServiceAdapter();
 
     @Override public String getSerialName() {
-      return "GenericEchoService";
+      return "app.cash.zipline.kotlin.GenericEchoService<kotlin.String>";
     }
 
     @Override public List<KSerializer<?>> getSerializers() {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -34,6 +34,7 @@ internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<
   private val contextualSerializer = ContextualSerializer(PassByReference::class)
   abstract val serializers: List<KSerializer<*>>
   abstract val serialName: String
+  abstract val simpleName: String
 
   override val descriptor = contextualSerializer.descriptor
 
@@ -61,7 +62,7 @@ internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<
 
   override fun hashCode() = this::class.hashCode()
 
-  override fun toString() = serialName
+  override fun toString() = simpleName
 }
 
 @PublishedApi

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -22,6 +22,7 @@ import app.cash.zipline.internal.bridge.SuspendCallback
 import app.cash.zipline.internal.bridge.SuspendingZiplineFunction
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import app.cash.zipline.internal.bridge.requireContextual
+import kotlin.reflect.typeOf
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
@@ -50,7 +51,8 @@ interface SampleService<T> : ZiplineService {
     /** This function's body is what callers use to create a properly-typed adapter. */
     internal inline fun <reified T> manualAdapter(): ManualAdapter<T> {
       return ManualAdapter<T>(
-        listOf(serializer<T>())
+        listOf(serializer<T>()),
+        typeOf<ManualAdapter<T>>().toString(), // this is resolved at build time
       )
     }
 
@@ -61,8 +63,8 @@ interface SampleService<T> : ZiplineService {
      */
     internal class ManualAdapter<TX>(
       override val serializers: List<KSerializer<*>>,
+      override val serialName: String,
     ) : ZiplineServiceAdapter<SampleService<TX>>() {
-      override val serialName: String = "SampleService"
 
       class ZiplineFunction0<TF>(
         argSerializers: List<KSerializer<*>>,

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -65,7 +65,7 @@ interface SampleService<T> : ZiplineService {
       override val serializers: List<KSerializer<*>>,
       override val serialName: String,
     ) : ZiplineServiceAdapter<SampleService<TX>>() {
-      override val simpleName: String = "ManualAdapter"
+      override val simpleName: String = "SampleService"
 
       class ZiplineFunction0<TF>(
         argSerializers: List<KSerializer<*>>,

--- a/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/engineTest/kotlin/app/cash/zipline/SampleService.kt
@@ -65,6 +65,7 @@ interface SampleService<T> : ZiplineService {
       override val serializers: List<KSerializer<*>>,
       override val serialName: String,
     ) : ZiplineServiceAdapter<SampleService<TX>>() {
+      override val simpleName: String = "ManualAdapter"
 
       class ZiplineFunction0<TF>(
         argSerializers: List<KSerializer<*>>,


### PR DESCRIPTION
`ziplineFunctions` fetches all of the serializers necessary, but currently it can be called a lot, meaning we end up doing a lot of work repeatedly. This PR caches the result of `ziplineFunctions`, enabling us to only do the work once.