### PR TITLE
Migrate `SetTimeout` test to `runTest`

### DIFF
--- a/zipline/src/hostTest/kotlin/app/cash/zipline/SetTimeoutTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/SetTimeoutTest.kt
@@ -16,28 +16,28 @@
 package app.cash.zipline
 
 import app.cash.zipline.testing.loadTestingJs
-import app.cash.zipline.testing.singleThreadCoroutineDispatcher
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 
 class SetTimeoutTest {
-  private val dispatcher = singleThreadCoroutineDispatcher("SetTimeoutTest")
+  private val dispatcher = StandardTestDispatcher()
   private val zipline = Zipline.create(dispatcher)
 
-  @BeforeTest fun setUp(): Unit = runBlocking(dispatcher) {
+  @BeforeTest fun setUp() = runTest(dispatcher) {
     zipline.loadTestingJs()
     zipline.quickJs.evaluate("testing.app.cash.zipline.testing.initZipline()")
   }
 
-  @AfterTest fun tearDown() = runBlocking(dispatcher) {
+  @AfterTest fun tearDown() = runTest(dispatcher) {
     zipline.close()
   }
 
-  @Test fun happyPath() = runBlocking(dispatcher) {
+  @Test fun happyPath() = runTest(dispatcher) {
     zipline.quickJs.evaluate(
       """
       var greeting = 'hello';
@@ -55,7 +55,7 @@ class SetTimeoutTest {
     assertEquals("goodbye", zipline.quickJs.evaluate("greeting"))
   }
 
-  @Test fun ziplineCloseSilentlyCancelsQueuedTasks(): Unit = runBlocking(dispatcher) {
+  @Test fun ziplineCloseSilentlyCancelsQueuedTasks() = runTest(dispatcher) {
     zipline.quickJs.evaluate(
       """
       var doNothing = function() {


### PR DESCRIPTION
The test now skips delays and runs in constant time regardless of the amount passed to `setTimeout` and `delay`.

Closes #1073. Closes #1080.

There's a lot of tests to migrate to this style.