### PR TITLE
Update source map parser to ECMA 426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Nothing yet!
+* Fix: Update source map parser to ECMA 426 which will not fail on the `ignoreList` key and ignore any extensions.
 
 
 ## [1.20.0] - 2025-03-20

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
@@ -56,15 +56,19 @@ data class SourceMap(
   }
 
   companion object {
+    private val json = Json {
+      ignoreUnknownKeys = true
+    }
+
     /**
      * Parses the contents of a source map file to enable mapping from the elements in the
      * transformed (e.g. minified) source to the elements in the original source. This is an
-     * implementation of the [Source Map Revision 3 Proposal](https://sourcemaps.info/spec.html).
+     * implementation of the [Source Map specification](https://tc39.es/ecma426).
      *
      * @param sourceMapJson contents of the source map file in JSON format.
      */
     fun parse(sourceMapJson: String): SourceMap {
-      val sourceMap = Json.decodeFromString(SourceMapJson.serializer(), sourceMapJson)
+      val sourceMap = json.decodeFromString(SourceMapJson.serializer(), sourceMapJson)
 
       val buffer = Buffer()
 

--- a/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/SourceMapParsingTest.kt
+++ b/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/SourceMapParsingTest.kt
@@ -65,6 +65,8 @@ class SourceMapParsingTest {
         "sourcesContent": [
           null
         ],
+        "ignoreList": [],
+        "x_google_ignoreList": [],
         "names": [],
         "mappings": ";;;;;;;;;;;;EAAA,gB;IACE,YAAY,c;IACZ,OAAQ,KAAI,KAAJ,C;EACV,C;;;;;;"
       }
@@ -87,6 +89,27 @@ class SourceMapParsingTest {
     )
     // Doesn't match any lines in the source file.
     assertNull(sourceMap.find(lineNumber = 17))
+  }
+
+  @Test fun doNotFailOnUnknownExtensions() {
+    val json = """
+      {
+        "version": 3,
+        "file": "kotlin-js-demo.js",
+        "sources": [
+          "../../../../../src/main/kotlin/main.kt"
+        ],
+        "sourcesContent": [
+          null
+        ],
+        "names": [],
+        "x_google_linecount": "12-34",
+        "x_hello": "world!",
+        "mappings": ";;;;;;;;;;;;EAAA,gB;IACE,YAAY,c;IACZ,OAAQ,KAAI,KAAJ,C;EACV,C;;;;;;"
+      }
+      """.trimIndent()
+
+    SourceMap.parse(json)
   }
 
   @Test fun readVarints() {


### PR DESCRIPTION
Ignore extensions, and allow the `ignoreList` key, specifically.