### PR TITLE
Use NSData.dataWithBytesNoCopy, but don't free

### DIFF
--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
@@ -37,7 +37,7 @@ import platform.CoreFoundation.kCFTypeDictionaryValueCallBacks
 import platform.Foundation.CFBridgingRelease
 import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
-import platform.Foundation.dataWithBytes
+import platform.Foundation.dataWithBytesNoCopy
 import platform.Security.SecKeyCreateWithData
 import platform.Security.SecKeyVerifySignature
 import platform.Security.errSecVerifyFailed
@@ -117,9 +117,10 @@ internal class EcdsaP256 : SignatureAlgorithm {
       byteArray.isNotEmpty() -> pin.addressOf(0)
       else -> null
     }
-    val nsData = NSData.dataWithBytes(
+    val nsData = NSData.dataWithBytesNoCopy(
       bytes = bytesPointer,
       length = byteArray.size.convert(),
+      freeWhenDone = false,
     )
     val typeRef = CFBridgingRetain(nsData) as CFDataRef
     try {


### PR DESCRIPTION
This function frees its argument which surprised me. Opt-out of that behavior.