### PR TITLE
Set JDK versions when running the compiler frontend

### DIFF
--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager
 import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporterFactory
 import org.jetbrains.kotlin.fir.pipeline.FirResult
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
@@ -50,6 +51,8 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
  * https://github.com/cashapp/redwood/blob/afe1c9f5f95eec3cff46837a4b2749cbaf72af8b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt#L28
  */
 internal class KotlinFirLoader(
+  private val javaHome: File,
+  private val jdkRelease: Int,
   private val sources: Collection<File>,
   private val classpath: Collection<File>,
 ) : AutoCloseable {
@@ -76,10 +79,10 @@ internal class KotlinFirLoader(
     configuration.put(CommonConfigurationKeys.MODULE_NAME, targetName)
     configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
     configuration.put(CommonConfigurationKeys.USE_FIR, true)
+    configuration.put(JVMConfigurationKeys.JDK_HOME, javaHome)
+    configuration.put(JVMConfigurationKeys.JDK_RELEASE, jdkRelease)
     configuration.addKotlinSourceRoots(sources.map { it.absolutePath })
-    // TODO Figure out how to add the JDK modules to the classpath. Currently importing the stdlib
-    //  allows a typealias to resolve to a JDK type which doesn't exist and thus breaks analysis.
-    configuration.addJvmClasspathRoots(classpath.filter { "kotlin-stdlib-" !in it.path })
+    configuration.addJvmClasspathRoots(classpath.toList())
 
     val environment = KotlinCoreEnvironment.createForProduction(
       disposable,

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/ValidateZiplineApi.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/ValidateZiplineApi.kt
@@ -31,6 +31,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.path
 import java.io.File
 import kotlin.io.path.exists
@@ -65,6 +66,16 @@ class ValidateZiplineApi(
     .required()
     .help("Path to the TOML file that this command will read and write")
 
+  private val javaHome by option("--java-home")
+    .path()
+    .required()
+    .help("JAVA_HOME to build against")
+
+  private val jdkRelease by option("--jdk-release")
+    .int()
+    .required()
+    .help("JDK release version to build against")
+
   private val sources by option("--sources")
     .file()
     .split(File.pathSeparator)
@@ -84,7 +95,7 @@ class ValidateZiplineApi(
       else -> TomlZiplineApi(listOf())
     }
 
-    val actualZiplineApi = readFirZiplineApi(sources, classpath)
+    val actualZiplineApi = readFirZiplineApi(javaHome.toFile(), jdkRelease, sources, classpath)
 
     when (val decision = makeApiCompatibilityDecision(expectedZiplineApi, actualZiplineApi)) {
       is ActualApiHasProblems -> {

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ValidateZiplineApiTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ValidateZiplineApiTask.kt
@@ -48,6 +48,12 @@ abstract class ValidateZiplineApiTask @Inject constructor(
   @get:OutputFile
   abstract val ziplineApiFile: RegularFileProperty
 
+  @get:Input
+  abstract val javaHome: Property<String>
+
+  @get:Input
+  abstract val jdkRelease: Property<Int>
+
   @get:InputFiles
   internal val sourcepath = fileCollectionFactory.configurableFiles("sourcepath")
 
@@ -76,6 +82,8 @@ abstract class ValidateZiplineApiTask @Inject constructor(
       it.mode.set(mode)
       it.projectDirectory.set(project.projectDir)
       it.tomlFile.set(tomlFileRelative)
+      it.javaHome.set(File(javaHome.get()))
+      it.jdkRelease.set(jdkRelease.get())
       it.sources.setFrom(sourcepath)
       it.classpath.setFrom(classpath)
     }
@@ -92,6 +100,8 @@ private interface ZiplineApiValidatorParameters : WorkParameters {
   val mode: Property<Mode>
   val projectDirectory: DirectoryProperty
   val tomlFile: RegularFileProperty
+  val javaHome: RegularFileProperty
+  val jdkRelease: Property<Int>
   val sources: ConfigurableFileCollection
   val classpath: ConfigurableFileCollection
 }
@@ -118,6 +128,10 @@ private abstract class ZiplineApiValidatorWorker @Inject constructor(
         subcommand,
         "--toml-file",
         parameters.tomlFile.get().asFile.toRelativeString(workingDirectory),
+        "--java-home",
+        parameters.javaHome.get().asFile.toString(),
+        "--jdk-release",
+        parameters.jdkRelease.get().toString(),
         "--sources",
         parameters.sources.files.joinToString(File.pathSeparator),
         "--class-path",

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -157,6 +157,7 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
       // TODO: the validation uses the wrong JDK. We should be getting the JDK from the
       //     KotlinCompile task (as defaultKotlinJavaToolchain.get().buildJvm), but it doesn't
       //     make that available for querying. Hack it to use Gradle's 'current' JVM.
+      //     https://youtrack.jetbrains.com/issue/KT-59735
       val buildJvm = Jvm.current()
       task.javaHome.set(buildJvm.javaHome.path)
       task.jdkRelease.set(


### PR DESCRIPTION
This is necessary to load JPMS modules from the JDK.

Unfortunately there's no nice API to fetch the JDK version from the Gradle KotlinCompile task. It exposes an API to write this data but not to read it.