### PR TITLE
Make ZiplineCache resilient to disk write failures

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
@@ -34,9 +34,9 @@ internal class FsCachingFetcher(
     nowEpochMs: Long,
     baseUrl: String?,
     url: String,
-  ): ByteString? {
+  ): ByteString {
     return cache.getOrPut(applicationName, sha256, nowEpochMs) {
-      delegate.fetch(applicationName, eventListener, id, sha256, nowEpochMs, baseUrl, url)
+      delegate.fetch(applicationName, eventListener, id, sha256, nowEpochMs, baseUrl, url)!!
     }
   }
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
@@ -88,8 +88,14 @@ class CacheFaultsTester {
    */
   var fileSystemWriteLimit = Int.MAX_VALUE
 
-  val files: List<Path>
+  /**
+   * Returns the names of the files managed by this cache, excluding SQLite temporary files.
+   * https://www.sqlite.org/tempfiles.html
+   */
+  val fileNames: List<String>
     get() = fileSystem.list(directory)
+      .map { it.name }
+      .filterNot { it.startsWith("zipline.db-") }
 
   init {
     fileSystem.createDirectories(directory)

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2024 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader.internal.cache
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.zipline.ZiplineManifest
+import app.cash.zipline.loader.ZiplineCache
+import app.cash.zipline.loader.internal.fetcher.LoadedManifest
+import app.cash.zipline.loader.randomToken
+import app.cash.zipline.loader.testSqlDriverFactory
+import assertk.assertThat
+import assertk.assertions.isIn
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.IOException
+import okio.Path
+import okio.SYSTEM
+import okio.Sink
+import okio.use
+
+/**
+ * Test [ZiplineCache] by injecting faults after an arbitrary number of writes. This is used to
+ * synthesize a full disk, where writes stop working when the disk is full.
+ *
+ * We support injecting failures for these writes:
+ *  - Opening a file to write it: `FileSystem.sink()`
+ *  - Closing a file after writing it: `Sink.close()`. This also truncates the file to 0 bytes.
+ *  - SQL executes.
+ *
+ * It overlays these failures with the following operations, potentially performed multiple times:
+ *  - opening the cache
+ *  - loading an application
+ *
+ * Loading the application may be successful or not. Successful loads are pinned; unsuccessful ones
+ * are not pinned. The load may also be fresh or not. Note that the cache implements storage only
+ * and not freshness policy.
+ */
+class CacheFaultsTester {
+  private val fileSystem = FileSystem.SYSTEM
+  private val directory =
+    FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "CacheFaultsTester-${randomToken().hex()}"
+  private var nowMillis = 1_000L
+
+  private val applicationName = "red"
+
+  /** Adjust this to trigger cache pruning. */
+  var cacheSize = Long.MAX_VALUE
+
+  /** Increment this to invalidate the cached code. */
+  var manifestVersion = 0
+
+  private val moduleName: String
+    get() = "$applicationName-$manifestVersion"
+  private val moduleContent: ByteString
+    get() = "I am the Zipline file for manifestVersion=$manifestVersion".encodeUtf8()
+  private val moduleContentSha256: ByteString
+    get() = moduleContent.sha256()
+
+  var downloadCount = 0
+    private set
+
+  /** This includes both direct file system and SQL writes. */
+  var fileSystemWriteCount = 0
+    private set
+
+  /**
+   * How many writes to permit until all further writes fail.
+   *
+   * Note that file deletes are always allowed, but SQL deletes are still limited because they must
+   * be journaled.
+   */
+  var fileSystemWriteLimit = Int.MAX_VALUE
+
+  val files: List<Path>
+    get() = fileSystem.list(directory)
+
+  init {
+    fileSystem.createDirectories(directory)
+  }
+
+  suspend fun withCache(block: suspend Session.() -> Unit) {
+    val driver = LimitWritesSqlDriver(
+      testSqlDriverFactory().create(
+        path = directory / "zipline.db",
+        schema = Database.Schema,
+      ),
+    )
+    val database = createDatabase(driver)
+
+    val cache = ZiplineCache(
+      driver = driver,
+      database = database,
+      fileSystem = LimitWritesFileSystem(fileSystem),
+      directory = directory,
+      maxSizeInBytes = cacheSize.toLong(),
+    )
+
+    try {
+      cache.initialize()
+      Session(cache).block()
+    } finally {
+      cache.close()
+    }
+  }
+
+  inner class Session internal constructor(
+    private val cache: ZiplineCache,
+  ) {
+    suspend fun loadApp(
+      loadSuccess: Boolean = true,
+      cachedResultIsFresh: Boolean = true,
+    ) {
+      val cachedManifest = cache.getPinnedManifest(applicationName, nowMillis)
+      val loadedManifest = when {
+        cachedManifest != null && cachedResultIsFresh -> cachedManifest
+        else -> downloadManifest()
+      }
+
+      for (module in loadedManifest.manifest.modules) {
+        val loadedZiplineFile = cache.getOrPut(
+          applicationName = applicationName,
+          sha256 = module.value.sha256,
+          nowEpochMs = nowMillis,
+          download = ::downloadZiplineFile,
+        )
+        assertThat(loadedZiplineFile).isIn(null, moduleContent)
+      }
+
+      if (loadSuccess) {
+        cache.pinManifest(applicationName, loadedManifest, nowMillis)
+        cache.updateManifestFreshAt(applicationName, loadedManifest, nowMillis)
+      } else {
+        cache.unpinManifest(applicationName, loadedManifest, nowMillis)
+      }
+    }
+
+    private fun downloadManifest(): LoadedManifest {
+      downloadCount++
+
+      val manifest = ZiplineManifest.create(
+        modules = mapOf(
+          moduleName to ZiplineManifest.Module(
+            url = "$moduleName.zipline",
+            sha256 = moduleContentSha256,
+          ),
+        ),
+      )
+
+      return LoadedManifest(
+        manifestBytes = manifest.encodeJson().encodeUtf8(),
+        manifest = manifest,
+        freshAtEpochMs = nowMillis,
+      )
+    }
+
+    private fun downloadZiplineFile(): ByteString {
+      downloadCount++
+      return moduleContent
+    }
+  }
+
+  private inner class LimitWritesFileSystem(
+    delegate: FileSystem,
+  ) : ForwardingFileSystem(delegate) {
+    override fun sink(file: Path, mustCreate: Boolean): Sink {
+      fileSystemWriteCount++
+      if (fileSystemWriteCount >= fileSystemWriteLimit) throw IOException("write limit exceeded")
+
+      return LimitWritesSink(
+        path = file,
+        delegate = super.sink(file, mustCreate),
+      )
+    }
+  }
+
+  private inner class LimitWritesSink(
+    val path: Path,
+    val delegate: Sink,
+  ) : Sink by delegate {
+    override fun close() {
+      delegate.close()
+
+      fileSystemWriteCount++
+      if (fileSystemWriteCount >= fileSystemWriteLimit) {
+        truncateFileToEmpty()
+        throw IOException("write limit exceeded")
+      }
+    }
+
+    private fun truncateFileToEmpty() {
+      fileSystem.openReadWrite(path).use {
+        it.resize(0L)
+      }
+    }
+  }
+
+  private inner class LimitWritesSqlDriver(
+    private val delegate: SqlDriver,
+  ) : SqlDriver by delegate {
+    override fun execute(
+      identifier: Int?,
+      sql: String,
+      parameters: Int,
+      binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> {
+      fileSystemWriteCount++
+      if (fileSystemWriteCount >= fileSystemWriteLimit) throw IOException("write limit exceeded")
+
+      return delegate.execute(identifier, sql, parameters, binders)
+    }
+  }
+}

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2024 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader.internal.cache
+
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.isEqualTo
+import assertk.assertions.isIn
+import assertk.assertions.isLessThanOrEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+
+/**
+ * This is almost like a fuzz test: in each method it runs many iterations of the same operations,
+ * but each iteration injects a failure after a different number of writes.
+ *
+ * Because the behavior or the file system is different on each run, the test is lenient in what it
+ * expects from the cache: it accepts a wide variety of download counts. But regardless of whether
+ * the file system accepts writes, the cache should never return invalid results.
+ */
+class ZiplineCacheFaultsTest {
+  @Test
+  fun openMissHitClose(): Unit = runBlocking {
+    // How many writes are attempted in this test in the happy path. Determined experimentally!
+    val noFailuresWriteCount = 20
+
+    for (i in 0 until noFailuresWriteCount + 1) {
+      val tester = CacheFaultsTester()
+      tester.fileSystemWriteLimit = i
+
+      tester.withCache {
+        // Initial launch should have 2 cache misses: the Manifest + the Zipline file.
+        loadApp()
+        assertThat(tester.downloadCount).isEqualTo(2)
+
+        // The subsequent launch should have between 2 and 4 cache misses, depending on what was
+        // successfully written to the cache last time.
+        loadApp()
+        assertThat(tester.downloadCount).isLessThanOrEqualTo(4)
+      }
+
+      // Assert more strictly if we didn't need to inject any write failures.
+      if (i >= noFailuresWriteCount) {
+        assertThat(tester.downloadCount).isEqualTo(2)
+      }
+
+      assertThat(tester.fileSystemWriteCount).isLessThanOrEqualTo(noFailuresWriteCount)
+    }
+  }
+
+  @Test
+  fun openMissClose_OpenHitClose(): Unit = runBlocking {
+    // How many writes are attempted in this test in the happy path. Determined experimentally!
+    val noFailuresWriteCount = 20
+
+    for (i in 0 until noFailuresWriteCount + 1) {
+      val tester = CacheFaultsTester()
+      tester.fileSystemWriteLimit = i
+
+      // Initial launch should have 2 cache misses: the Manifest + the Zipline file.
+      tester.withCache {
+        loadApp()
+      }
+      assertThat(tester.downloadCount).isEqualTo(2)
+
+      // The subsequent launch should have between 2 and 4 cache misses, depending on what was
+      // successfully written to the cache last time.
+      tester.withCache {
+        loadApp()
+      }
+      assertThat(tester.downloadCount).isLessThanOrEqualTo(4)
+
+      // Assert more strictly if we didn't need to inject any write failures.
+      if (i >= noFailuresWriteCount) {
+        assertThat(tester.downloadCount).isEqualTo(2)
+      }
+
+      assertThat(tester.fileSystemWriteCount).isLessThanOrEqualTo(noFailuresWriteCount)
+    }
+  }
+
+  @Test
+  fun openFailClose_OpenMissClose_OpenHitClose(): Unit = runBlocking {
+    // How many writes are attempted in this test in the happy path. Determined experimentally!
+    val noFailuresWriteCount = 27
+
+    for (i in 0 until noFailuresWriteCount + 1) {
+      val tester = CacheFaultsTester()
+      tester.fileSystemWriteLimit = i
+
+      // Initial launch should have 2 cache misses: the Manifest + the Zipline file.
+      tester.withCache {
+        loadApp(loadSuccess = false)
+      }
+      assertThat(tester.downloadCount).isEqualTo(2)
+
+      // The subsequent launch should have 2 more cache misses.
+      tester.manifestVersion++
+      tester.withCache {
+        loadApp()
+      }
+      assertThat(tester.downloadCount).isEqualTo(4)
+
+      // A third launch should have between 4 and 6 cache misses, depending on what was successfully
+      // written to the cache in round 2.
+      tester.withCache {
+        loadApp()
+      }
+      assertThat(tester.downloadCount).isLessThanOrEqualTo(6)
+
+      // Assert more strictly if we didn't need to inject any write failures.
+      if (i >= noFailuresWriteCount) {
+        assertThat(tester.downloadCount).isEqualTo(4)
+      }
+
+      assertThat(tester.fileSystemWriteCount).isLessThanOrEqualTo(noFailuresWriteCount)
+    }
+  }
+
+  /** This test confirms that stale cached results are pruned. */
+  @Test
+  fun openMissClose_openStaleClose(): Unit = runBlocking {
+    // How many writes are attempted in this test in the happy path. Determined experimentally!
+    val noFailuresWriteCount = 31
+
+    for (i in 0 until noFailuresWriteCount + 1) {
+      val tester = CacheFaultsTester()
+      tester.fileSystemWriteLimit = i
+
+      // Initial launch should have 2 cache misses: the Manifest + the Zipline file.
+      tester.withCache {
+        loadApp()
+      }
+      assertThat(tester.downloadCount).isEqualTo(2)
+
+      // The 2nd launch should have 2 more cache misses because the files have changed. When the
+      // updated files are pinned the old files should be pinned.
+      tester.cacheSize = 0
+      tester.manifestVersion++
+      tester.withCache {
+        loadApp(cachedResultIsFresh = false)
+      }
+      assertThat(tester.downloadCount).isEqualTo(4)
+
+      // We expect some combination of these files.
+      assertThat(tester.files.map { it.name }).each {
+        it.isIn(
+          "entry-1.bin",
+          "entry-2.bin",
+          "entry-3.bin",
+          "entry-4.bin",
+          "zipline.db",
+        )
+      }
+
+      // Opening the cache triggers pruning.
+      tester.withCache {
+      }
+
+      // Assert more strictly if we didn't need to inject any write failures.
+      if (i >= noFailuresWriteCount) {
+        assertThat(tester.files.map { it.name }).each {
+          it.isIn(
+            "entry-3.bin",
+            "entry-4.bin",
+            "zipline.db",
+          )
+        }
+      }
+
+      assertThat(tester.fileSystemWriteCount).isLessThanOrEqualTo(noFailuresWriteCount)
+    }
+  }
+}

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
@@ -156,7 +156,7 @@ class ZiplineCacheFaultsTest {
       assertThat(tester.downloadCount).isEqualTo(4)
 
       // We expect some combination of these files.
-      assertThat(tester.files.map { it.name }).each {
+      assertThat(tester.fileNames).each {
         it.isIn(
           "entry-1.bin",
           "entry-2.bin",
@@ -172,7 +172,7 @@ class ZiplineCacheFaultsTest {
 
       // Assert more strictly if we didn't need to inject any write failures.
       if (i >= noFailuresWriteCount) {
-        assertThat(tester.files.map { it.name }).each {
+        assertThat(tester.fileNames).each {
           it.isIn(
             "entry-3.bin",
             "entry-4.bin",

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
@@ -262,7 +262,7 @@ class ZiplineCacheTest {
       assertEquals(manifestApple, it.getPinnedManifest("red"))
       assertEquals(3, it.countPins())
 
-      it.getOrPutManifest("red", manifestFiretruck.manifestBytes, 1, nowMillis)
+      it.updateManifestFreshAt("red", manifestFiretruck, 1)
       assertEquals(4, it.countPins())
 
       assertEquals(manifestFiretruck, it.getPinnedManifest("red"))
@@ -406,18 +406,16 @@ class ZiplineCacheTest {
 
   private fun ZiplineCache.read(sha256: ByteString) = read(sha256, nowMillis)
 
-  private fun ZiplineCache.write(
+  private suspend fun ZiplineCache.write(
     applicationName: String,
     sha256: ByteString,
     content: ByteString,
-    isManifest: Boolean = false,
-    manifestFreshAtMs: Long? = null,
-  ) = write(applicationName, sha256, content, nowMillis, isManifest, manifestFreshAtMs)
+  ) = getOrPut(applicationName, sha256, nowMillis) { content }
 
   private suspend fun ZiplineCache.getOrPut(
     applicationName: String,
     sha256: ByteString,
-    download: suspend () -> ByteString?,
+    download: suspend () -> ByteString,
   ) = getOrPut(applicationName, sha256, nowMillis, download)
 
   private fun ZiplineCache.getPinnedManifest(applicationName: String) =


### PR DESCRIPTION
This pulls the try/catch block up to the public API of ZiplineCache. Exceptions put the cache in a degraded mode where all reads return null and all writes do nothing. This yields bad caching, but that's our best option given an unwritable disk.

This also introduces a very aggressive test case to confirm that the cache can recover from any write failure.

Closes: https://github.com/cashapp/zipline/issues/1369