### PR TITLE
Fix opting into EngineApi and expect-actual-classes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,18 @@ allprojects {
   plugins.withId("org.jetbrains.kotlin.multiplatform") {
     configure<KotlinMultiplatformExtension> {
       jvmToolchain(11)
+      @Suppress("OPT_IN_USAGE")
+      compilerOptions {
+        freeCompilerArgs.addAll("-opt-in=app.cash.zipline.EngineApi")
+      }
+      // https://youtrack.jetbrains.com/issue/KT-61573
+      targets.configureEach {
+        compilations.configureEach {
+          compilerOptions.configure {
+            freeCompilerArgs.addAll("-Xexpect-actual-classes")
+          }
+        }
+      }
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp",
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.1.1" }
 binary-compatibility-validator-gradle-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.13.2" }
 cklib-gradle-plugin = { module = "co.touchlab:cklib-gradle-plugin", version = "0.3.0" }
-coil-compose = { module = "io.coil-kt:coil-compose", version = "2.5.0" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.10" }
 duktape = { module = "com.squareup.duktape:duktape-android", version = "1.4.0" }
 http4k-core = { module = "org.http4k:http4k-core", version.ref = "http4k" }

--- a/samples/world-clock/android/build.gradle.kts
+++ b/samples/world-clock/android/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
   implementation(libs.androidx.appCompat)
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.lifecycle)
-  implementation(libs.coil.compose)
   implementation(libs.androidx.compose.material)
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.ui.tooling.preview)

--- a/zipline-bytecode/build.gradle.kts
+++ b/zipline-bytecode/build.gradle.kts
@@ -9,10 +9,10 @@ plugins {
 }
 
 kotlin {
-  sourceSets.all {
-    languageSettings {
-      optIn("app.cash.zipline.EngineApi")
-    }
+  compilerOptions {
+    freeCompilerArgs.addAll(
+      "-opt-in=app.cash.zipline.EngineApi",
+    )
   }
 }
 

--- a/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/StripLineNumbersTest.kt
+++ b/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/StripLineNumbersTest.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.bytecode
 
-import app.cash.zipline.EngineApi
 import app.cash.zipline.QuickJs
 import assertk.assertThat
 import assertk.assertions.startsWith
@@ -23,7 +22,6 @@ import kotlin.test.assertFailsWith
 import org.junit.After
 import org.junit.Test
 
-@OptIn(EngineApi::class)
 class StripLineNumbersTest {
   private val quickJs = QuickJs.create()
 

--- a/zipline-gradle-plugin/build.gradle.kts
+++ b/zipline-gradle-plugin/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 }
 
 kotlin {
-  sourceSets.all {
-    languageSettings {
-      optIn("app.cash.zipline.EngineApi")
-    }
+  compilerOptions {
+    freeCompilerArgs.addAll(
+      "-opt-in=app.cash.zipline.EngineApi",
+    )
   }
 }
 

--- a/zipline-loader-testing/build.gradle.kts
+++ b/zipline-loader-testing/build.gradle.kts
@@ -31,12 +31,6 @@ kotlin {
         implementation(libs.kotlinx.serialization.json)
       }
     }
-
-    sourceSets.all {
-      languageSettings {
-        optIn("app.cash.zipline.EngineApi")
-      }
-    }
   }
 
   targets.all {

--- a/zipline-loader/build.gradle.kts
+++ b/zipline-loader/build.gradle.kts
@@ -102,12 +102,6 @@ kotlin {
         implementation(projects.ziplineLoaderTesting)
       }
     }
-
-    all {
-      languageSettings {
-        optIn("app.cash.zipline.EngineApi")
-      }
-    }
   }
 }
 

--- a/zipline-profiler/build.gradle.kts
+++ b/zipline-profiler/build.gradle.kts
@@ -22,12 +22,6 @@ kotlin {
   tvosX64()
 
   sourceSets {
-    all {
-      languageSettings {
-        optIn("app.cash.zipline.EngineApi")
-      }
-    }
-
     val commonMain by getting {
       dependencies {
         api(projects.zipline)

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/IoTestingCommon.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/IoTestingCommon.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.zipline.testing
 
-import app.cash.zipline.EngineApi
 import app.cash.zipline.Zipline
 import okio.FileSystem
 import okio.Path
@@ -36,7 +35,6 @@ val ziplineRootOrNull: Path?
 internal expect fun getEnv(name: String): String?
 
 /** Load our testing libraries into QuickJS. */
-@OptIn(EngineApi::class)
 fun Zipline.loadTestingJs() {
   // Load modules in topologically-sorted order. In production the zipline-manifest does this.
   loadJsModuleFromResource("./kotlin-kotlin-stdlib.js")

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -150,12 +150,6 @@ kotlin {
         project.dependencies.add(pluginConfigurationName, projects.ziplineKotlinPlugin)
       }
     }
-
-    all {
-      languageSettings {
-        optIn("app.cash.zipline.EngineApi")
-      }
-    }
   }
 }
 


### PR DESCRIPTION
`expect-actual-classes` started warning in `1.9.20`.

Pulling this out of https://github.com/cashapp/zipline/pull/1212.