### PR TITLE
Run tests in a background thread on native

### DIFF
--- a/zipline-testing/build.gradle.kts
+++ b/zipline-testing/build.gradle.kts
@@ -53,6 +53,23 @@ kotlin {
       dependsOn(hostMain)
     }
 
+    val appleMain by creating {
+      dependsOn(nativeMain)
+    }
+    val macosX64Main by getting { dependsOn(appleMain) }
+    val macosArm64Main by getting { dependsOn(appleMain) }
+    val iosArm64Main by getting { dependsOn(appleMain) }
+    val iosX64Main by getting { dependsOn(appleMain) }
+    val iosSimulatorArm64Main by getting { dependsOn(appleMain) }
+    val tvosArm64Main by getting { dependsOn(appleMain) }
+    val tvosSimulatorArm64Main by getting { dependsOn(appleMain) }
+    val tvosX64Main by getting { dependsOn(appleMain) }
+
+    val linuxMain by creating {
+      dependsOn(nativeMain)
+    }
+    val linuxX64Main by getting { dependsOn(linuxMain) }
+
     targets.withType<KotlinNativeTarget> {
       val main by compilations.getting
       main.defaultSourceSet.dependsOn(nativeMain)

--- a/zipline-testing/src/appleMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersApple.kt
+++ b/zipline-testing/src/appleMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersApple.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.cinterop.convert
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import platform.Foundation.NSThread
+
+actual fun singleThreadCoroutineDispatcher(
+  name: String,
+  stackSize: Int,
+): CloseableCoroutineDispatcher {
+  val channel = Channel<Runnable?>(capacity = Channel.UNLIMITED)
+
+  val thread = NSThread {
+    runBlocking {
+      while (true) {
+        val runnable = channel.receive() ?: break
+        runnable.run()
+      }
+    }
+  }.apply {
+    this.name = name
+    this.stackSize = stackSize.convert()
+  }
+
+  thread.start()
+
+  return object : CloseableCoroutineDispatcher() {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+      channel.trySend(block)
+    }
+
+    override fun close() {
+      channel.trySend(null)
+    }
+  }
+}

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/CoroutineDispatchers.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/CoroutineDispatchers.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+
+/**
+ * Returns a CoroutineDispatcher that's confined to a single thread, appropriate for executing
+ * QuickJS. The dispatcher starts its thread lazily on first use.
+ *
+ * On Apple platforms we need to explicitly set the stack size for background threads; otherwise we
+ * get the default of 512 KiB which isn't sufficient for our QuickJS programs.
+ */
+expect fun singleThreadCoroutineDispatcher(
+  name: String,
+  stackSize: Int = 1024 * 1024,
+): CloseableCoroutineDispatcher

--- a/zipline-testing/src/jvmMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersJvm.kt
+++ b/zipline-testing/src/jvmMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersJvm.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+
+actual fun singleThreadCoroutineDispatcher(
+  name: String,
+  stackSize: Int,
+): CloseableCoroutineDispatcher {
+  val executorService = ThreadPoolExecutor(
+    0,
+    1,
+    100,
+    TimeUnit.MILLISECONDS,
+    LinkedBlockingQueue(),
+  ) { runnable ->
+    Thread(null, runnable, name, stackSize.toLong())
+  }
+
+  return executorService.asCoroutineDispatcher()
+}

--- a/zipline-testing/src/linuxMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersLinux.kt
+++ b/zipline-testing/src/linuxMain/kotlin/app/cash/zipline/testing/CoroutineDispatchersLinux.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.newSingleThreadContext
+
+actual fun singleThreadCoroutineDispatcher(
+  name: String,
+  stackSize: Int,
+): CloseableCoroutineDispatcher {
+  // TODO(jwilson): set the stack size?
+  return newSingleThreadContext(name)
+}

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/SetTimeoutTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/SetTimeoutTest.kt
@@ -16,26 +16,24 @@
 package app.cash.zipline
 
 import app.cash.zipline.testing.loadTestingJs
+import app.cash.zipline.testing.singleThreadCoroutineDispatcher
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.junit.After
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
 
 class SetTimeoutTest {
-  @Rule @JvmField
-  val ziplineTestRule = ZiplineTestRule()
-  private val dispatcher = ziplineTestRule.dispatcher
+  private val dispatcher = singleThreadCoroutineDispatcher("SetTimeoutTest")
   private val zipline = Zipline.create(dispatcher)
 
-  @Before fun setUp(): Unit = runBlocking(dispatcher) {
+  @BeforeTest fun setUp(): Unit = runBlocking(dispatcher) {
     zipline.loadTestingJs()
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.initZipline()")
   }
 
-  @After fun tearDown() = runBlocking(dispatcher) {
+  @AfterTest fun tearDown() = runBlocking(dispatcher) {
     zipline.close()
   }
 


### PR DESCRIPTION
This is difficult because the default stack size for background threads is different from the default stack size on the main thread: 512 KiB for background vs. 8 MiB for main.

This is setting infrastructure in place to promote more tests from jvmTest to hostTest.