### PR TITLE
Make Zipline's EventListener public

### DIFF
--- a/zipline/api/android/zipline.api
+++ b/zipline/api/android/zipline.api
@@ -167,6 +167,7 @@ public final class app/cash/zipline/Zipline {
 	public final fun bind (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
 	public final fun bind (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;)V
 	public final fun close ()V
+	public final fun getEventListener ()Lapp/cash/zipline/EventListener;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun getQuickJs ()Lapp/cash/zipline/QuickJs;
 	public final fun loadJsModule (Ljava/lang/String;Ljava/lang/String;)V

--- a/zipline/api/jvm/zipline.api
+++ b/zipline/api/jvm/zipline.api
@@ -167,6 +167,7 @@ public final class app/cash/zipline/Zipline {
 	public final fun bind (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
 	public final fun bind (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;Lapp/cash/zipline/internal/bridge/ZiplineServiceAdapter;)V
 	public final fun close ()V
+	public final fun getEventListener ()Lapp/cash/zipline/EventListener;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun getQuickJs ()Lapp/cash/zipline/QuickJs;
 	public final fun loadJsModule (Ljava/lang/String;Ljava/lang/String;)V

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -44,7 +44,7 @@ actual class Zipline private constructor(
   userSerializersModule: SerializersModule,
   dispatcher: CoroutineDispatcher,
   private val scope: CoroutineScope,
-  private val eventListener: EventListener,
+  val eventListener: EventListener,
 ) {
   private val endpoint = Endpoint(
     scope = scope,


### PR DESCRIPTION
ZiplineLoader creates an EventListener and associates it with a Zipline instance. I'd like to later recover the created EventListener instance.