### PR TITLE
Do not crash if runtime is absent

### DIFF
--- a/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
+++ b/zipline-gradle-plugin/src/test/kotlin/app/cash/zipline/gradle/ZiplineGradlePluginTest.kt
@@ -503,6 +503,12 @@ class ZiplineGradlePluginTest {
     assertThat(dumpResult.output).contains("Cannot locate tasks that match ':lib:ziplineApiDump'")
   }
 
+  @Test
+  fun pluginWithNoRuntimeDoesNotCrash() {
+    val projectDir = File("src/test/projects/no-runtime")
+    createRunner(projectDir, "clean", "run").build()
+  }
+
   private fun createRunner(
     projectDir: File,
     vararg taskNames: String,

--- a/zipline-gradle-plugin/src/test/projects/no-runtime/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/no-runtime/build.gradle.kts
@@ -1,0 +1,23 @@
+buildscript {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath("app.cash.zipline:zipline-gradle-plugin:${project.property("ziplineVersion")}")
+    classpath(libs.kotlin.gradle.plugin)
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/zipline-gradle-plugin/src/test/projects/no-runtime/lib/build.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/no-runtime/lib/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.zipline.gradle.ZiplineCompileTask
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
+
+plugins {
+  kotlin("jvm")
+  id("app.cash.zipline")
+  application
+}
+
+application {
+  mainClass = "app.cash.zipline.tests.MainKt"
+}

--- a/zipline-gradle-plugin/src/test/projects/no-runtime/lib/src/main/kotlin/app/cash/zipline/tests/Main.kt
+++ b/zipline-gradle-plugin/src/test/projects/no-runtime/lib/src/main/kotlin/app/cash/zipline/tests/Main.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.tests
+
+fun main() {
+  try {
+    Class.forName("app.cash.zipline.ZiplineService")
+    throw RuntimeException("Zipline runtime present but should be absent!")
+  } catch (e: ClassNotFoundException) {
+    println("Success!")
+  }
+}

--- a/zipline-gradle-plugin/src/test/projects/no-runtime/settings.gradle.kts
+++ b/zipline-gradle-plugin/src/test/projects/no-runtime/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":lib")

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -146,7 +146,7 @@ internal class BridgedInterface(
   }
 
   private val IrType.isContextual
-    get() = annotations.any { it.type.getClass()?.classId == ziplineApis.contextualClassId }
+    get() = annotations.any { it.type.getClass()?.classId == ZiplineApis.contextualClassId }
 
   class SerializerExpression(
     val expression: IrExpression,
@@ -260,10 +260,10 @@ internal class BridgedInterface(
   }
 
   private val IrType.isFlow
-    get() = getClass()?.classId == ziplineApis.flowClassId
+    get() = getClass()?.classId == ZiplineApis.flowClassId
 
   private val IrType.isStateFlow
-    get() = getClass()?.classId == ziplineApis.stateFlowClassId
+    get() = getClass()?.classId == ZiplineApis.stateFlowClassId
 
   /** Call this on any declaration returned by [classSymbol] to fill in the generic parameters. */
   fun resolveTypeParameters(type: IrType): IrType {


### PR DESCRIPTION
This is useful to allow targets we don't yet support, or when applying only to test code and not main code.

Closes #1181 