### PR TITLE
Disconnected inbound services on close

### DIFF
--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -143,6 +143,12 @@ actual class Zipline private constructor(
     closed = true
 
     scope.cancel()
+
+    // The inboundChannel is leaking for reasons unknown. Clean up all bound services
+    // to limit the blast radius.
+    for (serviceName in endpoint.inboundServices.keys.toTypedArray()) {
+       endpoint.inboundChannel.disconnect(serviceName)
+    }
     quickJs.close()
 
     // Don't wait for a JS continuation to resume, it never will. Canceling `scope` doesn't do this

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -26,6 +26,7 @@ import app.cash.zipline.testing.SuspendingPotatoService
 import app.cash.zipline.testing.loadTestingJs
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
@@ -75,6 +76,16 @@ class ZiplineTest {
       service.echo(EchoRequest("Jake"))
     }
     assertThat(e.message).isEqualTo("Zipline closed")
+  }
+
+  @Test fun inboundServicesReleasedOnClose() = runTest(dispatcher) {
+    zipline.quickJs.evaluate("testing.app.cash.zipline.testing.prepareJsBridges()")
+    val service = JvmEchoService("echo, echo, echo")
+    zipline.bind<EchoService>("helloService", service)
+
+    zipline.close()
+
+    assertThat(zipline.serviceNames).doesNotContain("helloService")
   }
 
   @Test fun jvmCallJsService() = runTest(dispatcher) {


### PR DESCRIPTION
Fixes part of #1278. `Zipline`'s `inboundChannel` itself is still leaked, however....