### PR TITLE
API to retrieve a service's target type

### DIFF
--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineServiceType.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineServiceType.kt
@@ -15,7 +15,18 @@
  */
 package app.cash.zipline
 
+import app.cash.zipline.internal.bridge.OutboundService
+
 interface ZiplineServiceType<T : ZiplineService> {
   val name: String
   val functions: List<ZiplineFunction<T>>
+}
+
+/**
+ * Returns the type of this service as described by the peer. Returns null if this service isn't an
+ * outbound service, if it is closed, or if it is unknown to the remote peer.
+ */
+val <T : ZiplineService> T.targetType : ZiplineServiceType<T>? get() {
+  if (this !is OutboundService) return null
+  return callHandler.targetType as ZiplineServiceType<T>?
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineServiceType.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/ZiplineServiceType.kt
@@ -26,7 +26,7 @@ interface ZiplineServiceType<T : ZiplineService> {
  * Returns the type of this service as described by the peer. Returns null if this service isn't an
  * outbound service, if it is closed, or if it is unknown to the remote peer.
  */
-val <T : ZiplineService> T.targetType : ZiplineServiceType<T>? get() {
+val <T : ZiplineService> T.targetType: ZiplineServiceType<T>? get() {
   if (this !is OutboundService) return null
   return callHandler.targetType as ZiplineServiceType<T>?
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/EndpointService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/EndpointService.kt
@@ -21,5 +21,5 @@ import app.cash.zipline.internal.bridge.SerializableZiplineServiceType
 internal interface EndpointService : ZiplineService {
   val serviceNames: Set<String>
 
-  fun serviceType(name: String): SerializableZiplineServiceType
+  fun serviceType(name: String): SerializableZiplineServiceType?
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -53,6 +53,10 @@ internal class OutboundCallHandler(
     )
   }
 
+  /** Returns the type of this service as reported by the opposite endpoint. */
+  val targetType: SerializableZiplineServiceType?
+    get() = endpoint.opposite.serviceType(serviceName)
+
   /** Returns a new service that uses this to send calls. */
   fun <T : ZiplineService> outboundService(): T {
     return adapter.outboundService(this) as T

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/SerializableZiplineServiceType.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/SerializableZiplineServiceType.kt
@@ -26,6 +26,7 @@ internal class SerializableZiplineServiceType(
 ) : ZiplineServiceType<ZiplineService> {
   constructor(type: ZiplineServiceType<*>) : this(
     type.name,
-    type.functions.map { function -> SerializableZiplineFunction(function) },
+    type.functions.map { function -> SerializableZiplineFunction(function) }
+      .sortedBy { it.name },
   )
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -32,10 +32,10 @@ internal fun newEndpointPair(
 ): Pair<Endpoint, Endpoint> {
   val pair = object : Any() {
     val a: Endpoint = Endpoint(
-      scope,
-      serializersModule,
-      listenerA,
-      object : CallChannel {
+      scope = scope,
+      userSerializersModule = serializersModule,
+      eventListener = listenerA,
+      outboundChannel = object : CallChannel {
         override fun call(callJson: String): String {
           return b.inboundChannel.call(callJson)
         }
@@ -44,9 +44,16 @@ internal fun newEndpointPair(
           return b.inboundChannel.disconnect(instanceName)
         }
       },
+      oppositeProvider = { b }
     )
 
-    val b: Endpoint = Endpoint(scope, serializersModule, listenerB, a.inboundChannel)
+    val b: Endpoint = Endpoint(
+      scope = scope,
+      userSerializersModule = serializersModule,
+      eventListener = listenerB,
+      outboundChannel = a.inboundChannel,
+      oppositeProvider = { a },
+    )
   }
 
   return pair.a to pair.b

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -44,7 +44,7 @@ internal fun newEndpointPair(
           return b.inboundChannel.disconnect(instanceName)
         }
       },
-      oppositeProvider = { b }
+      oppositeProvider = { b },
     )
 
     val b: Endpoint = Endpoint(

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -65,9 +65,12 @@ actual class Zipline private constructor(
         return jsInboundBridge.disconnect(instanceName)
       }
     },
+    oppositeProvider = {
+      guest
+    }
   )
 
-  private val guest = endpoint.take<GuestService>(ziplineGuestName)
+  private val guest: GuestService = endpoint.take(ziplineGuestName)
 
   actual val json: Json
     get() = endpoint.json

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -67,7 +67,7 @@ actual class Zipline private constructor(
     },
     oppositeProvider = {
       guest
-    }
+    },
   )
 
   private val guest: GuestService = endpoint.take(ziplineGuestName)

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -53,6 +53,9 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
         return jsOutboundChannel.disconnect(instanceName)
       }
     },
+    oppositeProvider = {
+      host
+    }
   )
 
   actual val json = endpoint.json

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -55,7 +55,7 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
     },
     oppositeProvider = {
       host
-    }
+    },
   )
 
   actual val json = endpoint.json


### PR DESCRIPTION
This enables introspection on what functions the target has. This should prove useful for backwards-compatibility.