### PR TITLE
Don't crash if creating a cache directory fails

### DIFF
--- a/zipline-loader/api/android/zipline-loader.api
+++ b/zipline-loader/api/android/zipline-loader.api
@@ -102,6 +102,7 @@ public final class app/cash/zipline/loader/SignatureAlgorithmId : java/lang/Enum
 }
 
 public final class app/cash/zipline/loader/ZiplineCache : java/io/Closeable {
+	public synthetic fun <init> (Lapp/cash/sqldelight/db/SqlDriver;Lapp/cash/zipline/loader/internal/cache/Database;Lokio/FileSystem;Lokio/Path;JLapp/cash/zipline/loader/LoaderEventListener;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 }
 

--- a/zipline-loader/api/jvm/zipline-loader.api
+++ b/zipline-loader/api/jvm/zipline-loader.api
@@ -102,6 +102,7 @@ public final class app/cash/zipline/loader/SignatureAlgorithmId : java/lang/Enum
 }
 
 public final class app/cash/zipline/loader/ZiplineCache : java/io/Closeable {
+	public synthetic fun <init> (Lapp/cash/sqldelight/db/SqlDriver;Lapp/cash/zipline/loader/internal/cache/Database;Lokio/FileSystem;Lokio/Path;JLapp/cash/zipline/loader/LoaderEventListener;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 }
 

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/internal/cache/databaseAndroid.kt
@@ -23,10 +23,10 @@ import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import okio.Path
 
-internal actual class SqlDriverFactory(
+internal class AndroidSqliteDriverFactory(
   private val context: Context,
-) {
-  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
+) : SqlDriverFactory {
+  override fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     return AndroidSqliteDriver(
       schema = schema,

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
@@ -16,7 +16,7 @@
 package app.cash.zipline.loader
 
 import android.content.Context
-import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.cache.AndroidSqliteDriverFactory
 import okio.FileSystem
 import okio.Path
 
@@ -28,7 +28,7 @@ fun ZiplineCache(
   loaderEventListener: LoaderEventListener,
 ): ZiplineCache {
   return ZiplineCache(
-    sqlDriverFactory = SqlDriverFactory(context),
+    sqlDriverFactory = AndroidSqliteDriverFactory(context),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/NullSqlDriver.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/NullSqlDriver.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import okio.IOException
+
+/**
+ * A SQL Driver that always throws [IOException]. Used this when creating a driver fails, such as
+ * when the disk is full.
+ */
+internal class NullSqlDriver : SqlDriver {
+  override fun <R> executeQuery(
+    identifier: Int?,
+    sql: String,
+    mapper: (SqlCursor) -> QueryResult<R>,
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)?,
+  ) = throw IOException("NullSqlDriver")
+
+  override fun execute(
+    identifier: Int?,
+    sql: String,
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)?,
+  ) = throw IOException("NullSqlDriver")
+
+  override fun newTransaction() = throw IOException("NullSqlDriver")
+
+  override fun currentTransaction() = throw IOException("NullSqlDriver")
+
+  override fun addListener(vararg queryKeys: String, listener: Query.Listener) = Unit
+
+  override fun removeListener(vararg queryKeys: String, listener: Query.Listener) = Unit
+
+  override fun notifyListeners(vararg queryKeys: String) = Unit
+
+  override fun close() = Unit
+}

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/cache/database.kt
@@ -21,7 +21,7 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import okio.Path
 
-internal expect class SqlDriverFactory {
+internal interface SqlDriverFactory {
   /**
    * Create a SqlDriver to be used in creating and managing a SqlLite instance on disk.
    *
@@ -39,11 +39,9 @@ internal fun validateDbPath(path: Path) {
   }
 }
 
-internal fun createDatabase(driver: SqlDriver): Database {
-  return Database(
+internal fun createDatabase(driver: SqlDriver): Database = Database(
     driver,
     filesAdapter = Files.Adapter(
       file_stateAdapter = EnumColumnAdapter(),
     ),
   )
-}

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheFaultsTest.kt
@@ -35,7 +35,7 @@ class ZiplineCacheFaultsTest {
   @Test
   fun openMissHitClose(): Unit = runBlocking {
     // How many writes are attempted in this test in the happy path. Determined experimentally!
-    val noFailuresWriteCount = 21
+    val noFailuresWriteCount = 23
 
     for (i in 0..noFailuresWriteCount) {
       val tester = CacheFaultsTester()
@@ -65,7 +65,7 @@ class ZiplineCacheFaultsTest {
   @Test
   fun openMissClose_OpenHitClose(): Unit = runBlocking {
     // How many writes are attempted in this test in the happy path. Determined experimentally!
-    val noFailuresWriteCount = 21
+    val noFailuresWriteCount = 24
 
     for (i in 0..noFailuresWriteCount) {
       val tester = CacheFaultsTester()
@@ -97,7 +97,7 @@ class ZiplineCacheFaultsTest {
   @Test
   fun openFailClose_OpenMissClose_OpenHitClose(): Unit = runBlocking {
     // How many writes are attempted in this test in the happy path. Determined experimentally!
-    val noFailuresWriteCount = 27
+    val noFailuresWriteCount = 31
 
     for (i in 0..noFailuresWriteCount) {
       val tester = CacheFaultsTester()
@@ -137,7 +137,7 @@ class ZiplineCacheFaultsTest {
   @Test
   fun openMissClose_openStaleClose(): Unit = runBlocking {
     // How many writes are attempted in this test in the happy path. Determined experimentally!
-    val noFailuresWriteCount = 32
+    val noFailuresWriteCount = 36
 
     for (i in 0..noFailuresWriteCount) {
       val tester = CacheFaultsTester()

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
@@ -15,6 +15,8 @@
  */
 package app.cash.zipline.loader.internal.cache
 
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.zipline.loader.LoaderEventListener
 import app.cash.zipline.loader.ZiplineCache
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
@@ -366,17 +368,18 @@ class ZiplineCacheTest {
       path = directory / "zipline.db",
       schema = Database.Schema,
     )
-    val database = createDatabase(driver)
+
+    val testSqlDriverFactory = object : SqlDriverFactory {
+      override fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>) = driver
+    }
 
     val cache = ZiplineCache(
-      driver = driver,
-      database = database,
+      sqlDriverFactory = testSqlDriverFactory,
       fileSystem = fileSystem,
       directory = directory,
       maxSizeInBytes = cacheSize.toLong(),
       loaderEventListener = LoaderEventListener.None,
     )
-    cache.initialize()
     try {
       return block(cache)
     } finally {

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/cache/databaseJvm.kt
@@ -22,8 +22,8 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.sql.SQLException
 import okio.Path
 
-internal actual class SqlDriverFactory {
-  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
+internal class JdbcSqliteDriverFactory : SqlDriverFactory {
+  override fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:$path")
     try {

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.zipline.loader
 
-import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.cache.JdbcSqliteDriverFactory
 import okio.FileSystem
 import okio.Path
 
@@ -26,7 +26,7 @@ fun ZiplineCache(
   loaderEventListener: LoaderEventListener,
 ): ZiplineCache {
   return ZiplineCache(
-    sqlDriverFactory = SqlDriverFactory(),
+    sqlDriverFactory = JdbcSqliteDriverFactory(),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseJvmTest.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseJvmTest.kt
@@ -29,7 +29,7 @@ class DatabaseJvmTest {
   @JvmField @Rule
   val temporaryFolder = TemporaryFolder()
 
-  private val sqlDriverFactory = SqlDriverFactory()
+  private val sqlDriverFactory = JdbcSqliteDriverFactory()
   private lateinit var driver: SqlDriver
   private lateinit var database: Produce
 

--- a/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
+++ b/zipline-loader/src/jvmTest/kotlin/app/cash/zipline/loader/loaderTestsJvm.kt
@@ -15,12 +15,13 @@
  */
 package app.cash.zipline.loader
 
+import app.cash.zipline.loader.internal.cache.JdbcSqliteDriverFactory
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import java.security.SecureRandom
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 
-internal actual fun testSqlDriverFactory() = SqlDriverFactory()
+internal actual fun testSqlDriverFactory(): SqlDriverFactory = JdbcSqliteDriverFactory()
 
 actual fun randomByteString(size: Int): ByteString {
   val byteArray = ByteArray(size)

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/cache/databaseNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/cache/databaseNative.kt
@@ -24,8 +24,8 @@ import co.touchlab.sqliter.DatabaseConfiguration
 import co.touchlab.sqliter.interop.SQLiteException
 import okio.Path
 
-internal actual class SqlDriverFactory {
-  actual fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
+internal class NativeSqliteDriverFactory : SqlDriverFactory {
+  override fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
     validateDbPath(path)
     return NativeSqliteDriver(
       configuration = DatabaseConfiguration(

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
@@ -16,7 +16,7 @@
 package app.cash.zipline.loader
 
 import app.cash.zipline.EventListener
-import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import app.cash.zipline.loader.internal.cache.NativeSqliteDriverFactory
 import app.cash.zipline.loader.internal.systemEpochMsClock
 import kotlinx.coroutines.CoroutineDispatcher
 import okio.FileSystem
@@ -30,7 +30,7 @@ fun ZiplineCache(
   loaderEventListener: LoaderEventListener,
 ): ZiplineCache {
   return ZiplineCache(
-    sqlDriverFactory = SqlDriverFactory(),
+    sqlDriverFactory = NativeSqliteDriverFactory(),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseNativeTest.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/internal/cache/DatabaseNativeTest.kt
@@ -33,7 +33,7 @@ class DatabaseNativeTest {
 
   @Test
   fun `happy path`() {
-    val sqlDriverFactory = SqlDriverFactory()
+    val sqlDriverFactory = NativeSqliteDriverFactory()
     val driver = sqlDriverFactory.create(
       path = driverPath,
       schema = Produce.Schema,
@@ -46,7 +46,7 @@ class DatabaseNativeTest {
 
   @Test
   fun dbPathMustEndWithDb() {
-    val sqlDriverFactory = SqlDriverFactory()
+    val sqlDriverFactory = NativeSqliteDriverFactory()
     val exception = assertFailsWith<IllegalArgumentException> {
       sqlDriverFactory.create(
         path = "zipline-database-test.not-db".toPath(),

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
@@ -15,12 +15,13 @@
  */
 package app.cash.zipline.loader
 
+import app.cash.zipline.loader.internal.cache.NativeSqliteDriverFactory
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import kotlin.random.Random
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 
-internal actual fun testSqlDriverFactory() = SqlDriverFactory()
+internal actual fun testSqlDriverFactory(): SqlDriverFactory = NativeSqliteDriverFactory()
 
 actual fun randomByteString(size: Int): ByteString {
   return Random.nextBytes(size).toByteString()


### PR DESCRIPTION
I'd previously attempted to recover when writes fail, but I missed this case.