### PR TITLE
Publish only to Maven Central on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,7 +155,7 @@ jobs:
           path: zipline-cli/build/distributions/zipline-cli-*.zip
           if-no-files-found: error
 
-      - run: ./gradlew publish
+      - run: ./gradlew publishToMavenCentral
         if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/zipline' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - run: ./gradlew assemble :dokkaHtmlMultiModule
 
-      - run: ./gradlew publish
+      - run: ./gradlew publishToMavenCentral
         if: ${{ github.repository == 'cashapp/zipline' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}


### PR DESCRIPTION
This avoids publishing to the test-local repo which, while cheap, does a bunch of file I/O which is slow on Macs.