### PR TITLE
Retain compiler-generated copy function

### DIFF
--- a/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
@@ -32,6 +32,7 @@ import okio.ByteString.Companion.encodeUtf8
  * Use [ZiplineManifest.create] to create instances.
  */
 @Serializable
+@ExposedCopyVisibility // For binary compatibility.
 data class ZiplineManifest private constructor(
   /** Metadata on this manifest that isn't authenticated by a signature. */
   val unsigned: Unsigned = Unsigned(),


### PR DESCRIPTION
This would have disappeared once we updated to Kotlin 2.1.