### PR TITLE
Recover from more SQL exceptions

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -201,7 +201,7 @@ class ZiplineCache internal constructor(
       try {
         fileSystem.delete(path)
         database.filesQueries.delete(metadata.id)
-      } catch (ignored: IOException) {
+      } catch (ignored: Exception) {
       }
       return null
     }
@@ -418,7 +418,7 @@ class ZiplineCache internal constructor(
     try {
       deleteDirtyFiles()
       prune()
-    } catch (e: IOException) {
+    } catch (e: Exception) {
       hasWriteFailures = true // Mark this cache as broken.
       loaderEventListener.cacheStorageFailed(null, e)
     }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -58,7 +58,6 @@ class ProductionFetcherReceiverTest {
   @AfterTest
   fun tearDown() {
     tester.afterTest()
-    cache.close()
   }
 
   @Test

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/CacheFaultsTester.kt
@@ -239,9 +239,13 @@ class CacheFaultsTester {
       binders: (SqlPreparedStatement.() -> Unit)?,
     ): QueryResult<Long> {
       fileSystemWriteCount++
-      if (fileSystemWriteCount >= fileSystemWriteLimit) throw IOException("write limit exceeded")
+      if (fileSystemWriteCount >= fileSystemWriteLimit) {
+        throw SqlFaultException("write limit exceeded")
+      }
 
       return delegate.execute(identifier, sql, parameters, binders)
     }
   }
+
+  private class SqlFaultException(message: String) : Exception(message)
 }


### PR DESCRIPTION
We've received crashes like this in the wild:

    co.touchlab.sqliter.interop.SQLiteExceptionErrorCode in kfun:co.touchlab.sqliter.native.NativeDatabaseConnection#createStatement(kotlin.String){}co.touchlab.sqliter.Statement
    error while compiling: PRAGMA journal_mode
    database or disk is full
        co.touchlab.sqliter.native.NativeDatabaseConnection#createStatement(kotlin.String){}co.touchlab.sqliter.Statement
        co.touchlab.sqliter#withStatement__at__co.touchlab.sqliter.DatabaseConnection(kotlin.String;kotlin.Function1<co.touchlab.s...
        co.touchlab.sqliter.native.NativeDatabaseManager.createConnection#internal
        co.touchlab.sqliter.native.NativeDatabaseManager#createMultiThreadedConnection(){}co.touchlab.sqliter.DatabaseConnection
        app.cash.sqldelight.driver.native.NativeSqliteDriver.NativeSqliteDriver$3.invoke#internal
        app.cash.sqldelight.driver.native.Pool.Pool$borrowEntry$nextAvailable$1.invoke#internal
        app.cash.sqldelight.driver.native.util.PoolLock#withLock(kotlin.Function1<app.cash.sqldelight.driver.native.util.PoolLock....
        app.cash.sqldelight.driver.native.Pool#borrowEntry(){}app.cash.sqldelight.driver.native.Borrowed<1:0>
        app.cash.sqldelight.driver.native.Pool#access(kotlin.Function1<1:0,0:0>){0§<kotlin.Any?>}0:0
        app.cash.sqldelight.driver.native.NativeSqliteDriver#accessConnection(kotlin.Boolean;kotlin.Function1<app.cash.sqldelight....
        app.cash.sqldelight.driver.native.ConnectionWrapper#executeQuery(kotlin.Int?;kotlin.String;kotlin.Function1<app.cash.sqlde...
        app.cash.sqldelight.SimpleQuery.execute#internal
        app.cash.sqldelight.ExecutableQuery#executeAsOneOrNull(){}1:0?
        app.cash.zipline.loader#ZiplineCache(app.cash.zipline.loader.internal.cache.SqlDriverFactory;okio.FileSystem;okio.Path;kot...
        app.cash.redwood.treehouse.IosTreehousePlatform#newCache(kotlin.String;kotlin.Long;app.cash.zipline.loader.LoaderEventList...

I believe the problem is we aren't catching a broad-enough exception.