### PR TITLE
Fix collision in serviceTypeCache keys

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -176,7 +176,7 @@ internal class AdapterGenerator(
       val serialNameExpression = when {
         hasTypeArguments -> {
           irCall(
-            callee = ziplineApis.serialNameFunction
+            callee = ziplineApis.serialNameFunction,
           ).apply {
             putValueArgument(0, irString(adapterType.classFqName!!.asString()))
             putValueArgument(1, irGet(serializersListLocal))

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -204,7 +204,10 @@ internal class BridgedInterface(
       }
 
       type.isSubtypeOfClass(ziplineApis.ziplineService) -> {
-        // ServiceType.Companion.Adapter(serializers)
+        // ServiceType.Companion.Adapter(
+        //   serializers,
+        //   serialName("com.example.ServiceType", serializers),
+        // )
         AdapterGenerator(
           pluginContext,
           ziplineApis,
@@ -212,7 +215,7 @@ internal class BridgedInterface(
           pluginContext.referenceClass(type.getClass()!!.classId!!)!!.owner,
         ).adapterExpression(
           serializersListExpression = parameterList,
-          serialName = type.asString(),
+          adapterType = type,
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -87,6 +87,10 @@ internal class ZiplineApis(
           it.owner.typeParameters.size == 1
       }
 
+  val serialNameFunction: IrSimpleFunctionSymbol
+    get() = pluginContext.referenceFunctions(bridgeFqPackage.callableId("serialName"))
+      .single()
+
   val requireContextual: IrSimpleFunctionSymbol
     get() = pluginContext.referenceFunctions(
       bridgeFqPackage.callableId("requireContextual"),

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -371,6 +371,19 @@ fun irBlockBodyBuilder(
   )
 }
 
+fun irBlockBuilder(
+  irPluginContext: IrGeneratorContext,
+  scopeWithIr: ScopeWithIr,
+  original: IrElement,
+): IrBlockBuilder {
+  return IrBlockBuilder(
+    context = irPluginContext,
+    scope = scopeWithIr.scope,
+    startOffset = original.startOffset.toSyntheticIfUnknown(),
+    endOffset = original.endOffset.toSyntheticIfUnknown(),
+  )
+}
+
 /** This creates `companion object` if it doesn't exist already. */
 fun getOrCreateCompanion(
   enclosing: IrClass,

--- a/zipline/api/android/zipline.api
+++ b/zipline/api/android/zipline.api
@@ -551,6 +551,7 @@ public abstract class app/cash/zipline/internal/bridge/ZiplineServiceAdapter : k
 }
 
 public final class app/cash/zipline/internal/bridge/ZiplineServiceAdapterKt {
+	public static final fun serialName (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public static final fun ziplineServiceAdapter ()Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;
 	public static final fun ziplineServiceAdapter (Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;)Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;
 }

--- a/zipline/api/jvm/zipline.api
+++ b/zipline/api/jvm/zipline.api
@@ -551,6 +551,7 @@ public abstract class app/cash/zipline/internal/bridge/ZiplineServiceAdapter : k
 }
 
 public final class app/cash/zipline/internal/bridge/ZiplineServiceAdapterKt {
+	public static final fun serialName (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public static final fun ziplineServiceAdapter ()Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;
 	public static final fun ziplineServiceAdapter (Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;)Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -76,3 +76,17 @@ internal fun <T : ZiplineService> ziplineServiceAdapter(
 ): ZiplineServiceAdapter<T> {
   return ziplineServiceAdapter
 }
+
+/**
+ * Returns a string like `kotlinx.coroutines.Flow<kotlin.String>`. This can be used as a unique
+ * key to identify a serializer for [typeName] that has [serializers] for its type arguments.
+ */
+@PublishedApi
+internal fun serialName(typeName: String, serializers: List<KSerializer<*>>): String {
+  return buildString {
+    append(typeName)
+    serializers.joinTo(this, separator = ",", prefix = "<", postfix = ">") {
+      it.descriptor.serialName
+    }
+  }
+}


### PR DESCRIPTION
We were selecting cache keys at build-time, which resulted in multiple flows using the same serializer instances, despite having different runtime types.

This changes key construction to happen at runtime instead.

Closes: https://github.com/cashapp/zipline/issues/1039