### PR TITLE
Avoid flakiness in ConsoleTest

### DIFF
--- a/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
+++ b/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
@@ -29,7 +29,6 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before

--- a/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
+++ b/zipline/src/jvmTest/kotlin/app/cash/zipline/ConsoleTest.kt
@@ -147,7 +147,6 @@ class ConsoleTest {
     assertEquals(Level.INFO, record.level)
     assertEquals("this message for %s is a %d out of %d Jesse 8 10", record.message)
 
-    advanceUntilIdle()
     assertNull(takeLogMessage())
   }
 


### PR DESCRIPTION
The advanceUntilIdle wasn't doing anything to help confirm the correctness of our Console feature.

Closes: https://github.com/cashapp/zipline/issues/1308