### PR TITLE
Force a fresh release

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,4 @@ in this repo as are the release tags. Available versions are listed on
 [qjs]: https://bellard.org/quickjs/
 [trivia.kt]: samples/trivia/trivia-shared/src/commonMain/kotlin/app/cash/zipline/samples/trivia/trivia.kt
 [triviaJs.kt]: samples/trivia/trivia-js/src/jsMain/kotlin/app/cash/zipline/samples/trivia/triviaJs.kt
+


### PR DESCRIPTION
Some changes were made at Sonatype to fix issues with Misk publishing. This PR kicks off a fresh release once merged to trunk and will verify that publishing still works for other Cash App repos.