### PR TITLE
Introduce Zipline attachments for namespaced functionality

### DIFF
--- a/zipline-cryptography/api/zipline-cryptography.api
+++ b/zipline-cryptography/api/zipline-cryptography.api
@@ -1,3 +1,16 @@
+public abstract interface class app/cash/zipline/cryptography/SecureRandom {
+	public abstract fun nextBytes ([BII)V
+	public abstract fun nextLong ()J
+}
+
+public final class app/cash/zipline/cryptography/SecureRandom$DefaultImpls {
+	public static synthetic fun nextBytes$default (Lapp/cash/zipline/cryptography/SecureRandom;[BIIILjava/lang/Object;)V
+}
+
+public abstract interface class app/cash/zipline/cryptography/ZiplineCryptography {
+	public abstract fun getSecureRandom ()Lapp/cash/zipline/cryptography/SecureRandom;
+}
+
 public final class app/cash/zipline/cryptography/ZiplineCryptographyJvmKt {
 	public static final fun installCryptographyService (Lapp/cash/zipline/Zipline;)V
 }

--- a/zipline-cryptography/src/commonMain/kotlin/app/cash/zipline/cryptography/SecureRandom.kt
+++ b/zipline-cryptography/src/commonMain/kotlin/app/cash/zipline/cryptography/SecureRandom.kt
@@ -15,12 +15,8 @@
  */
 package app.cash.zipline.cryptography
 
-import app.cash.zipline.Zipline
+interface SecureRandom {
+  fun nextBytes(sink: ByteArray, offset: Int = 0, count: Int = sink.size - offset)
 
-val Zipline.cryptography: ZiplineCryptography
-  get() = getOrPutAttachment(ZiplineCryptography::class) {
-    val cryptographyService = take<ZiplineCryptographyService>("zipline/cryptography")
-    object : ZiplineCryptography {
-      override val secureRandom = BridgedSecureRandom(cryptographyService)
-    }
-  }
+  fun nextLong(): Long
+}

--- a/zipline-cryptography/src/commonMain/kotlin/app/cash/zipline/cryptography/ZiplineCryptography.kt
+++ b/zipline-cryptography/src/commonMain/kotlin/app/cash/zipline/cryptography/ZiplineCryptography.kt
@@ -15,8 +15,7 @@
  */
 package app.cash.zipline.cryptography
 
-interface Random {
-  fun nextBytes(sink: ByteArray, offset: Int = 0, count: Int = sink.size - offset)
-
-  fun nextLong(): Long
+/** Guest-side API to Zipline's security services. */
+interface ZiplineCryptography {
+  val secureRandom: SecureRandom
 }

--- a/zipline-cryptography/src/jsMain/kotlin/app/cash/zipline/cryptography/BridgedSecureRandom.kt
+++ b/zipline-cryptography/src/jsMain/kotlin/app/cash/zipline/cryptography/BridgedSecureRandom.kt
@@ -15,9 +15,9 @@
  */
 package app.cash.zipline.cryptography
 
-class SecureRandom internal constructor(
+internal class BridgedSecureRandom internal constructor(
   private val securityService: ZiplineCryptographyService,
-) : Random {
+) : SecureRandom {
   override fun nextBytes(sink: ByteArray, offset: Int, count: Int) {
     require(offset + count <= sink.size) {
       "offset: $offset + count: $count > sink.size: ${sink.size}"

--- a/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/secureRandom.kt
+++ b/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/secureRandom.kt
@@ -18,5 +18,5 @@ package app.cash.zipline.testing
 import app.cash.zipline.ZiplineService
 
 interface RandomStringMaker : ZiplineService {
-  fun randomString(): String
+    fun randomString(): String
 }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/secureRandomJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/secureRandomJs.kt
@@ -17,10 +17,10 @@ package app.cash.zipline.testing
 
 import app.cash.zipline.Zipline
 import app.cash.zipline.cryptography.SecureRandom
-import app.cash.zipline.cryptography.ZiplineCryptography
+import app.cash.zipline.cryptography.cryptography
 
 private val zipline by lazy { Zipline.get() }
-private val ziplineCryptography = ZiplineCryptography(zipline)
+private val ziplineCryptography = zipline.cryptography
 
 class RealRandomStringMaker(
   private val secureRandom: SecureRandom,

--- a/zipline/api/android/zipline.api
+++ b/zipline/api/android/zipline.api
@@ -171,6 +171,7 @@ public final class app/cash/zipline/Zipline {
 	public final fun close ()V
 	public final fun getEventListener ()Lapp/cash/zipline/EventListener;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getOrPutAttachment (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun getQuickJs ()Lapp/cash/zipline/QuickJs;
 	public final fun loadJsModule (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun loadJsModule ([BLjava/lang/String;)V

--- a/zipline/api/jvm/zipline.api
+++ b/zipline/api/jvm/zipline.api
@@ -171,6 +171,7 @@ public final class app/cash/zipline/Zipline {
 	public final fun close ()V
 	public final fun getEventListener ()Lapp/cash/zipline/EventListener;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getOrPutAttachment (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun getQuickJs ()Lapp/cash/zipline/QuickJs;
 	public final fun loadJsModule (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun loadJsModule ([BLjava/lang/String;)V

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
@@ -46,5 +46,5 @@ expect class Zipline {
    * Use this API to attach services, features, or other application data to a Zipline instance so
    * that you may read it later.
    */
-  fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T) : T
+  fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T): T
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/Zipline.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.zipline
 
+import kotlin.reflect.KClass
 import kotlinx.serialization.json.Json
 
 expect class Zipline {
@@ -38,4 +39,12 @@ expect class Zipline {
     name: String,
     scope: ZiplineScope = ZiplineScope(),
   ): T
+
+  /**
+   * Attaches a computed to this Zipline using [key] as a key.
+   *
+   * Use this API to attach services, features, or other application data to a Zipline instance so
+   * that you may read it later.
+   */
+  fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T) : T
 }

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -29,6 +29,8 @@ import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
 import app.cash.zipline.internal.initModuleLoader
 import app.cash.zipline.internal.loadJsModule
 import kotlin.coroutines.resumeWithException
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -82,6 +84,8 @@ actual class Zipline private constructor(
     get() = guest.serviceNames
 
   private var closed = false
+
+  private val attachments = mutableMapOf<KClass<*>, Any>()
 
   init {
     // Eagerly publish the channel so the guest can call us.
@@ -156,6 +160,11 @@ actual class Zipline private constructor(
 
   fun loadJsModule(bytecode: ByteArray, id: String) {
     loadJsModule(quickJs, id, bytecode)
+  }
+
+  actual fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T) : T {
+    val value = attachments.getOrPut(key, compute)
+    return key.cast(value)
   }
 
   companion object {

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -162,7 +162,7 @@ actual class Zipline private constructor(
     loadJsModule(quickJs, id, bytecode)
   }
 
-  actual fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T) : T {
+  actual fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T): T {
     val value = attachments.getOrPut(key, compute)
     return key.cast(value)
   }

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -22,6 +22,8 @@ import app.cash.zipline.internal.ZIPLINE_HOST_NAME
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.Endpoint
 import app.cash.zipline.internal.bridge.ZiplineServiceAdapter
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -68,6 +70,8 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
 
   internal val host: HostService = endpoint.take(ZIPLINE_HOST_NAME)
 
+  private val attachments = mutableMapOf<KClass<*>, Any>()
+
   actual fun <T : ZiplineService> bind(name: String, instance: T) {
     error("unexpected call to Zipline.bind: is the Zipline plugin configured?")
   }
@@ -95,6 +99,11 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
     adapter: ZiplineServiceAdapter<T>,
   ): T {
     return endpoint.take(name, scope, adapter)
+  }
+
+  actual fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T): T {
+    val value = attachments.getOrPut(key, compute)
+    return key.cast(value)
   }
 
   companion object {


### PR DESCRIPTION
Zipline attachments allow for namespaced singletons per zipline instance. This allows for default implementations of zipline functionality but allow for testable overrides. Secure random is now the default random provider.