### PR TITLE
Use min-sdk from toml for world-clock.

### DIFF
--- a/samples/world-clock/android/build.gradle.kts
+++ b/samples/world-clock/android/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
   defaultConfig {
     applicationId = "com.example.zipline.worldclock"
-    minSdk = libs.versions.compileSdk.get().toInt()
+    minSdk = libs.versions.minSdk.get().toInt()
   }
 
   compileOptions {

--- a/samples/world-clock/android/build.gradle.kts
+++ b/samples/world-clock/android/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
   defaultConfig {
     applicationId = "com.example.zipline.worldclock"
-    minSdk = libs.versions.minSdk.get().toInt()
+    minSdk = 21
   }
 
   compileOptions {


### PR DESCRIPTION
 - Fix for compile-sdk being used as min-sdk in world-clock android sample