### PR TITLE
Fix a crash, value can't be deserialized to Long

### DIFF
--- a/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/encoding.kt
+++ b/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/encoding.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import app.cash.zipline.ZiplineService
+import kotlinx.serialization.Contextual
+
+interface EncodingService : ZiplineService {
+  fun echoLong(request: @Contextual Long): Long
+}

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/encodingJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/encodingJs.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.testing
+
+import app.cash.zipline.Zipline
+
+class JsEncodingService : EncodingService {
+  override fun echoLong(request: Long): Long {
+    return request
+  }
+}
+
+private val zipline by lazy { Zipline.get() }
+
+@JsExport
+fun prepareEncodingJsBridges() {
+  zipline.bind<EncodingService>(
+    "encodingService",
+    JsEncodingService(),
+  )
+}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -68,6 +68,7 @@ internal class Endpoint internal constructor(
     serializersModule = SerializersModule {
       contextual(PassByReference::class, PassByReferenceSerializer(this@Endpoint))
       contextual(Throwable::class, ThrowableSerializer)
+      contextual(Long::class, LongSerializer)
       contextual(Flow::class) { serializers ->
         FlowSerializer(
           ziplineServiceSerializer<FlowZiplineService<Any?>>(

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/longs.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/longs.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.internal.bridge
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.long
+
+/** Put longs in strings if they can't be represented exactly as doubles. */
+internal object LongSerializer : KSerializer<Long> {
+  override val descriptor = PrimitiveSerialDescriptor(
+    "LongSerializer",
+    PrimitiveKind.LONG,
+  )
+
+  override fun deserialize(decoder: Decoder): Long {
+    return when (val jsonElement = (decoder as JsonDecoder).decodeJsonElement()) {
+      is JsonArray, is JsonObject, JsonNull -> throw SerializationException("expected a Long")
+      is JsonPrimitive -> jsonElement.long
+    }
+  }
+
+  override fun serialize(encoder: Encoder, value: Long) {
+    if (value in MIN_SAFE_INTEGER..MAX_SAFE_INTEGER) {
+      encoder.encodeLong(value)
+    } else {
+      encoder.encodeString(value.toString())
+    }
+  }
+
+  // All integers in this range can be expressed as a double. Outside of it they can't.
+  private const val MIN_SAFE_INTEGER = -9007199254740991L // -(2^53 – 1)
+  private const val MAX_SAFE_INTEGER = 9007199254740991L // 2^53 – 1
+}

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/EncodingTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/EncodingTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline
+
+import app.cash.zipline.testing.EncodingService
+import app.cash.zipline.testing.loadTestingJs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class EncodingTest {
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private val dispatcher = UnconfinedTestDispatcher()
+  private val zipline = Zipline.create(dispatcher)
+
+  @BeforeTest fun setUp() = runBlocking(dispatcher) {
+    zipline.loadTestingJs()
+  }
+
+  @AfterTest fun tearDown() = runBlocking(dispatcher) {
+    zipline.close()
+  }
+
+  /**
+   * We encode all numbers as doubles for a significant performance gain in `encodeToStringFast()`.
+   * Unfortunately this breaks high valued longs (greater than 2^53) because they don't all have an
+   * exact representation as a double.
+   *
+   * We work around this by using `@Contextual` on Longs, plus an encoder that wraps very
+   * these high-valued longs in strings.
+   */
+  @Test fun encodeLongs() = runBlocking(dispatcher) {
+    zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareEncodingJsBridges()")
+
+    val service = zipline.take<EncodingService>("encodingService")
+    assertThat(service.echoLong(Long.MIN_VALUE)).isEqualTo(Long.MIN_VALUE)
+    assertThat(service.echoLong(-9007199254740993L)).isEqualTo(-9007199254740993L)
+    assertThat(service.echoLong(-9007199254740992L)).isEqualTo(-9007199254740992L)
+    assertThat(service.echoLong(-9007199254740991L)).isEqualTo(-9007199254740991L)
+    assertThat(service.echoLong(-9007199254740990L)).isEqualTo(-9007199254740990L)
+    assertThat(service.echoLong(-1L)).isEqualTo(-1L)
+    assertThat(service.echoLong(0L)).isEqualTo(0L)
+    assertThat(service.echoLong(1L)).isEqualTo(1L)
+    assertThat(service.echoLong(9007199254740990L)).isEqualTo(9007199254740990L)
+    assertThat(service.echoLong(9007199254740991L)).isEqualTo(9007199254740991L)
+    assertThat(service.echoLong(9007199254740992L)).isEqualTo(9007199254740992L)
+    assertThat(service.echoLong(9007199254740993L)).isEqualTo(9007199254740993L)
+    assertThat(service.echoLong(Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE)
+  }
+}


### PR DESCRIPTION
The full stacktrace looks like this:

    app.cash.zipline.QuickJsException: 9007199254740992 can't be deserialized to Long due to a potential precision loss
        at JavaScript.captureStack(./kotlin-kotlin-stdlib.js:3207)
        at JavaScript.SerializationException_init_$Create$_0(./kotlinx-serialization-kotlinx-serialization-core.js:828)
        at JavaScript.<anonymous>(./kotlinx-serialization-kotlinx-serialization-json.js:6533)
        at ...
        at JavaScript.decodeSerializableValuePolymorphic(./kotlinx-serialization-kotlinx-serialization-json.js:2569)
        at JavaScript.<anonymous>(./kotlinx-serialization-kotlinx-serialization-json.js:6385)
        at JavaScript.decodeDynamic(./kotlinx-serialization-kotlinx-serialization-json.js:6252)
        at JavaScript.decodeFromDynamic(./kotlinx-serialization-kotlinx-serialization-json.js:6227)
        at JavaScript.decodeFromStringFast(./zipline-root-zipline.js:4221)
        at ...
        at app.cash.zipline.JniCallChannel.call(Native Method)
        at app.cash.zipline.JniCallChannel.call(JniCallChannel.kt:25)
        at app.cash.zipline.Zipline$endpoint$1.call(Zipline.kt:61)
        at app.cash.zipline.internal.bridge.OutboundCallHandler.call(OutboundCallHandler.kt:98)
        at app.cash.zipline.testing.EncodingService$Companion$Adapter$GeneratedOutboundService.echoLong(encoding.kt:20)
        at app.cash.zipline.EncodingTest$encodeLong$1.invokeSuspend(EncodingTest.kt:48)