### PR TITLE
Replace `[en|de]codeNullableSerializableElement` with `nullable`

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineApis.kt
@@ -36,6 +36,7 @@ internal class ZiplineApis(
   private val ziplineFqPackage = FqPackageName("app.cash.zipline")
   private val bridgeFqPackage = FqPackageName("app.cash.zipline.internal.bridge")
   private val serializationFqPackage = FqPackageName("kotlinx.serialization")
+  private val serializationBuiltInsFqPackage = FqPackageName("kotlinx.serialization.builtins")
   private val collectionsFqPackage = FqPackageName(StandardClassIds.BASE_COLLECTIONS_PACKAGE)
   val contextualClassId = serializationFqPackage.classId("Contextual")
   private val serializationModulesFqPackage = FqPackageName("kotlinx.serialization.modules")
@@ -95,6 +96,10 @@ internal class ZiplineApis(
     get() = pluginContext.referenceFunctions(
       bridgeFqPackage.callableId("requireContextual"),
     ).single()
+
+  val nullableSerializer: IrPropertySymbol
+    get() = pluginContext.referenceProperties(serializationBuiltInsFqPackage.callableId("nullable"))
+      .single()
 
   /** This symbol for `ziplineServiceSerializer(KClass<*>, List<KSerializer<*>>)`. */
   val ziplineServiceSerializerTwoArg: IrSimpleFunctionSymbol

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
@@ -21,7 +21,6 @@ import app.cash.zipline.ZiplineFunction
 import app.cash.zipline.ZiplineScoped
 import app.cash.zipline.ZiplineService
 import app.cash.zipline.ziplineServiceSerializer
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -226,7 +225,6 @@ internal class RealCallSerializer(
   }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 internal class ArgsListSerializer(
   internal val serializers: List<KSerializer<*>>,
 ) : KSerializer<List<*>> {
@@ -237,7 +235,7 @@ internal class ArgsListSerializer(
     encoder.encodeStructure(descriptor) {
       for (i in serializers.indices) {
         @Suppress("UNCHECKED_CAST") // We don't have a type argument T for each parameter.
-        encodeNullableSerializableElement(descriptor, i, serializers[i] as KSerializer<Any?>, value[i])
+        encodeSerializableElement(descriptor, i, serializers[i] as KSerializer<Any?>, value[i])
       }
     }
   }
@@ -247,7 +245,7 @@ internal class ArgsListSerializer(
       val result = mutableListOf<Any?>()
       for (i in serializers.indices) {
         check(decodeElementIndex(descriptor) == i)
-        result += decodeNullableSerializableElement(descriptor, i, serializers[i])
+        result += decodeSerializableElement(descriptor, i, serializers[i])
       }
       check(decodeElementIndex(descriptor) == DECODE_DONE)
       return@decodeStructure result


### PR DESCRIPTION
`encodeNullableSerializableElement` and `decodeNullableSerializableElement` are both experimental APIs, whereas `nullable` isn't.