### PR TITLE
Don't use dataWithBytesNoCopy

### DIFF
--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
@@ -37,7 +37,7 @@ import platform.CoreFoundation.kCFTypeDictionaryValueCallBacks
 import platform.Foundation.CFBridgingRelease
 import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
-import platform.Foundation.dataWithBytesNoCopy
+import platform.Foundation.dataWithBytes
 import platform.Security.SecKeyCreateWithData
 import platform.Security.SecKeyVerifySignature
 import platform.Security.errSecVerifyFailed
@@ -117,7 +117,7 @@ internal class EcdsaP256 : SignatureAlgorithm {
       byteArray.isNotEmpty() -> pin.addressOf(0)
       else -> null
     }
-    val nsData = NSData.dataWithBytesNoCopy(
+    val nsData = NSData.dataWithBytes(
       bytes = bytesPointer,
       length = byteArray.size.convert(),
     )


### PR DESCRIPTION
I was observing heap corruption when calling this function on a non-main thread.

This resulted in crashes in either the GC finalizer processor:

        Thread 4 Crashed:: GC finalizer processor
        0   libsystem_kernel.dylib               0x187ca4764 __pthread_kill + 8
        1   libsystem_pthread.dylib              0x187cdbc28 pthread_kill + 288
        2   libsystem_c.dylib                    0x187be9ae8 abort + 180
        3   libsystem_malloc.dylib               0x187b0ae28 malloc_vreport + 908
        4   libsystem_malloc.dylib               0x187b0e6e8 malloc_report + 64
        5   libsystem_malloc.dylib               0x187b1af20 find_zone_and_free + 308
        6   Foundation                           0x188cde424 -[NSConcreteData dealloc] + 96
        7   test.kexe                            0x101201c14 kotlin::mm::ExtraObjectData::Uninstall() + 372
        8   test.kexe                            0x101203724 kotlin::mm::ObjectFactory<kotlin::gc::ConcurrentMarkAndSweep>::FinalizerQueue::Finalize() + 208
        9   test.kexe                            0x1012031c4 std::__1::invoke_result<kotlin::gc::FinalizerProcessor::StartFinalizerThreadIfNone()::>::type
        ...

Or the application thread:

        Thread 6 Crashed:
        0   libsystem_kernel.dylib               0x187ca4764 __pthread_kill + 8
        1   libsystem_pthread.dylib              0x187cdbc28 pthread_kill + 288
        2   libsystem_c.dylib                    0x187be9ae8 abort + 180
        3   libsystem_malloc.dylib               0x187b0ae28 malloc_vreport + 908
        4   libsystem_malloc.dylib               0x187b0e6e8 malloc_report + 64
        5   libsystem_malloc.dylib               0x187b1af20 find_zone_and_free + 308
        6   Foundation                           0x188cde424 -[NSConcreteData dealloc] + 96
        7   libobjc.A.dylib                      0x1879480b4 AutoreleasePoolPage::releaseUntil(objc_object**) + 196
        8   libobjc.A.dylib                      0x187944b7c objc_autoreleasePoolPop + 256
        9   test.kexe                            0x10300f8d8 Kotlin_objc_autoreleasePoolPop + 140
        10  test.kexe                            0x102cfdd3c kfun:kotlinx.cinterop#autoreleasepool(kotlin.Function0<0:0>){0§<kotlin.Any?>}0:0 + 120 (ObjectiveCUtils.kt:15) [inlined]
        ...

Crashes reproduce consistently and do not recur with this fix.