### PR TITLE
Add FreshnessChecker into zipline loading process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,14 +69,14 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: jvm-native-libraries
+          name: jvm-native-libraries-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.cmake-arch }}
           path: zipline/src/jvmMain/resources/*
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: test-report
+          name: test-report-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.cmake-arch }}
           path: '**/build/reports/tests/**'
           retention-days: 1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,18 +67,11 @@ jobs:
         run: ./gradlew -p samples check --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
-          name: jvm-native-libraries-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.cmake-arch }}
+          name: jvm-native-libraries
           path: zipline/src/jvmMain/resources/*
           if-no-files-found: error
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: test-report-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.cmake-arch }}
-          path: '**/build/reports/tests/**'
-          retention-days: 1
 
   android:
     # We build on a Mac to get hardware acceleration for the Android emulator.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,6 @@ jobs:
         run: ./gradlew -p samples check --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
-
       - uses: actions/upload-artifact@v4
         with:
           name: jvm-native-libraries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
         run: ./gradlew -p samples check --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
+
       - uses: actions/upload-artifact@v4
         with:
           name: jvm-native-libraries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,11 +67,18 @@ jobs:
         run: ./gradlew -p samples check --stacktrace
         if: matrix.arch == 'amd64' || matrix.arch == 'x86_64'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: jvm-native-libraries
           path: zipline/src/jvmMain/resources/*
           if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: test-report
+          path: '**/build/reports/tests/**'
+          retention-days: 1
 
   android:
     # We build on a Mac to get hardware acceleration for the Android emulator.

--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -16,12 +16,12 @@
 package app.cash.zipline.samples.trivia
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.DefaultFreshnessCheckerNotFresh
 import app.cash.zipline.loader.LoadResult
 import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
-
 fun getTriviaService(zipline: Zipline): TriviaService {
   return zipline.take("triviaService")
 }
@@ -33,7 +33,7 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
     NO_SIGNATURE_CHECKS,
     OkHttpClient(),
   )
-  return when (val result = loader.loadOnce("trivia", manifestUrl)) {
+  return when (val result = loader.loadOnce("trivia", DefaultFreshnessCheckerNotFresh, manifestUrl)) {
     is LoadResult.Success -> result.zipline
     is LoadResult.Failure -> error(result.exception)
   }

--- a/samples/world-clock/presenters/src/hostMain/kotlin/app/cash/zipline/samples/worldclock/host.kt
+++ b/samples/world-clock/presenters/src/hostMain/kotlin/app/cash/zipline/samples/worldclock/host.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.samples.worldclock
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.DefaultFreshnessCheckerNotFresh
 import app.cash.zipline.loader.LoadResult
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
@@ -41,6 +42,7 @@ fun startWorldClockZipline(
   scope.launch(ziplineDispatcher + SupervisorJob()) {
     val loadResultFlow: Flow<LoadResult> = ziplineLoader.load(
       applicationName = "world-clock",
+      freshnessChecker = DefaultFreshnessCheckerNotFresh,
       manifestUrlFlow = repeatFlow(manifestUrl, 500L),
       initializer = { zipline: Zipline ->
         zipline.bind("WorldClockHost", host)

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
@@ -16,6 +16,7 @@
 package app.cash.zipline.tests
 
 import app.cash.zipline.Zipline
+import app.cash.zipline.loader.DefaultFreshnessCheckerNotFresh
 import app.cash.zipline.loader.LoadResult
 import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineHttpClient
@@ -47,7 +48,7 @@ suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
     httpClient = localDirectoryHttpClient,
   )
 
-  val result = loader.loadOnce("test", "https://localhost/manifest.zipline.json")
+  val result = loader.loadOnce("test", DefaultFreshnessCheckerNotFresh, "https://localhost/manifest.zipline.json")
   return when (result) {
     is LoadResult.Success -> result.zipline
     is LoadResult.Failure -> throw result.exception

--- a/zipline-gradle-plugin/src/test/projects/crash/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchCrashServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/crash/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchCrashServiceJvm.kt
@@ -17,6 +17,7 @@ package app.cash.zipline.tests
 
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineException
+import app.cash.zipline.loader.DefaultFreshnessCheckerNotFresh
 import app.cash.zipline.loader.LoadResult
 import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineHttpClient
@@ -56,6 +57,7 @@ suspend fun launchZipline(
 
   val loadResult = loader.loadOnce(
     "test",
+    DefaultFreshnessCheckerNotFresh,
     "https://localhost/manifest.zipline.json",
   ) as LoadResult.Success
 

--- a/zipline-loader/api/android/zipline-loader.api
+++ b/zipline-loader/api/android/zipline-loader.api
@@ -1,7 +1,16 @@
+public final class app/cash/zipline/loader/DefaultFreshnessCheckerNotFresh : app/cash/zipline/loader/FreshnessChecker {
+	public static final field INSTANCE Lapp/cash/zipline/loader/DefaultFreshnessCheckerNotFresh;
+	public fun isFresh (Lapp/cash/zipline/ZiplineManifest;J)Z
+}
+
 public final class app/cash/zipline/loader/FastCodeUpdatesKt {
 	public static final fun schemeAndAuthority (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun withDevelopmentServerPush-SxA4cEA (Lkotlinx/coroutines/flow/Flow;Lapp/cash/zipline/loader/ZiplineHttpClient;J)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun withDevelopmentServerPush-SxA4cEA$default (Lkotlinx/coroutines/flow/Flow;Lapp/cash/zipline/loader/ZiplineHttpClient;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class app/cash/zipline/loader/FreshnessChecker {
+	public abstract fun isFresh (Lapp/cash/zipline/ZiplineManifest;J)Z
 }
 
 public abstract class app/cash/zipline/loader/LoadResult {
@@ -122,9 +131,13 @@ public final class app/cash/zipline/loader/ZiplineLoader {
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineDispatcher;Lapp/cash/zipline/loader/ManifestVerifier;Lapp/cash/zipline/loader/ZiplineHttpClient;Lapp/cash/zipline/EventListener;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun download (Ljava/lang/String;Lokio/Path;Lokio/FileSystem;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConcurrentDownloads ()I
+	public final fun load (Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public final fun load (Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun load$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun load$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun loadOnce (Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun loadOnce (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loadOnce$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun loadOnce$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setConcurrentDownloads (I)V
 	public final fun withCache (Lapp/cash/zipline/loader/ZiplineCache;)Lapp/cash/zipline/loader/ZiplineLoader;

--- a/zipline-loader/api/jvm/zipline-loader.api
+++ b/zipline-loader/api/jvm/zipline-loader.api
@@ -1,7 +1,16 @@
+public final class app/cash/zipline/loader/DefaultFreshnessCheckerNotFresh : app/cash/zipline/loader/FreshnessChecker {
+	public static final field INSTANCE Lapp/cash/zipline/loader/DefaultFreshnessCheckerNotFresh;
+	public fun isFresh (Lapp/cash/zipline/ZiplineManifest;J)Z
+}
+
 public final class app/cash/zipline/loader/FastCodeUpdatesKt {
 	public static final fun schemeAndAuthority (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun withDevelopmentServerPush-SxA4cEA (Lkotlinx/coroutines/flow/Flow;Lapp/cash/zipline/loader/ZiplineHttpClient;J)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun withDevelopmentServerPush-SxA4cEA$default (Lkotlinx/coroutines/flow/Flow;Lapp/cash/zipline/loader/ZiplineHttpClient;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class app/cash/zipline/loader/FreshnessChecker {
+	public abstract fun isFresh (Lapp/cash/zipline/ZiplineManifest;J)Z
 }
 
 public abstract class app/cash/zipline/loader/LoadResult {
@@ -122,9 +131,13 @@ public final class app/cash/zipline/loader/ZiplineLoader {
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineDispatcher;Lapp/cash/zipline/loader/ManifestVerifier;Lapp/cash/zipline/loader/ZiplineHttpClient;Lapp/cash/zipline/EventListener;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun download (Ljava/lang/String;Lokio/Path;Lokio/FileSystem;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConcurrentDownloads ()I
+	public final fun load (Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public final fun load (Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun load$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun load$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun loadOnce (Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun loadOnce (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loadOnce$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Lapp/cash/zipline/loader/FreshnessChecker;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun loadOnce$default (Lapp/cash/zipline/loader/ZiplineLoader;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setConcurrentDownloads (I)V
 	public final fun withCache (Lapp/cash/zipline/loader/ZiplineCache;)Lapp/cash/zipline/loader/ZiplineLoader;

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
@@ -16,17 +16,30 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.ZiplineManifest
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
 
-
-/** Checks if a given ZiplineManifest is considered fresh, therefore safe to be served. */
+/**
+ * Checks if a given ZiplineManifest is considered fresh.
+ *
+ * For local development that requires continuous loading (or hot loading), supply a
+ * FreshnessChecker that always returns false.
+ */
 interface FreshnessChecker {
 
-  /** Returns true if the manifest is considered fresh. */
+  /**
+   * Decides whether the [manifest] is eligible to be used.
+   *
+   * Returns true to launch the [manifest] immediately; false to download a fresh
+   * ZiplineManifest and launch that.
+   */
   fun isFresh(
     manifest: ZiplineManifest,
     freshAtEpochMs: Long,
-    //shelfLife: Duration = 168.hours
   ): Boolean
+}
+
+/** A FreshnessChecker that always returns true. */
+object DefaultFreshnessCheckerNotFresh : FreshnessChecker {
+  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean {
+    return false
+  }
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.zipline.ZiplineManifest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+
+/** Checks if a given ZiplineManifest is considered fresh, therefore safe to be served. */
+interface FreshnessChecker {
+
+  /** Returns true if the manifest is considered fresh. */
+  fun isFresh(
+    manifest: ZiplineManifest,
+    freshAtEpochMs: Long,
+    //shelfLife: Duration = 168.hours
+  ): Boolean
+}

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -157,20 +157,20 @@ class ZiplineLoader internal constructor(
    * network is unreachable: returns null, and emits a LoadResult.Failure
    *
    * @param manifestUrlFlow a flow that emits whenever by the downstream service.
-   * @param freshnessChecker checks if a cached ZiplineManifest is considered fresh.
+   * @param freshnessChecker checks if a cached ZiplineManifest is considered fresh. Defaulted to
+   * always return false, which means always load from network when [manifestUrlFlow] emits.
    */
   fun load(
     applicationName: String,
-    freshnessChecker: FreshnessChecker,
+    freshnessChecker: FreshnessChecker = DefaultFreshnessCheckerNotFresh,
     manifestUrlFlow: Flow<String>,
     serializersModule: SerializersModule = EmptySerializersModule(),
     initializer: (Zipline) -> Unit = {},
   ): Flow<LoadResult> {
     return channelFlow {
       var previousManifest: ZiplineManifest? = null
-      val now = nowEpochMs()
       val localManifest = loadFromLocal(
-        now,
+        nowEpochMs(),
         applicationName,
         freshnessChecker,
         serializersModule,
@@ -188,7 +188,7 @@ class ZiplineLoader internal constructor(
         } else {
           val loadedFromNetwork = loadFromNetwork(
             previousManifest,
-            now,
+            nowEpochMs(),
             applicationName,
             manifestUrl,
             serializersModule,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import okio.IOException
 
 @Suppress("UnstableApiUsage")
 @ExperimentalCoroutinesApi
@@ -147,8 +148,8 @@ class LoaderEventsTest {
       listOf(
         "applicationLoadStart red bogusUrl",
         "downloadStart red bogusUrl",
-        "downloadFailed red bogusUrl java.io.IOException: 404: bogusUrl not found",
-        "applicationLoadFailed red java.io.IOException: 404: bogusUrl not found",
+        "downloadFailed red bogusUrl " + "${IOException::class.qualifiedName}: 404: bogusUrl not found",
+        "applicationLoadFailed red " + "${IOException::class.qualifiedName}: 404: bogusUrl not found",
       ),
       eventListener.takeAll(skipServiceEvents = true),
     )

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
@@ -116,7 +116,6 @@ class LoaderEventsTest {
 
   @Test
   fun loadAlreadyCached() = runBlocking {
-    // TODO
     assertEquals("apple", tester.success("red", "apple", FakeFreshnessCheckerFresh))
     eventListener.takeAll()
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import okio.Buffer
 import okio.FileSystem
@@ -112,13 +113,23 @@ class LoaderTester(
     }
   }
 
-  suspend fun success(applicationName: String, seed: String): String {
-    val success = load(applicationName, seed, count = 1).first() as LoadResult.Success
+  suspend fun success(
+    applicationName: String,
+    seed: String,
+    freshnessChecker: FreshnessChecker,
+  ): String {
+    val success =
+      load(applicationName, seed, count = 1, freshnessChecker).first() as LoadResult.Success
     val log = success.zipline.quickJs.evaluate("globalThis.log", "assert.js") as String
     return log.removeSuffix(" loaded\n")
   }
 
-  fun load(applicationName: String, seed: String, count: Int = 1): Flow<LoadResult> {
+  fun load(
+    applicationName: String,
+    seed: String,
+    count: Int = 1,
+    freshnessChecker: FreshnessChecker,
+  ): Flow<LoadResult> {
     val manifestUrl = "$baseUrl/$applicationName/${getApplicationManifestFileName(applicationName)}"
     val ziplineFileByteString =
       testFixtures.createZiplineFile(LoaderTestFixtures.createJs(seed), "$seed.js")
@@ -134,7 +145,44 @@ class LoaderTester(
     return loader.load(
       applicationName = applicationName,
       manifestUrlFlow = List(count) { manifestUrl }.asFlow(),
-      freshnessChecker = FakeFreshnessCheckerFresh(),
+      freshnessChecker = freshnessChecker,
+    )
+  }
+
+  // Used to test the deprecated load function, and should be deleted when the deprecated function
+  // is removed.
+  suspend fun successForDeprecatedLoad(
+    applicationName: String,
+    seed: String,
+  ): String {
+    val success = deprecatedLoad(applicationName, seed, count = 1).first() as LoadResult.Success
+    val log = success.zipline.quickJs.evaluate("globalThis.log", "assert.js") as String
+    return log.removeSuffix(" loaded\n")
+  }
+
+  // Used to test the deprecated load function, and should be deleted when the deprecated function
+  // is removed.
+  private fun deprecatedLoad(
+    applicationName: String,
+    seed: String,
+    count: Int = 1,
+  ): Flow<LoadResult> {
+    val manifestUrl = "$baseUrl/$applicationName/${getApplicationManifestFileName(applicationName)}"
+    val ziplineFileByteString =
+      testFixtures.createZiplineFile(LoaderTestFixtures.createJs(seed), "$seed.js")
+    val loadedManifest = LoaderTestFixtures.createRelativeManifest(
+      seed,
+      ziplineFileByteString.sha256(),
+      includeUnknownFieldInJson,
+    )
+    httpClient.filePathToByteString = mapOf(
+      manifestUrl to loadedManifest.manifestBytes,
+      "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString,
+    )
+    @Suppress("DEPRECATION_ERROR")
+    return loader.load(
+      applicationName = applicationName,
+      manifestUrlFlow = List(count) { manifestUrl }.asFlow(),
     )
   }
 
@@ -169,6 +217,18 @@ class LoaderTester(
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n",
     )
+  }
+
+  suspend fun failureManifestFetchingFails(applicationName: String): LoadResult {
+    val seed = "fail"
+    val ziplineFileByteString = testFixtures.createZiplineFile(
+      LoaderTestFixtures.createJs(seed),
+      "$seed.js",
+    )
+    httpClient.filePathToByteString = mapOf(
+      "$baseUrl/$applicationName/$seed.zipline" to ziplineFileByteString,
+    )
+    return loader.load(applicationName, FakeFreshnessCheckerFresh, flowOf("bogusUrl")).single()
   }
 
   suspend fun failureManifestTooLarge(applicationName: String): String {
@@ -227,6 +287,18 @@ class LoaderTester(
     return (zipline.quickJs.evaluate("globalThis.log", "assert.js") as String).removeSuffix(
       " loaded\n",
     )
+  }
+
+  suspend fun failureCacheNotFresh(applicationName: String): LoadResult {
+    val manifestUrl = "$baseUrl/$applicationName/${getApplicationManifestFileName(applicationName)}"
+
+    httpClient.filePathToByteString = mapOf()
+
+    return load(
+      applicationName,
+      manifestUrl,
+      freshnessChecker = DefaultFreshnessCheckerNotFresh,
+    ).first()
   }
 
   suspend fun failureCodeFetchFails(applicationName: String): String {
@@ -314,7 +386,7 @@ class LoaderTester(
   ) {
     val results = loader.load(
       applicationName = applicationName,
-      freshnessChecker = FakeFreshnessCheckerFresh(),
+      freshnessChecker = FakeFreshnessCheckerFresh,
       manifestUrlFlow = flowOf(manifestUrl),
       initializer = initializer,
     )
@@ -322,14 +394,8 @@ class LoaderTester(
   }
 }
 
-class FakeFreshnessCheckerFresh : FreshnessChecker {
+object FakeFreshnessCheckerFresh : FreshnessChecker {
   override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean {
     return true
-  }
-}
-
-class FakeFreshnessCheckerNotFresh : FreshnessChecker {
-  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean {
-    return false
   }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
@@ -70,7 +70,7 @@ class ZiplineLoaderSigningTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.bravoByteString,
     )
-    val zipline = (tester.loader.loadOnce("test", MANIFEST_URL) as LoadResult.Success).zipline
+    val zipline = (tester.loader.loadOnce("test", DefaultFreshnessCheckerNotFresh, MANIFEST_URL) as LoadResult.Success).zipline
     zipline.close()
 
     assertContains(eventListener.takeAll(), "manifestVerified test key1")
@@ -100,7 +100,7 @@ class ZiplineLoaderSigningTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.alphaByteString,
     )
-    val result = tester.loader.loadOnce("test", MANIFEST_URL)
+    val result = tester.loader.loadOnce("test", DefaultFreshnessCheckerNotFresh, MANIFEST_URL)
     assertTrue(result is LoadResult.Failure)
     assertTrue(result.exception is IllegalStateException)
     assertEquals("checksum mismatch for bravo", result.exception.message)
@@ -121,7 +121,7 @@ class ZiplineLoaderSigningTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.bravoByteString,
     )
-    val loadResult = tester.loader.loadOnce("test", MANIFEST_URL)
+    val loadResult = tester.loader.loadOnce("test", DefaultFreshnessCheckerNotFresh, MANIFEST_URL)
     assertEquals(
       "manifest signature for key key1 did not verify!",
       (loadResult as LoadResult.Failure).exception.message,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -95,7 +95,11 @@ class ZiplineLoaderTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.bravoByteString,
     )
-    val zipline = (loader.loadOnce("test", MANIFEST_URL) as LoadResult.Success).zipline
+    val zipline = (loader.loadOnce(
+      applicationName = "test",
+      freshnessChecker = FakeFreshnessCheckerFresh(),
+      manifestUrl = MANIFEST_URL,
+    ) as LoadResult.Success).zipline
     assertEquals(
       zipline.getLog(),
       """
@@ -115,7 +119,11 @@ class ZiplineLoaderTest {
       ALPHA_URL to testFixtures.alphaByteString,
       BRAVO_URL to testFixtures.bravoByteString,
     )
-    val ziplineColdCache = (loader.loadOnce("test", MANIFEST_URL) as LoadResult.Success).zipline
+    val ziplineColdCache = (loader.loadOnce(
+      applicationName = "test",
+      freshnessChecker = FakeFreshnessCheckerFresh(),
+      manifestUrl = MANIFEST_URL
+    ) as LoadResult.Success).zipline
     assertEquals(
       ziplineColdCache.quickJs.evaluate("globalThis.log", "assert.js"),
       """
@@ -131,7 +139,10 @@ class ZiplineLoaderTest {
       MANIFEST_URL to testFixtures.manifestNoBaseUrlByteString,
       // Note no actual alpha/bravo files are available on the network
     )
-    val ziplineWarmedCache = (loader.loadOnce("test", MANIFEST_URL) as LoadResult.Success).zipline
+    val ziplineWarmedCache = (loader.loadOnce(
+      applicationName = "test",
+      freshnessChecker = FakeFreshnessCheckerFresh(),
+      manifestUrl = MANIFEST_URL) as LoadResult.Success).zipline
     assertEquals(
       ziplineWarmedCache.quickJs.evaluate("globalThis.log", "assert.js"),
       """
@@ -159,7 +170,11 @@ class ZiplineLoaderTest {
       MANIFEST_URL to testFixtures.manifestByteString,
       // Note no actual alpha/bravo files are available on the cache / network
     )
-    val zipline = (loader.loadOnce("test", MANIFEST_URL) as LoadResult.Success).zipline
+    val zipline = (loader.loadOnce(
+      applicationName = "test",
+      freshnessChecker = FakeFreshnessCheckerFresh(),
+      manifestUrl = MANIFEST_URL
+    ) as LoadResult.Success).zipline
     assertEquals(
       zipline.getLog(),
       """
@@ -282,6 +297,7 @@ class ZiplineLoaderTest {
     val manifestUrlFlow = flowOf(appleManifestUrl, firetruckManifestUrl)
     loader.load(
       applicationName = "red",
+      freshnessChecker = FakeFreshnessCheckerNotFresh(),
       manifestUrlFlow = manifestUrlFlow,
       initializer = {},
     ).test {
@@ -296,16 +312,11 @@ class ZiplineLoaderTest {
           " loaded\n",
         ),
       )
-      assertEquals(
-        "firetruck",
-        (
+      assertEquals("firetruck",(
           (awaitItem() as LoadResult.Success).zipline.quickJs.evaluate(
-          "globalThis.log",
+            "globalThis.log",
             "assert.js",
-        ) as String
-        ).removeSuffix(
-          " loaded\n",
-        ),
+          ) as String).removeSuffix(" loaded\n"),
       )
       awaitComplete()
     }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -115,13 +115,11 @@ class ZiplineLoaderTest {
       initializer = {},
     ).test {
       assertEquals(
-        "firetruck",
-        (
+        "firetruck loaded\n",
         (awaitItem() as LoadResult.Success).zipline.quickJs.evaluate(
           "globalThis.log",
           "assert.js",
-        ) as String
-        ).removeSuffix(" loaded\n"),
+        ),
       )
       awaitComplete()
     }

--- a/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
+++ b/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -146,6 +147,7 @@ class ConsoleTest {
     assertEquals(Level.INFO, record.level)
     assertEquals("this message for %s is a %d out of %d Jesse 8 10", record.message)
 
+    advanceUntilIdle()
     assertNull(takeLogMessage())
   }
 


### PR DESCRIPTION
This PR

1) Added a new parameter to `ZiplineLoader#load`, and `ZiplineLoader#loadOnce`
2) Changed behaviors of `ZiplineLoader#load`, and `ZiplineLoader#loadOnce`
3) `ZiplineLoader#load`, and `ZiplineLoader#loadOnce` with existing parameter list are marked as `@Deprecated`

Follow up changes: 
1) add a informational eventListener.applicationLoadSkipped for reason
2) add retry when fetching from network fails 