### PR TITLE
Flip the endianness of the function flags

### DIFF
--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/JsObjectWriter.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/JsObjectWriter.kt
@@ -89,7 +89,7 @@ class JsObjectWriter(
   }
 
   private fun writeFunction(value: JsFunctionBytecode) {
-    sink.writeShort(value.flags)
+    sink.writeShortLe(value.flags)
     sink.writeByte(value.jsMode.toInt())
     writeAtom(value.name.toJsString())
     sink.writeLeb128(value.argCount)

--- a/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/Es2015SupportTest.kt
+++ b/zipline-bytecode/src/test/kotlin/app/cash/zipline/bytecode/Es2015SupportTest.kt
@@ -68,10 +68,10 @@ class Es2015SupportTest {
     assertThat(exception.stackTraceToString()).startsWith(
       """
       |app.cash.zipline.QuickJsException: boom!
-      |	at JavaScript.goBoom1(demo.js)
-      |	at JavaScript.goBoom2(demo.js)
-      |	at JavaScript.goBoom3(demo.js)
-      |	at JavaScript.sayHello(demo.js)
+      |	at JavaScript.goBoom1(demo.js:19)
+      |	at JavaScript.goBoom2(demo.js:15)
+      |	at JavaScript.goBoom3(demo.js:11)
+      |	at JavaScript.sayHello(demo.js:7)
       |	at JavaScript.<eval>(?)
       """.trimMargin(),
     )


### PR DESCRIPTION
This value was mostly pass-through: we read it
and wrote it back, without interpretting it, so
it was easy for this bug to sneak through.

The one catch we didn't handle is the debug
flag is always true in practice, but with
ES2015 we now see the incorrect flag triggering
incorrect behavior.

This was annoying to isolate.