### PR TITLE
EventListener.manifestReady

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -259,6 +259,8 @@ class ZiplineLoader internal constructor(
         return null
       }
 
+      eventListener.manifestReady(applicationName, manifestUrl, loadedManifest.manifest)
+
       val zipline = loadFromManifest(
         applicationName,
         eventListener,
@@ -312,6 +314,8 @@ class ZiplineLoader internal constructor(
       return null
     } else {
       try {
+        eventListener.manifestReady(applicationName, null, loadedManifest.manifest)
+
         val zipline = loadFromManifest(
           applicationName,
           eventListener,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderEventsTest.kt
@@ -51,6 +51,7 @@ class LoaderEventsTest {
         "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "manifestReady red",
         "ziplineCreated",
         "downloadStart red https://example.com/files/red/apple.zipline",
         "downloadEnd red https://example.com/files/red/apple.zipline",
@@ -73,6 +74,7 @@ class LoaderEventsTest {
     assertEquals(
       listOf(
         "applicationLoadStart red null",
+        "manifestReady red",
         "ziplineCreated",
         "moduleLoadStart apple",
         "moduleLoadEnd apple",
@@ -96,6 +98,7 @@ class LoaderEventsTest {
         "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "manifestReady red",
         "ziplineCreated",
         "downloadStart red https://example.com/files/red/apple.zipline",
         "downloadEnd red https://example.com/files/red/apple.zipline",
@@ -129,6 +132,7 @@ class LoaderEventsTest {
         "applicationLoadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadStart red https://example.com/files/red/red.manifest.zipline.json",
         "downloadEnd red https://example.com/files/red/red.manifest.zipline.json",
+        "manifestReady red",
         "ziplineCreated",
         "moduleLoadStart apple",
         "moduleLoadEnd apple",
@@ -163,6 +167,7 @@ class LoaderEventsTest {
     assertEquals(
       listOf(
         "applicationLoadStart red null",
+        "manifestReady red",
         "ziplineCreated",
         "moduleLoadStart firetruck",
         "moduleLoadEnd firetruck",
@@ -183,6 +188,7 @@ class LoaderEventsTest {
     assertEquals(
       listOf(
         "applicationLoadStart red null",
+        "manifestReady red",
         "ziplineCreated",
         "moduleLoadStart firetruck",
         "moduleLoadEnd firetruck",
@@ -203,6 +209,7 @@ class LoaderEventsTest {
     assertEquals(
       listOf(
         "applicationLoadStart red null",
+        "manifestReady red",
         "ziplineCreated",
         "moduleLoadStart firetruck",
         "moduleLoadEnd firetruck",

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderSigningTest.kt
@@ -21,6 +21,8 @@ import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.BRAVO_URL
 import app.cash.zipline.loader.testing.LoaderTestFixtures.Companion.MANIFEST_URL
 import app.cash.zipline.loader.testing.SampleKeys
 import app.cash.zipline.testing.LoggingEventListener
+import assertk.assertThat
+import assertk.assertions.isLessThan
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -73,7 +75,13 @@ class ZiplineLoaderSigningTest {
     val zipline = (tester.loader.loadOnce("test", DefaultFreshnessCheckerNotFresh, MANIFEST_URL) as LoadResult.Success).zipline
     zipline.close()
 
-    assertContains(eventListener.takeAll(), "manifestVerified test key1")
+    val events = eventListener.takeAll()
+    assertContains(events, "manifestVerified test key1")
+    assertContains(events, "manifestReady test")
+
+    // The manifestReady event should follow the manifestVerified event.
+    assertThat(events.indexOf("manifestVerified test key1"))
+      .isLessThan(events.indexOf("manifestReady test"))
   }
 
   /**

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -174,6 +174,17 @@ class LoggingEventListener : EventListener(), EventListener.Factory {
     )
   }
 
+  override fun manifestReady(
+    applicationName: String,
+    manifestUrl: String?,
+    manifest: ZiplineManifest,
+  ) {
+    log(
+      applicationName = applicationName,
+      log = "manifestReady $applicationName",
+    )
+  }
+
   override fun moduleLoadStart(zipline: Zipline, moduleId: String): Any? {
     log(
       moduleId = moduleId,

--- a/zipline/api/android/zipline.api
+++ b/zipline/api/android/zipline.api
@@ -38,6 +38,7 @@ public abstract class app/cash/zipline/EventListener {
 	public fun mainFunctionEnd (Lapp/cash/zipline/Zipline;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun mainFunctionStart (Lapp/cash/zipline/Zipline;Ljava/lang/String;)Ljava/lang/Object;
 	public fun manifestParseFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Exception;)V
+	public fun manifestReady (Ljava/lang/String;Ljava/lang/String;Lapp/cash/zipline/ZiplineManifest;)V
 	public fun manifestVerified (Ljava/lang/String;Ljava/lang/String;Lapp/cash/zipline/ZiplineManifest;Ljava/lang/String;)V
 	public fun moduleLoadEnd (Lapp/cash/zipline/Zipline;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun moduleLoadStart (Lapp/cash/zipline/Zipline;Ljava/lang/String;)Ljava/lang/Object;

--- a/zipline/api/jvm/zipline.api
+++ b/zipline/api/jvm/zipline.api
@@ -38,6 +38,7 @@ public abstract class app/cash/zipline/EventListener {
 	public fun mainFunctionEnd (Lapp/cash/zipline/Zipline;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun mainFunctionStart (Lapp/cash/zipline/Zipline;Ljava/lang/String;)Ljava/lang/Object;
 	public fun manifestParseFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Exception;)V
+	public fun manifestReady (Ljava/lang/String;Ljava/lang/String;Lapp/cash/zipline/ZiplineManifest;)V
 	public fun manifestVerified (Ljava/lang/String;Ljava/lang/String;Lapp/cash/zipline/ZiplineManifest;Ljava/lang/String;)V
 	public fun moduleLoadEnd (Lapp/cash/zipline/Zipline;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun moduleLoadStart (Lapp/cash/zipline/Zipline;Ljava/lang/String;)Ljava/lang/Object;

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
@@ -186,6 +186,17 @@ abstract class EventListener {
   }
 
   /**
+   * Invoked when the loader has successfully fetched a manifest, verified it (if necessary), and
+   * will proceed to download and load each of its modules.
+   */
+  open fun manifestReady(
+    applicationName: String,
+    manifestUrl: String?,
+    manifest: ZiplineManifest,
+  ) {
+  }
+
+  /**
    * Invoked when a module load starts. This is the process of loading code into QuickJS.
    *
    * @return any object. This value will be passed back to [moduleLoadEnd] when the call is


### PR DESCRIPTION
I want to trigger behavior based on when the manifest is chosen and a load will proceed.

The specific behavior I want is to preload some data that's in the manifest, and so I want an event that occurs before any other downloading or code loading.