### PR TITLE
Stop setting -Xir-per-module

### DIFF
--- a/zipline-testing/build.gradle.kts
+++ b/zipline-testing/build.gradle.kts
@@ -68,12 +68,6 @@ kotlin {
 }
 
 tasks {
-  withType<KotlinJsCompile>().all {
-    kotlinOptions {
-      freeCompilerArgs += listOf("-Xir-per-module")
-    }
-  }
-
   // https://kotlinlang.org/docs/whatsnew19.html#library-linkage-in-kotlin-native
   withType<KotlinNativeCompile>().all {
     kotlinOptions {


### PR DESCRIPTION
This is the default.