### PR TITLE
Version code defaults to null, fix comment on manifest version

### DIFF
--- a/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
@@ -49,7 +49,7 @@ data class ZiplineManifest private constructor(
   /** Fully qualified main function to start the application (ie. "zipline.ziplineMain"). */
   val mainFunction: String? = null,
 
-  /** Version to represent the code as defined in this manifest, by default it will be Git commit SHA. */
+  /** Version to represent the code as defined in this manifest */
   val version: String? = null,
 
   /**


### PR DESCRIPTION
The default value of "version" is null. Git commit SHA is a recommended way to populate the version, but is not the default