### PR TITLE
Upgrade to SQLDelight 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlinx-serialization = "1.6.0"
 okHttp = "4.12.0"
 okio = "3.6.0"
 minSdk = "18"
-sqldelight = "1.5.5"
+sqldelight = "2.0.0"
 
 [libraries]
 android-desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
@@ -57,11 +57,11 @@ okio-core = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakeFileSystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "4.2.1" }
 shadowJar-gradle-plugin = { module = "gradle.plugin.com.github.johnrengelman:shadow", version = "8.0.0" }
-sqldelight-gradle-plugin = { module = "com.squareup.sqldelight:gradle-plugin", version.ref = "sqldelight" }
-sqldelight-driver-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
-sqldelight-driver-native = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqldelight" }
-sqldelight-driver-sqlite = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
-sqldelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqldelight" }
+sqldelight-gradle-plugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
+sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
+sqldelight-driver-native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-driver-sqlite = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version = "3.44.0.0" }
 turbine = { module = "app.cash.turbine:turbine", version = "1.0.0" }
 downloadTask-gradle-plugin = { module = "de.undercouch:gradle-download-task", version = "5.5.0" }

--- a/zipline-loader-testing/build.gradle.kts
+++ b/zipline-loader-testing/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 plugins {
   kotlin("multiplatform")
   kotlin("plugin.serialization")
-  id("com.squareup.sqldelight")
+  id("app.cash.sqldelight")
 }
 
 kotlin {
@@ -51,7 +51,9 @@ kotlin {
 }
 
 sqldelight {
-  database("Produce") {
-    packageName = "app.cash.zipline.loader.internal.cache.testing"
+  databases {
+    create("Produce") {
+      packageName.set("app.cash.zipline.loader.internal.cache.testing")
+    }
   }
 }

--- a/zipline-loader/build.gradle.kts
+++ b/zipline-loader/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   kotlin("plugin.serialization")
   id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base")
-  id("com.squareup.sqldelight")
+  id("app.cash.sqldelight")
   id("de.undercouch.download")
   id("binary-compatibility-validator")
 }
@@ -135,8 +135,10 @@ android {
 }
 
 sqldelight {
-  database("Database") {
-    packageName = "app.cash.zipline.loader.internal.cache"
+  databases {
+    create("Database") {
+      packageName.set("app.cash.zipline.loader.internal.cache")
+    }
   }
 }
 

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
@@ -17,6 +17,7 @@ package app.cash.zipline.loader.internal.cache
 
 import android.content.Context
 import android.database.SQLException
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
@@ -25,7 +26,7 @@ import okio.Path
 internal actual class SqlDriverFactory(
   private val context: Context,
 ) {
-  actual fun create(path: Path, schema: SqlSchema<*>): SqlDriver {
+  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     return AndroidSqliteDriver(
       schema = schema,

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
@@ -17,14 +17,15 @@ package app.cash.zipline.loader.internal.cache
 
 import android.content.Context
 import android.database.SQLException
-import com.squareup.sqldelight.android.AndroidSqliteDriver
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import okio.Path
 
 internal actual class SqlDriverFactory(
   private val context: Context,
 ) {
-  actual fun create(path: Path, schema: SqlDriver.Schema): SqlDriver {
+  actual fun create(path: Path, schema: SqlSchema<*>): SqlDriver {
     validateDbPath(path)
     return AndroidSqliteDriver(
       schema = schema,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader
 
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.zipline.loader.internal.cache.Database
 import app.cash.zipline.loader.internal.cache.FileState
 import app.cash.zipline.loader.internal.cache.Files
@@ -22,7 +23,6 @@ import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import app.cash.zipline.loader.internal.cache.createDatabase
 import app.cash.zipline.loader.internal.cache.isSqlException
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
-import com.squareup.sqldelight.db.SqlDriver
 import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import okio.Closeable

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
@@ -15,8 +15,9 @@
  */
 package app.cash.zipline.loader.internal.cache
 
-import com.squareup.sqldelight.EnumColumnAdapter
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.EnumColumnAdapter
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import okio.Path
 
 internal expect class SqlDriverFactory {
@@ -25,7 +26,7 @@ internal expect class SqlDriverFactory {
    *
    * Database is created and migrated after the driver is initialized prior to return.
    */
-  fun create(path: Path, schema: SqlDriver.Schema): SqlDriver
+  fun create(path: Path, schema: SqlSchema<*>): SqlDriver
 }
 
 /** Identify if an exception is from platform specific SqlLite library */

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.loader.internal.cache
 
 import app.cash.sqldelight.EnumColumnAdapter
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import okio.Path
@@ -26,7 +27,7 @@ internal expect class SqlDriverFactory {
    *
    * Database is created and migrated after the driver is initialized prior to return.
    */
-  fun create(path: Path, schema: SqlSchema<*>): SqlDriver
+  fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver
 }
 
 /** Identify if an exception is from platform specific SqlLite library */

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseCommonTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseCommonTest.kt
@@ -15,11 +15,11 @@
  */
 package app.cash.zipline.loader.internal.cache
 
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.zipline.loader.randomToken
 import app.cash.zipline.loader.testSqlDriverFactory
 import app.cash.zipline.loader.testing.LoaderTestFixtures
 import app.cash.zipline.testing.systemFileSystem
-import com.squareup.sqldelight.db.SqlDriver
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.cache
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
@@ -22,7 +23,7 @@ import java.sql.SQLException
 import okio.Path
 
 internal actual class SqlDriverFactory {
-  actual fun create(path: Path, schema: SqlSchema<*>): SqlDriver {
+  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:$path")
     try {

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
@@ -15,13 +15,14 @@
  */
 package app.cash.zipline.loader.internal.cache
 
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.sql.SQLException
 import okio.Path
 
 internal actual class SqlDriverFactory {
-  actual fun create(path: Path, schema: SqlDriver.Schema): SqlDriver {
+  actual fun create(path: Path, schema: SqlSchema<*>): SqlDriver {
     validateDbPath(path)
     val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:$path")
     try {

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseJvmTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseJvmTest.kt
@@ -15,8 +15,8 @@
  */
 package app.cash.zipline.loader.internal.cache
 
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.zipline.loader.internal.cache.testing.Produce
-import com.squareup.sqldelight.db.SqlDriver
 import kotlin.test.assertEquals
 import okio.Path.Companion.toOkioPath
 import org.junit.After

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/cache/databaseNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/cache/databaseNative.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline.loader.internal.cache
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
@@ -24,7 +25,7 @@ import co.touchlab.sqliter.interop.SQLiteException
 import okio.Path
 
 internal actual class SqlDriverFactory {
-  actual fun create(path: Path, schema: SqlSchema<*>): SqlDriver {
+  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     return NativeSqliteDriver(
       configuration = DatabaseConfiguration(

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseNativeTest.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseNativeTest.kt
@@ -39,6 +39,7 @@ class DatabaseNativeTest {
       schema = Produce.Schema,
     )
     val database = Produce(driver)
+    Produce.Schema.create(driver)
     assertEquals(0, database.produceQueries.count().executeAsOne())
     driver.close()
   }


### PR DESCRIPTION
The old version depended on co.touchlab:sqliter-driver:1.0.10

The new version depends on co.touchlab:sqliter-driver:1.2.3

Unfortunately these dependencies are mutually-incompatible.