### PR TITLE
Use older macOS for building iOS for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,7 +112,7 @@ jobs:
           script: ./gradlew connectedCheck
 
   ios-app:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
macOS 15 has a simulator problem due to Xcode 26 beta being present now.