### PR TITLE
Update how we collect output JS files

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
@@ -78,7 +78,7 @@ abstract class ZiplineCompileTask : DefaultTask() {
   ) {
     description = "Compile .js to .zipline"
 
-    val linkOutputFolderProvider = jsProductionTask.outputFile.map { it.parentFile }
+    val linkOutputFolderProvider = jsProductionTask.outputFile.map { it.asFile.parentFile }
     inputDir.fileProvider(linkOutputFolderProvider)
     outputDir.fileProvider(
       linkOutputFolderProvider.map {

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -60,11 +60,14 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
 
     kotlinExtension.targets.withType(KotlinJsIrTarget::class.java).all { kotlinTarget ->
       kotlinTarget.binaries.withType(JsIrBinary::class.java).all { kotlinBinary ->
-        registerCompileZiplineTask(
+        val ziplineCompileTask = registerCompileZiplineTask(
           project = target,
           jsProductionTask = kotlinBinary.asJsProductionTask(),
           extension = ziplineExtension,
         )
+        ziplineCompileTask.configure {
+          it.dependsOn(kotlinBinary.linkTask)
+        }
       }
     }
 
@@ -141,6 +144,7 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
       createdTask.description = "Serves Zipline files"
       createdTask.inputDir.set(ziplineCompileTask.flatMap { it.outputDir })
       createdTask.port.set(extension.httpServerPort)
+      createdTask.dependsOn(ziplineCompileTask)
     }
 
     return ziplineCompileTask

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
@@ -519,6 +519,7 @@ class ZiplineGradlePluginTest {
   ): GradleRunner {
     val gradleRoot = projectDir.resolve("gradle").also { it.mkdir() }
     File("../gradle/wrapper").copyRecursively(gradleRoot.resolve("wrapper"), true)
+    File(projectDir, "kotlin-js-store/yarn.lock").delete()
     val arguments = arrayOf("--info", "--stacktrace", "--continue")
     return GradleRunner.create()
       .withProjectDir(projectDir)


### PR DESCRIPTION
This is updated with Kotlin 2.0, and our previous approach isn't compatible with the configuration cache.