### PR TITLE
Build with JDK 20 on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - name: Build native library (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - run: ./gradlew assembleAndroidTest
 
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - name: Build Xcode samples
         run: |
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - uses: actions/download-artifact@v3
       - run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - name: Build native library (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - run: ./gradlew assembleAndroidTest
 
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 20
 
       - uses: actions/download-artifact@v3
       - run: |


### PR DESCRIPTION
This does not affect the target JVM version:

    $ java -version
    openjdk version "20.0.1" 2023-04-18
    OpenJDK Runtime Environment Zulu20.30+11-CA (build 20.0.1+9)
    OpenJDK 64-Bit Server VM Zulu20.30+11-CA (build 20.0.1+9, mixed mode, sharing)

    $ rm -r build/testMaven/

    $ gw publishAllPublicationsToTestMavenRepository

    $ rg jvmTarget build/testMaven/
    build/testMaven/app/cash/zipline/zipline/1.0.0-SNAPSHOT/zipline-1.0.0-20230516.152400-1-kotlin-tooling-metadata.json
    71:          "jvmTarget": "11",

    build/testMaven/app/cash/zipline/zipline-loader/1.0.0-SNAPSHOT/zipline-loader-1.0.0-20230516.152400-1-kotlin-tooling-metadata.json
    61:          "jvmTarget": "11",

Unblocks #945 and #946.