### PR TITLE
Make builds 16KB compliant

### DIFF
--- a/zipline/src/androidMain/CMakeLists.txt
+++ b/zipline/src/androidMain/CMakeLists.txt
@@ -8,3 +8,5 @@ file(GLOB_RECURSE sources "../../native/*.c" "../../native/*.cpp")
 add_library(quickjs SHARED ${sources})
 
 target_link_libraries(quickjs)
+
+target_link_options(quickjs PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Closes: https://github.com/cashapp/zipline/issues/1243