### PR TITLE
Downgrade http4k

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidx-compose = "1.7.8"
 compileSdk = "35"
-http4k = "4.48.2.0"
+http4k = "4.48.0.0"
 kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.8.1"


### PR DESCRIPTION
This sneaky .2 version is not tagged on their GitHub nor is the code present, but it adds a nag about commercial support for the 4.x series. We're perfectly happy on an old, open source version indefinitely (or until we can switch away to something like Ktor).