### PR TITLE
Add the ziplineApiCheck task as a 'check'

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineApiValidationTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineApiValidationTask.kt
@@ -52,6 +52,18 @@ abstract class ZiplineApiValidationTask @Inject constructor(
   @get:Classpath
   internal val classpath = fileCollectionFactory.configurableFiles("classpath")
 
+  init {
+    when (mode) {
+      Mode.Check -> {
+        group = "verification"
+        description = "Confirm that the current Zipline API matches the expectations file"
+      }
+      Mode.Dump -> {
+        description = "Write the current Zipline APIs to the expectations file"
+      }
+    }
+  }
+
   @TaskAction
   fun task() {
     val tomlFile = ziplineApiFile.get().asFile

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -116,7 +116,7 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
 
   private fun registerZiplineApiTask(
     project: Project,
-    kotlinCompileTool: KotlinCompileTool,
+    compileTask: KotlinCompileTool,
     mode: ZiplineApiValidationTask.Mode,
   ) {
     val task = project.tasks.register(
@@ -125,10 +125,16 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
       mode,
     )
 
-    task.configure {
-      it.ziplineApiFile.set(project.file("api/zipline-api.toml"))
-      it.sourcepath.setFrom(kotlinCompileTool.sources)
-      it.classpath.setFrom(kotlinCompileTool.libraries)
+    if (mode == ZiplineApiValidationTask.Mode.Check) {
+      project.tasks.named("check").configure { checkTask ->
+        checkTask.dependsOn(task)
+      }
+    }
+
+    task.configure { task ->
+      task.ziplineApiFile.set(project.file("api/zipline-api.toml"))
+      task.sourcepath.setFrom(compileTask.sources)
+      task.classpath.setFrom(compileTask.libraries)
     }
   }
 

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplinePluginTest.kt
@@ -245,6 +245,11 @@ class ZiplinePluginTest {
     ziplineApiTaskFailsOnDroppedApi(":lib:ziplineApiDump")
   }
 
+  @Test
+  fun checkTaskIncludesZiplineApiCheck() {
+    ziplineApiTaskFailsOnDroppedApi(":lib:check")
+  }
+
   private fun ziplineApiTaskFailsOnDroppedApi(taskName: String) {
     val projectDir = File("src/test/projects/basic")
     val ziplineApiToml = projectDir.resolve("lib/api/zipline-api.toml")


### PR DESCRIPTION
This will break downstream users. They'll be able to fix by running ziplineApiDump and checking in the produced file.