### PR TITLE
Use output directories like build/zipline/Production

### DIFF
--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineCompileTask.kt
@@ -73,19 +73,15 @@ abstract class ZiplineCompileTask : DefaultTask() {
   abstract val stripLineNumbers: Property<Boolean>
 
   internal fun configure(
+    outputDirectoryName: String,
     jsProductionTask: JsProductionTask,
     extension: ZiplineExtension,
   ) {
     description = "Compile .js to .zipline"
 
-    val linkOutputFolderProvider = jsProductionTask.outputFile.map { it.asFile.parentFile }
-    inputDir.fileProvider(linkOutputFolderProvider)
-    outputDir.fileProvider(
-      linkOutputFolderProvider.map {
-        it.parentFile.resolve("${it.name}Zipline")
-      },
-    )
+    inputDir.fileProvider(jsProductionTask.outputFile.map { it.asFile.parentFile })
 
+    outputDir.set(project.layout.buildDirectory.dir("zipline/$outputDirectoryName"))
     mainModuleId.set(extension.mainModuleId)
     mainFunction.set(extension.mainFunction)
     version.set(extension.version)

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -129,7 +129,7 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
     // For every JS executable, create a task that compiles its .js to .zipline.
     //   input:  build/compileSync/js/main/productionExecutable/kotlin
     //   output: build/zipline/Production
-    val outputDirectoryName = "${target.capitalize()}${mode.capitalize()}${toolName}"
+    val outputDirectoryName = "${target.capitalize()}${mode.capitalize()}$toolName"
     val ziplineCompileTask = project.tasks.register(
       "${jsProductionTask.name}Zipline",
       ZiplineCompileTask::class.java,

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -60,14 +60,11 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
 
     kotlinExtension.targets.withType(KotlinJsIrTarget::class.java).all { kotlinTarget ->
       kotlinTarget.binaries.withType(JsIrBinary::class.java).all { kotlinBinary ->
-        val ziplineCompileTask = registerCompileZiplineTask(
+        registerCompileZiplineTask(
           project = target,
           jsProductionTask = kotlinBinary.asJsProductionTask(),
           extension = ziplineExtension,
         )
-        ziplineCompileTask.configure {
-          it.dependsOn(kotlinBinary.linkTask)
-        }
       }
     }
 
@@ -125,26 +122,27 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
     jsProductionTask: JsProductionTask,
     extension: ZiplineExtension,
   ): TaskProvider<ZiplineCompileTask> {
+    val target = (if (jsProductionTask.targetName == "js") "" else jsProductionTask.targetName)
+    val mode = jsProductionTask.mode.name
+    val toolName = jsProductionTask.toolName ?: ""
+
     // For every JS executable, create a task that compiles its .js to .zipline.
-    //   input: build/compileSync/js/main/productionExecutable/kotlin
-    //   output: build/compileSync/js/main/productionExecutable/kotlinZipline
+    //   input:  build/compileSync/js/main/productionExecutable/kotlin
+    //   output: build/zipline/Production
+    val outputDirectoryName = "${target.capitalize()}${mode.capitalize()}${toolName}"
     val ziplineCompileTask = project.tasks.register(
       "${jsProductionTask.name}Zipline",
       ZiplineCompileTask::class.java,
     )
     ziplineCompileTask.configure {
-      it.configure(jsProductionTask, extension)
+      it.configure(outputDirectoryName, jsProductionTask, extension)
     }
 
-    val target = (if (jsProductionTask.targetName == "js") "" else jsProductionTask.targetName)
-    val mode = jsProductionTask.mode.name
-    val toolName = jsProductionTask.toolName ?: ""
     val serveTaskName = "serve${target.capitalize()}${mode.capitalize()}${toolName}Zipline"
     project.tasks.register(serveTaskName, ZiplineServeTask::class.java) { createdTask ->
       createdTask.description = "Serves Zipline files"
       createdTask.inputDir.set(ziplineCompileTask.flatMap { it.outputDir })
       createdTask.port.set(extension.httpServerPort)
-      createdTask.dependsOn(ziplineCompileTask)
     }
 
     return ziplineCompileTask

--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
@@ -38,9 +38,7 @@ class ZiplineGradlePluginTest {
     assertThat(SUCCESS_OUTCOMES)
       .contains(result.task(taskName)!!.outcome)
 
-    val ziplineOut = projectDir.resolve(
-      "lib/build/compileSync/js/main/productionExecutable/kotlinZipline",
-    )
+    val ziplineOut = projectDir.resolve("lib/build/zipline/Production")
     assertThat(ziplineOut.resolve(manifestFileName).exists()).isTrue()
     assertThat(ziplineOut.resolve("basic-lib.zipline").exists()).isTrue()
   }
@@ -58,9 +56,7 @@ class ZiplineGradlePluginTest {
     assertThat(SUCCESS_OUTCOMES)
       .contains(result.task(taskName)!!.outcome)
 
-    val ziplineOut = projectDir.resolve(
-      "lib/build/compileSync/js/main/developmentExecutable/kotlinZipline",
-    )
+    val ziplineOut = projectDir.resolve("lib/build/zipline/Development")
     assertThat(ziplineOut.resolve(manifestFileName).exists()).isTrue()
     assertThat(ziplineOut.resolve("basic-lib.zipline").exists()).isTrue()
   }
@@ -188,9 +184,7 @@ class ZiplineGradlePluginTest {
     assertThat(SUCCESS_OUTCOMES)
       .contains(result.task(taskName)!!.outcome)
 
-    val ziplineOut = projectDir.resolve(
-      "lib/build/compileSync/blue/main/developmentExecutable/kotlinZipline",
-    )
+    val ziplineOut = projectDir.resolve("lib/build/zipline/BlueDevelopment")
     val manifest = ziplineOut.resolve(manifestFileName)
     assertThat(manifest.exists()).isTrue()
     assertThat(manifest.readText())
@@ -207,9 +201,7 @@ class ZiplineGradlePluginTest {
     assertThat(SUCCESS_OUTCOMES)
       .contains(result.task(taskName)!!.outcome)
 
-    val ziplineOut = projectDir.resolve(
-      "lib/build/compileSync/js/main/developmentExecutable/kotlinZipline",
-    )
+    val ziplineOut = projectDir.resolve("lib/build/zipline/Development")
     val manifest = ziplineOut.resolve(manifestFileName)
     val manifestText = manifest.readText()
     assertThat(manifestText)
@@ -227,9 +219,7 @@ class ZiplineGradlePluginTest {
     assertThat(SUCCESS_OUTCOMES)
       .contains(result.task(taskName)!!.outcome)
 
-    val ziplineOut = projectDir.resolve(
-      "lib/build/compileSync/js/main/developmentExecutable/kotlinZipline",
-    )
+    val ziplineOut = projectDir.resolve("lib/build/zipline/Development")
     val manifest = ziplineOut.resolve(manifestFileName)
     assertThat(manifest.readText())
       .containsMatch(Regex(""""signatures":\{"key1":"\w{128}","key2":"\w{128}"}"""))

--- a/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/basic/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchGreetServiceJvm.kt
@@ -33,7 +33,7 @@ import okio.Path.Companion.toPath
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   // A fake HTTP client that returns files as the Webpack dev server would return them.
   val localDirectoryHttpClient = object : ZiplineHttpClient() {
-    val base = "build/compileSync/js/main/productionExecutable/kotlinZipline".toPath()
+    val base = "build/zipline/Production".toPath()
     override suspend fun download(
       url: String,
       requestHeaders: List<Pair<String, String>>,

--- a/zipline-gradle-plugin/src/test/projects/crash/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchCrashServiceJvm.kt
+++ b/zipline-gradle-plugin/src/test/projects/crash/lib/src/jvmMain/kotlin/app/cash/zipline/tests/launchCrashServiceJvm.kt
@@ -38,8 +38,8 @@ suspend fun launchZipline(
   // A fake HTTP client that returns files as the Webpack dev server would return them.
   val localDirectoryHttpClient = object : ZiplineHttpClient() {
     val base = when (optimizeMode) {
-      "development" -> "build/compileSync/js/main/developmentExecutable/kotlinZipline".toPath()
-      else -> "build/kotlin-webpack/js/productionExecutableZipline".toPath()
+      "development" -> "build/zipline/Development".toPath()
+      else -> "build/zipline/ProductionWebpack".toPath()
     }
     override suspend fun download(
       url: String,


### PR DESCRIPTION
Previously we derived our output directory from the output directory of the previous step's output. That was less likely to have collisions but also caused some Gradle grief.

Closes: https://github.com/cashapp/zipline/issues/1354