### PR TITLE
Scope EventListener to a specific Zipline instance

### DIFF
--- a/zipline-loader/api/android/zipline-loader.api
+++ b/zipline-loader/api/android/zipline-loader.api
@@ -129,5 +129,6 @@ public final class app/cash/zipline/loader/ZiplineLoader {
 	public final fun setConcurrentDownloads (I)V
 	public final fun withCache (Lapp/cash/zipline/loader/ZiplineCache;)Lapp/cash/zipline/loader/ZiplineLoader;
 	public final fun withEmbedded (Lokio/Path;Lokio/FileSystem;)Lapp/cash/zipline/loader/ZiplineLoader;
+	public final fun withEventListenerFactory (Lapp/cash/zipline/EventListener$Factory;)Lapp/cash/zipline/loader/ZiplineLoader;
 }
 

--- a/zipline-loader/api/jvm/zipline-loader.api
+++ b/zipline-loader/api/jvm/zipline-loader.api
@@ -129,5 +129,6 @@ public final class app/cash/zipline/loader/ZiplineLoader {
 	public final fun setConcurrentDownloads (I)V
 	public final fun withCache (Lapp/cash/zipline/loader/ZiplineCache;)Lapp/cash/zipline/loader/ZiplineLoader;
 	public final fun withEmbedded (Lokio/Path;Lokio/FileSystem;)Lapp/cash/zipline/loader/ZiplineLoader;
+	public final fun withEventListenerFactory (Lapp/cash/zipline/EventListener$Factory;)Lapp/cash/zipline/loader/ZiplineLoader;
 }
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/Fetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/Fetcher.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
+import app.cash.zipline.EventListener
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import okio.ByteString
@@ -31,6 +32,7 @@ internal interface Fetcher {
    */
   suspend fun fetch(
     applicationName: String,
+    eventListener: EventListener,
     id: String,
     sha256: ByteString,
     nowEpochMs: Long,
@@ -45,6 +47,7 @@ internal interface Fetcher {
 internal suspend fun List<Fetcher>.fetch(
   concurrentDownloadsSemaphore: Semaphore,
   applicationName: String,
+  eventListener: EventListener,
   id: String,
   sha256: ByteString,
   nowEpochMs: Long,
@@ -56,6 +59,7 @@ internal suspend fun List<Fetcher>.fetch(
     try {
       return@withPermit fetcher.fetch(
         applicationName = applicationName,
+        eventListener = eventListener,
         id = id,
         sha256 = sha256,
         nowEpochMs = nowEpochMs,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.loader.ZiplineCache
 import okio.ByteString
 
@@ -27,6 +28,7 @@ internal class FsCachingFetcher(
 ) : Fetcher {
   override suspend fun fetch(
     applicationName: String,
+    eventListener: EventListener,
     id: String,
     sha256: ByteString,
     nowEpochMs: Long,
@@ -34,7 +36,7 @@ internal class FsCachingFetcher(
     url: String,
   ): ByteString? {
     return cache.getOrPut(applicationName, sha256, nowEpochMs) {
-      delegate.fetch(applicationName, id, sha256, nowEpochMs, baseUrl, url)
+      delegate.fetch(applicationName, eventListener, id, sha256, nowEpochMs, baseUrl, url)
     }
   }
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsEmbeddedFetcher.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.loader.internal.getApplicationManifestFileName
 import okio.ByteString
 import okio.FileSystem
@@ -29,6 +30,7 @@ internal class FsEmbeddedFetcher(
 ) : Fetcher {
   override suspend fun fetch(
     applicationName: String,
+    eventListener: EventListener,
     id: String,
     sha256: ByteString,
     nowEpochMs: Long,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcher.kt
@@ -32,14 +32,14 @@ import okio.ByteString.Companion.encodeUtf8
 
 /**
  * Download resources from the network. If the download fails, the exception is reported to
- * [eventListener] and this fetcher returns null.
+ * [EventListener] and this fetcher returns null.
  */
 internal class HttpFetcher(
   private val httpClient: ZiplineHttpClient,
-  private val eventListener: EventListener,
 ) : Fetcher {
   override suspend fun fetch(
     applicationName: String,
+    eventListener: EventListener,
     id: String,
     sha256: ByteString,
     nowEpochMs: Long,
@@ -47,6 +47,7 @@ internal class HttpFetcher(
     url: String,
   ) = fetchByteString(
     applicationName = applicationName,
+    eventListener = eventListener,
     baseUrl = baseUrl,
     url = url,
     requestHeaders = ZIPLINE_REQUEST_HEADERS,
@@ -54,11 +55,13 @@ internal class HttpFetcher(
 
   suspend fun fetchManifest(
     applicationName: String,
+    eventListener: EventListener,
     url: String,
     freshAtEpochMs: Long,
   ): LoadedManifest {
     val manifestBytesWithoutBaseUrlUtf8 = fetchByteString(
       applicationName = applicationName,
+      eventListener = eventListener,
       baseUrl = null,
       url = url,
       requestHeaders = MANIFEST_REQUEST_HEADERS,
@@ -112,6 +115,7 @@ internal class HttpFetcher(
 
   private suspend fun fetchByteString(
     applicationName: String,
+    eventListener: EventListener,
     baseUrl: String?,
     url: String,
     requestHeaders: List<Pair<String, String>>,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/DownloadOnlyFetcherReceiverTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.ALPHA_URL
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.BRAVO_URL
@@ -37,6 +38,7 @@ class DownloadOnlyFetcherReceiverTest {
     dispatcher = dispatcher,
     httpClient = httpClient,
     nowEpochMs = { 1 },
+    eventListenerFactory = EventListenerNoneFactory,
   )
 
   private val fileSystem = systemFileSystem
@@ -49,7 +51,13 @@ class DownloadOnlyFetcherReceiverTest {
       BRAVO_URL to testFixtures.bravoByteString,
     )
 
-    loader.download("test", downloadDir, fileSystem, testFixtures.embeddedLoadedManifest)
+    loader.download(
+      "test",
+      EventListener.NONE,
+      downloadDir,
+      fileSystem,
+      testFixtures.embeddedLoadedManifest,
+    )
 
     assertTrue(fileSystem.exists(downloadDir / testFixtures.alphaSha256Hex))
     assertEquals(

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -33,7 +33,7 @@ import okio.FileSystem
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoaderTester(
-  private val eventListener: EventListener = EventListener.NONE,
+  private val eventListenerFactory: EventListener.Factory = EventListenerNoneFactory,
   private val manifestVerifier: ManifestVerifier = NO_SIGNATURE_CHECKS,
 ) {
   val tempDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "okio-${randomToken().hex()}"
@@ -75,7 +75,7 @@ class LoaderTester(
       manifestVerifier = manifestVerifier,
       httpClient = httpClient,
       nowEpochMs = { nowMillis },
-      eventListener = eventListener,
+      eventListenerFactory = eventListenerFactory,
     ).withEmbedded(
       embeddedDir = embeddedDir,
       embeddedFileSystem = embeddedFileSystem,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
@@ -146,6 +147,7 @@ class ProductionFetcherReceiverTest {
   ): Zipline {
     return loadFromManifest(
       applicationName = applicationName,
+      eventListener = EventListener.NONE,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
       serializersModule = EmptySerializersModule(),
       initializer = initializer,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
@@ -40,7 +40,7 @@ import okio.ByteString.Companion.encodeUtf8
 class ZiplineLoaderSigningTest {
   private val eventListener = LoggingEventListener()
   private val tester = LoaderTester(
-    eventListener = eventListener,
+    eventListenerFactory = eventListener,
     manifestVerifier = ManifestVerifier.Builder()
       .addEd25519("key1", SampleKeys.key1Public)
       .build(),

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.loader
 
 import app.cash.turbine.test
+import app.cash.zipline.EventListener
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
@@ -230,7 +231,13 @@ class ZiplineLoaderTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.bravoByteString,
     )
-    loader.download("test", downloadDir, fileSystem, testFixtures.embeddedLoadedManifest)
+    loader.download(
+      "test",
+      EventListener.NONE,
+      downloadDir,
+      fileSystem,
+      testFixtures.embeddedLoadedManifest,
+    )
 
     // check that files have been downloaded to downloadDir as expected
     assertTrue(fileSystem.exists(downloadDir / getApplicationManifestFileName("test")))
@@ -314,6 +321,7 @@ class ZiplineLoaderTest {
   ): Zipline {
     return loadFromManifest(
       applicationName = applicationName,
+      eventListener = EventListener.NONE,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
       serializersModule = EmptySerializersModule(),
       initializer = initializer,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/FetcherTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
+import app.cash.zipline.EventListener
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -36,6 +37,7 @@ class FetcherTest {
   private val fetcherAlpha = object : Fetcher {
     override suspend fun fetch(
       applicationName: String,
+      eventListener: EventListener,
       id: String,
       sha256: ByteString,
       nowEpochMs: Long,
@@ -50,6 +52,7 @@ class FetcherTest {
   private val fetcherBravo = object : Fetcher {
     override suspend fun fetch(
       applicationName: String,
+      eventListener: EventListener,
       id: String,
       sha256: ByteString,
       nowEpochMs: Long,
@@ -73,6 +76,7 @@ class FetcherTest {
     val actualByteString = fetchers.fetch(
       concurrentDownloadsSemaphore = concurrentDownloadsSemaphore,
       applicationName = "foxtrot",
+      eventListener = EventListener.NONE,
       id = "alpha",
       sha256 = "alpha".encodeUtf8().sha256(),
       nowEpochMs = 1_000L,
@@ -82,6 +86,7 @@ class FetcherTest {
     fetchers.fetch(
       concurrentDownloadsSemaphore = concurrentDownloadsSemaphore,
       applicationName = "foxtrot",
+      eventListener = EventListener.NONE,
       id = "bravo",
       sha256 = "bravo".encodeUtf8().sha256(),
       nowEpochMs = 1_000L,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcherTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/fetcher/HttpFetcherTest.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.loader.internal.fetcher
 
-import app.cash.zipline.EventListener
 import app.cash.zipline.loader.FakeZiplineHttpClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,7 +22,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 class HttpFetcherTest {
-  private val httpFetcher = HttpFetcher(FakeZiplineHttpClient(), EventListener.NONE)
+  private val httpFetcher = HttpFetcher(FakeZiplineHttpClient())
   private val json = Json {
     prettyPrint = true
   }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -29,19 +29,20 @@ import okio.ByteString
 import okio.FileSystem
 import okio.Path
 
+val EventListenerNoneFactory = EventListener.Factory { _, _ -> EventListener.NONE }
+
 fun testZiplineLoader(
   dispatcher: CoroutineDispatcher,
   manifestVerifier: ManifestVerifier = NO_SIGNATURE_CHECKS,
   httpClient: ZiplineHttpClient,
   nowEpochMs: () -> Long,
-  eventListener: EventListener = EventListener.NONE,
+  eventListenerFactory: EventListener.Factory,
 ) = ZiplineLoader(
-  dispatcher,
-  manifestVerifier,
-  httpClient,
-  eventListener,
-  nowEpochMs,
-)
+  dispatcher = dispatcher,
+  manifestVerifier = manifestVerifier,
+  httpClient = httpClient,
+  nowEpochMs = nowEpochMs,
+).withEventListenerFactory(eventListenerFactory)
 
 fun testZiplineCache(
   fileSystem: FileSystem,

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -22,9 +22,11 @@ import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.ZiplineService
 
-class LoggingEventListener : EventListener() {
+class LoggingEventListener : EventListener(), EventListener.Factory {
   private var nextCallId = 1
   private val log = ArrayDeque<LogEntry>()
+
+  override fun create(applicationName: String, manifestUrl: String?) = this
 
   override fun bindService(zipline: Zipline, name: String, service: ZiplineService) {
     log(

--- a/zipline/api/android/zipline.api
+++ b/zipline/api/android/zipline.api
@@ -50,6 +50,10 @@ public final class app/cash/zipline/EventListener$Companion {
 	public final fun getNONE ()Lapp/cash/zipline/EventListener;
 }
 
+public abstract interface class app/cash/zipline/EventListener$Factory {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/zipline/EventListener;
+}
+
 public abstract interface class app/cash/zipline/InterruptHandler {
 	public abstract fun poll ()Z
 }

--- a/zipline/api/jvm/zipline.api
+++ b/zipline/api/jvm/zipline.api
@@ -50,6 +50,10 @@ public final class app/cash/zipline/EventListener$Companion {
 	public final fun getNONE ()Lapp/cash/zipline/EventListener;
 }
 
+public abstract interface class app/cash/zipline/EventListener$Factory {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/zipline/EventListener;
+}
+
 public abstract interface class app/cash/zipline/InterruptHandler {
 	public abstract fun poll ()Z
 }

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
@@ -230,6 +230,20 @@ abstract class EventListener {
   open fun ziplineClosed(zipline: Zipline) {
   }
 
+  fun interface Factory {
+    /**
+     * Creates an event listener to receive all events of a single [Zipline] instance.
+     *
+     * This may be used to group events from the same load, without tracking distinct [Zipline]
+     * instances in a map. For example, it could be used to connect a [serviceLeaked] event to the
+     * offending code's `manifestUrl` or [ZiplineManifest.version].
+     */
+    fun create(
+      applicationName: String,
+      manifestUrl: String?,
+    ): EventListener
+  }
+
   companion object {
     val NONE: EventListener = object : EventListener() {
     }


### PR DESCRIPTION
This introduces a new interface, EventListener.Factory, similar to a class of the same name in OkHttp.

Implementations of this interface may produce a distinct EventListener instance for each Zipline instance. We want this downstream so that we can associate metadata collected at loading time to events that occur at execution time.