### PR TITLE
Better error messages when topological sort fails

### DIFF
--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/topologicalSort.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/topologicalSort.kt
@@ -62,18 +62,11 @@ internal fun <T> List<T>.topologicalSort(sourceToTarget: (T) -> Iterable<T>): Li
     buildString {
       append("No topological ordering is possible for these items:")
 
-      val unorderedItems = toMutableSet()
-        .apply {
-          removeAll(result.toSet())
-        }
-
+      val unorderedItems = this@topologicalSort.toSet() - result.toSet()
       for (unorderedItem in unorderedItems) {
         append("\n  ")
         append(unorderedItem)
-        val unsatisfiedDeps = sourceToTarget(unorderedItem).toMutableSet()
-          .apply {
-            removeAll(result.toSet())
-          }
+        val unsatisfiedDeps = sourceToTarget(unorderedItem).toSet() - result.toSet()
         unsatisfiedDeps.joinTo(this, separator = ", ", prefix = " (", postfix = ")")
       }
     }

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/topologicalSort.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/topologicalSort.kt
@@ -59,7 +59,24 @@ internal fun <T> List<T>.topologicalSort(sourceToTarget: (T) -> Iterable<T>): Li
   }
 
   require(result.size == this.size) {
-    "No topological ordering is possible for $this"
+    buildString {
+      append("No topological ordering is possible for these items:")
+
+      val unorderedItems = toMutableSet()
+        .apply {
+          removeAll(result.toSet())
+        }
+
+      for (unorderedItem in unorderedItems) {
+        append("\n  ")
+        append(unorderedItem)
+        val unsatisfiedDeps = sourceToTarget(unorderedItem).toMutableSet()
+          .apply {
+            removeAll(result.toSet())
+          }
+        unsatisfiedDeps.joinTo(this, separator = ", ", prefix = " (", postfix = ")")
+      }
+    }
   }
 
   return result

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineManifestTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineManifestTest.kt
@@ -108,7 +108,10 @@ class ZiplineManifestTest {
       )
     }
     assertEquals(
-      "No topological ordering is possible for [alpha]",
+      """
+      |No topological ordering is possible for these items:
+      |  alpha (alpha)
+      """.trimMargin(),
       selfDependencyException.message,
     )
 
@@ -129,7 +132,11 @@ class ZiplineManifestTest {
       )
     }
     assertEquals(
-      "No topological ordering is possible for [alpha, bravo]",
+      """
+      |No topological ordering is possible for these items:
+      |  alpha (bravo)
+      |  bravo (alpha)
+      """.trimMargin(),
       cyclicalException.message,
     )
   }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
@@ -91,7 +91,7 @@ class TopologicalSortTest {
       |No topological ordering is possible for these items:
       |  a (b)
       |  b (a)
-      """.trimMargin()
+      """.trimMargin(),
     )
   }
 
@@ -105,7 +105,7 @@ class TopologicalSortTest {
       """
       |No topological ordering is possible for these items:
       |  a (c)
-      """.trimMargin()
+      """.trimMargin(),
     )
   }
 
@@ -120,7 +120,7 @@ class TopologicalSortTest {
       |No topological ordering is possible for these items:
       |  d (e)
       |  e (d, f)
-      """.trimMargin()
+      """.trimMargin(),
     )
   }
 

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
@@ -16,6 +16,8 @@
 
 package app.cash.zipline.internal
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -80,10 +82,46 @@ class TopologicalSortTest {
 
   @Test
   fun cycleCrashes() {
-    assertFailsWith<IllegalArgumentException> {
+    val exception = assertFailsWith<IllegalArgumentException> {
       listOf("a", "b")
         .topologicalSort(edges("ab", "ba"))
     }
+    assertThat(exception).hasMessage(
+      """
+      |No topological ordering is possible for these items:
+      |  a (b)
+      |  b (a)
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun elementConsumedButNotDeclaredCrashes() {
+    val exception = assertFailsWith<IllegalArgumentException> {
+      listOf("a", "b")
+        .topologicalSort(edges("ab", "ac"))
+    }
+    assertThat(exception).hasMessage(
+      """
+      |No topological ordering is possible for these items:
+      |  a (c)
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun exceptionMessageOnlyIncludesProblematicItems() {
+    val exception = assertFailsWith<IllegalArgumentException> {
+      listOf("a", "b", "c", "d", "e")
+        .topologicalSort(edges("ab", "bc", "da", "de", "db", "ed", "ef"))
+    }
+    assertThat(exception).hasMessage(
+      """
+      |No topological ordering is possible for these items:
+      |  d (e)
+      |  e (d, f)
+      """.trimMargin()
+    )
   }
 
   private fun assertTopologicalSort(unsorted: List<String>, sorted: List<String>, vararg edges: String) {


### PR DESCRIPTION
    No topological ordering is possible for these items:
      ./Kotlin-DateTime-library-kotlinx-datetime-js-ir.js (@js-joda/core)