### PR TITLE
Change Linux build from amd64/centos:7 to amd64/oraclelinux:8

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,5 @@
+# We use Docker because GitHub actions doesn't offer virtual environments for old distros, and we
+# need to build on old distros to run on old distros.
+
+FROM amd64/oraclelinux:8
+RUN dnf install gcc-c++ cmake3 java-11-openjdk-devel

--- a/.github/workflows/build-linux-amd64.sh
+++ b/.github/workflows/build-linux-amd64.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
-# Run this in Docker with the Zipline project mounted at /zipline.
-#
-# We use Docker because GitHub actions doesn't offer virtual environments for old distros, and we
-# need to build on old distros to run on old distros.
-
 set -e
 set -x
-
-cd /zipline
-
-dnf install gcc-c++ cmake3 java-11-openjdk-devel
 
 mkdir -p build/jni/amd64/
 mkdir -p zipline/src/jvmMain/resources/jni/amd64/
 cmake3 -S zipline/src/jvmMain/ -B build/jni/amd64/ \
   -DQUICKJS_VERSION="$(cat zipline/native/quickjs/VERSION)" \
-  -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
-  -DCMAKE_C_COMPILER=/usr/bin/gcc \
-  -DCMAKE_CXX_COMPILER=/usr/bin/g++
+  -DCMAKE_SYSTEM_PROCESSOR=x86_64
 cmake3 --build build/jni/amd64/ --verbose

--- a/.github/workflows/build-linux-amd64.sh
+++ b/.github/workflows/build-linux-amd64.sh
@@ -1,32 +1,19 @@
 #!/bin/bash
 
 # Run this in Docker with the Zipline project mounted at /zipline.
-#
-# This script runs on CentOS 7 with devtoolset-7. We deliberately use an
-# old distro so our artifacts will run on similarly old distros. We need
-# to use Docker because GitHub actions doesn't offer virtual environments
-# for obsolete distros.
-#
-# We need the distribution's libc and libcxx to be old-enough so its outputs
-# work for our users. We also need a compiler that's new-enough that it has
-# `stdatomic.h`. Yuck.
 
 set -e
 set -x
 
 cd /zipline
-yum -y install centos-release-scl
-yum -y install devtoolset-7 devtoolset-7-toolchain
-. /opt/rh/devtoolset-7/enable
-yum -y install epel-release
-yum -y install cmake3
-yum -y install java-1.8.0-openjdk-devel
+
+dnf install gcc-c++ cmake3 java-11-openjdk-devel
 
 mkdir -p build/jni/amd64/
 mkdir -p zipline/src/jvmMain/resources/jni/amd64/
 cmake3 -S zipline/src/jvmMain/ -B build/jni/amd64/ \
   -DQUICKJS_VERSION="$(cat zipline/native/quickjs/VERSION)" \
   -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
-  -DCMAKE_C_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/gcc \
-  -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/c++
+  -DCMAKE_C_COMPILER=/usr/bin/gcc \
+  -DCMAKE_CXX_COMPILER=/usr/bin/g++
 cmake3 --build build/jni/amd64/ --verbose

--- a/.github/workflows/build-linux-amd64.sh
+++ b/.github/workflows/build-linux-amd64.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 # Run this in Docker with the Zipline project mounted at /zipline.
+#
+# We use Docker because GitHub actions doesn't offer virtual environments for old distros, and we
+# need to build on old distros to run on old distros.
 
 set -e
 set -x

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,10 +42,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           cp -a . ../zipline-dockerbuild
+          docker build \
+            --tag zipline-linux-amd64 \
+            .github/workflows
           docker run \
             --volume `pwd`/../zipline-dockerbuild:/zipline \
-            amd64/oraclelinux:8 \
-            /zipline/.github/workflows/build-linux-amd64.sh
+            --workdir /zipline \
+            --entrypoint ./.github/workflows/build-linux-amd64.sh \
+            zipline-linux-amd64
           mkdir -p zipline/src/jvmMain/resources/jni/amd64
           cp -v ../zipline-dockerbuild/build/jni/amd64/libquickjs.* zipline/src/jvmMain/resources/jni/amd64/
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           cp -a . ../zipline-dockerbuild
           docker run \
             --volume `pwd`/../zipline-dockerbuild:/zipline \
-            amd64/centos:7 \
+            amd64/oraclelinux:8 \
             /zipline/.github/workflows/build-linux-amd64.sh
           mkdir -p zipline/src/jvmMain/resources/jni/amd64
           cp -v ../zipline-dockerbuild/build/jni/amd64/libquickjs.* zipline/src/jvmMain/resources/jni/amd64/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,10 +39,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           cp -a . ../zipline-dockerbuild
+          docker build \
+            --tag zipline-linux-amd64 \
+            .github/workflows
           docker run \
             --volume `pwd`/../zipline-dockerbuild:/zipline \
-            amd64/oraclelinux:8 \
-            /zipline/.github/workflows/build-linux-amd64.sh
+            --workdir /zipline \
+            --entrypoint ./.github/workflows/build-linux-amd64.sh \
+            zipline-linux-amd64
           mkdir -p zipline/src/jvmMain/resources/jni/amd64
           cp -v ../zipline-dockerbuild/build/jni/amd64/libquickjs.* zipline/src/jvmMain/resources/jni/amd64/
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           cp -a . ../zipline-dockerbuild
           docker run \
             --volume `pwd`/../zipline-dockerbuild:/zipline \
-            amd64/centos:7 \
+            amd64/oraclelinux:8 \
             /zipline/.github/workflows/build-linux-amd64.sh
           mkdir -p zipline/src/jvmMain/resources/jni/amd64
           cp -v ../zipline-dockerbuild/build/jni/amd64/libquickjs.* zipline/src/jvmMain/resources/jni/amd64/


### PR DESCRIPTION
Our downstream consumers no longer need builds for CentOS 7 (2014) and are now happy with Oracle Linux 8 (2019).