### PR TITLE
Fix build failures: Spotless formatting and dependency compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,7 @@ allprojects {
 
   plugins.withId("org.jetbrains.kotlin.multiplatform") {
     configure<KotlinMultiplatformExtension> {
-      jvmToolchain(11)
+      jvmToolchain(17)
       @Suppress("OPT_IN_USAGE")
       compilerOptions {
         freeCompilerArgs.addAll("-opt-in=app.cash.zipline.EngineApi")
@@ -168,7 +168,7 @@ allprojects {
 
   plugins.withId("org.jetbrains.kotlin.jvm") {
     configure<KotlinJvmProjectExtension> {
-      jvmToolchain(11)
+      jvmToolchain(17)
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ jetty-ee10Servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", vers
 jetty-ee10WebsocketJettyServer = { module = "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server", version.ref = "jetty" }
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 junit = { module = "junit:junit", version = "4.13.2" }
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.9.0" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.8.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-compose-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }

--- a/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
+++ b/samples/trivia/trivia-host/src/main/kotlin/app/cash/zipline/samples/trivia/launchZiplineJvm.kt
@@ -22,9 +22,7 @@ import app.cash.zipline.loader.ManifestVerifier.Companion.NO_SIGNATURE_CHECKS
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
-fun getTriviaService(zipline: Zipline): TriviaService {
-  return zipline.take("triviaService")
-}
+fun getTriviaService(zipline: Zipline): TriviaService = zipline.take("triviaService")
 
 suspend fun launchZipline(dispatcher: CoroutineDispatcher): Zipline {
   val manifestUrl = "http://localhost:8080/manifest.zipline.json"

--- a/samples/trivia/trivia-js/src/jsMain/kotlin/app/cash/zipline/samples/trivia/triviaJs.kt
+++ b/samples/trivia/trivia-js/src/jsMain/kotlin/app/cash/zipline/samples/trivia/triviaJs.kt
@@ -55,8 +55,7 @@ class RealTriviaService : TriviaService {
 
   override fun games() = gameWithAnswersList.map { it.game }
 
-  override fun answer(gameId: Int, questionId: Int, answer: String) =
-    gameWithAnswersList[gameId].questionList[questionId].result(answer)
+  override fun answer(gameId: Int, questionId: Int, answer: String) = gameWithAnswersList[gameId].questionList[questionId].result(answer)
 }
 
 interface QuestionAndAnswer {

--- a/samples/world-clock/ios/shared/src/commonMain/kotlin/app/cash/zipline/samples/worldclock/exposed.kt
+++ b/samples/world-clock/ios/shared/src/commonMain/kotlin/app/cash/zipline/samples/worldclock/exposed.kt
@@ -26,9 +26,7 @@ fun exposedTypes(
   worldClockIos: WorldClockIos,
   worldClockModel: WorldClockModel,
   worldClockPresenter: WorldClockPresenter,
-) {
-  throw AssertionError()
-}
+): Unit = throw AssertionError()
 
 fun byteStringOf(data: NSData): ByteString = data.toByteString()
 

--- a/samples/world-clock/presenters/src/hostMain/kotlin/app/cash/zipline/samples/worldclock/host.kt
+++ b/samples/world-clock/presenters/src/hostMain/kotlin/app/cash/zipline/samples/worldclock/host.kt
@@ -75,11 +75,9 @@ fun startWorldClockZipline(
 }
 
 /** Poll for code updates by emitting the manifest on an interval. */
-private fun <T> repeatFlow(content: T, delayMillis: Long): Flow<T> {
-  return flow {
+private fun <T> repeatFlow(content: T, delayMillis: Long): Flow<T> = flow {
     while (true) {
       emit(content)
       delay(delayMillis)
     }
   }
-}

--- a/samples/world-clock/presenters/src/jsMain/kotlin/app/cash/zipline/samples/worldclock/SayHello.kt
+++ b/samples/world-clock/presenters/src/jsMain/kotlin/app/cash/zipline/samples/worldclock/SayHello.kt
@@ -16,7 +16,5 @@
 package app.cash.zipline.samples.worldclock
 
 class SayHello {
-  fun getMessage(): String {
-    return "Hello from Kotlin/JS"
-  }
+  fun getMessage(): String = "Hello from Kotlin/JS"
 }

--- a/samples/world-clock/presenters/src/jsMain/kotlin/app/cash/zipline/samples/worldclock/js.kt
+++ b/samples/world-clock/presenters/src/jsMain/kotlin/app/cash/zipline/samples/worldclock/js.kt
@@ -39,8 +39,7 @@ class RealWorldClockPresenter(
 ) : WorldClockPresenter {
   override fun models(
     events: Flow<WorldClockEvent>,
-  ): Flow<WorldClockModel> {
-    return flow {
+  ): Flow<WorldClockModel> = flow {
       while (true) {
         emit(
           WorldClockModel(
@@ -50,5 +49,4 @@ class RealWorldClockPresenter(
         delay(16)
       }
     }
-  }
 }

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/ApiCompatibilityDecision.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/ApiCompatibilityDecision.kt
@@ -82,8 +82,7 @@ fun makeApiCompatibilityDecision(
   }
 }
 
-private fun FirZiplineApi.toToml(): TomlZiplineApi {
-  return TomlZiplineApi(
+private fun FirZiplineApi.toToml(): TomlZiplineApi = TomlZiplineApi(
     services.map { service ->
       TomlZiplineService(
         name = service.name,
@@ -96,4 +95,3 @@ private fun FirZiplineApi.toToml(): TomlZiplineApi {
       )
     },
   )
-}

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/FirZiplineApiReader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/FirZiplineApiReader.kt
@@ -51,12 +51,10 @@ fun readFirZiplineApi(
   jdkRelease: Int,
   sources: Collection<File>,
   classpath: Collection<File>,
-): FirZiplineApi {
-  return KotlinFirLoader(javaHome, jdkRelease, sources, classpath).use { loader ->
+): FirZiplineApi = KotlinFirLoader(javaHome, jdkRelease, sources, classpath).use { loader ->
     val output = loader.load("zipline-api-dump")
     FirZiplineApiReader(output).read()
   }
-}
 
 private val ziplineServiceClassId =
   ClassId(FqName("app.cash.zipline"), Name.identifier("ZiplineService"))
@@ -95,12 +93,10 @@ internal class FirZiplineApiReader(
       return ziplineServiceClssSymbol.isSupertypeOf(symbol, session)
     }
 
-  private fun FirRegularClass.asDeclaredZiplineService(): FirZiplineService {
-    return FirZiplineService(
+  private fun FirRegularClass.asDeclaredZiplineService(): FirZiplineService = FirZiplineService(
       symbol.classId.asSingleFqName().asString(),
       bridgedFunctions(this),
     )
-  }
 
   private fun bridgedFunctions(type: FirRegularClass): List<FirZiplineFunction> {
     val result = sortedSetOf<FirZiplineFunction>(
@@ -175,8 +171,7 @@ internal class FirZiplineApiReader(
     }
   }
 
-  private fun FirTypeProjection.asString(): String {
-    return when (this) {
+  private fun FirTypeProjection.asString(): String = when (this) {
       is FirStarProjection -> {
         "*"
       }
@@ -187,7 +182,6 @@ internal class FirZiplineApiReader(
         error("Unexpected kind of FirTypeProjection: " + javaClass.simpleName)
       }
     }
-  }
 
   /** Collect all regular class declarations in this. */
   private fun FirFile.regularClasses(): List<FirRegularClass> {
@@ -196,7 +190,7 @@ internal class FirZiplineApiReader(
       visitor = object : FirDefaultVisitor<Unit, MutableList<FirRegularClass>>() {
         override fun visitRegularClass(
           regularClass: FirRegularClass,
-          data: MutableList<FirRegularClass>
+          data: MutableList<FirRegularClass>,
         ) {
           super.visitRegularClass(regularClass, data)
           data.add(regularClass)
@@ -204,7 +198,7 @@ internal class FirZiplineApiReader(
 
         override fun visitElement(
           element: FirElement,
-          data: MutableList<FirRegularClass>
+          data: MutableList<FirRegularClass>,
         ) {
           element.acceptChildren(this, data)
         }

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
@@ -110,6 +110,7 @@ internal class KotlinFirLoader(
     }
 
     val sourceFiles = files.mapTo(mutableSetOf(), ::KtVirtualFileSourceFile)
+
     @OptIn(LegacyK2CliPipeline::class)
     val input = ModuleCompilerInput(
       targetId = TargetId(JvmProtoBufUtil.DEFAULT_MODULE_NAME, targetName),

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/ZiplineApis.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/ZiplineApis.kt
@@ -17,8 +17,7 @@ package app.cash.zipline.api.validator.fir
 
 import okio.ByteString.Companion.encodeUtf8
 
-internal fun String.signatureHash(): String =
-  encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
+internal fun String.signatureHash(): String = encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
 
 /** Don't bridge these. */
 internal val NON_INTERFACE_FUNCTION_NAMES = setOf(

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/toml/ZiplineApiTomlReader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/toml/ZiplineApiTomlReader.kt
@@ -20,9 +20,7 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.IOException
 import okio.Options
 
-fun BufferedSource.readTomlZiplineApi(): TomlZiplineApi {
-  return TomlZiplineApiReader(this).readServices()
-}
+fun BufferedSource.readTomlZiplineApi(): TomlZiplineApi = TomlZiplineApiReader(this).readServices()
 
 /**
  * Super-limited reader for the tiny subset of TOML we use for Zipline API files.

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/SourceMap.kt
@@ -153,8 +153,7 @@ internal fun BufferedSource.readVarint(): Long {
   throw IOException("malformed varint")
 }
 
-internal fun BufferedSource.readBase64Character(): Int {
-  return when (val c = readByte().toInt().toChar()) {
+internal fun BufferedSource.readBase64Character(): Int = when (val c = readByte().toInt().toChar()) {
     in 'A'..'Z' -> {
       // char ASCII value
       //  A    65    0
@@ -177,4 +176,3 @@ internal fun BufferedSource.readBase64Character(): Int {
     '/', '_' -> 63
     else -> throw IOException("Unexpected character")
   }
-}

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/applySourceMap.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/applySourceMap.kt
@@ -54,8 +54,7 @@ private class SourceMapBytecodeRewriter(
   val sourceMap: SourceMap,
   val atoms: MutableAtomSet,
 ) {
-  fun JsObject.jsToKt(): JsObject {
-    return when (this) {
+  fun JsObject.jsToKt(): JsObject = when (this) {
       is JsFunctionBytecode -> {
         copy(
           debug = debug?.jsToKt(),
@@ -64,7 +63,6 @@ private class SourceMapBytecodeRewriter(
       }
       else -> this
     }
-  }
 
   fun Debug.jsToKt(): Debug {
     val ktPc2LineBuffer = Buffer()

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/atoms.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/atoms.kt
@@ -45,12 +45,10 @@ class MutableAtomSet(
 
   override val strings: List<JsString> = _strings
 
-  override fun get(id: Int): JsString {
-    return when {
+  override fun get(id: Int): JsString = when {
       id < BUILT_IN_ATOMS.size -> BUILT_IN_ATOMS[id]
       else -> _strings[id - BUILT_IN_ATOMS.size]
     }
-  }
 
   override fun idOf(value: JsString): Int {
     val result = stringToId[value]

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/encoding.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/encoding.kt
@@ -27,23 +27,17 @@ internal inline infix fun Byte.and(other: Int): Int = toInt() and other
 
 /** Like QuickJS' `bc_get_flags` where n is 1. */
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
-internal inline fun Int.bit(bit: Int): Boolean {
-  return (this shr bit) and 0x1 != 0x1
-}
+internal inline fun Int.bit(bit: Int): Boolean = (this shr bit) and 0x1 != 0x1
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
-internal inline fun Boolean.toBit(bit: Int): Int {
-  return when {
+internal inline fun Boolean.toBit(bit: Int): Int = when {
     this -> 0
     else -> 1 shl bit
   }
-}
 
 /** Like QuickJS' `bc_get_flags` where n is > 1. */
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
-internal inline fun Int.bits(bit: Int, bitCount: Int): Int {
-  return (this ushr bit) and ((1 shl bitCount) - 1)
-}
+internal inline fun Int.bits(bit: Int, bitCount: Int): Int = (this ushr bit) and ((1 shl bitCount) - 1)
 
 internal fun BufferedSource.readLeb128(): Int {
   var result = 0

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/stripLineNumbers.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/stripLineNumbers.kt
@@ -34,8 +34,7 @@ fun stripLineNumbers(jsBytecode: ByteArray): ByteArray {
   return result.readByteArray()
 }
 
-fun JsObject.stripLineNumbers(): JsObject {
-  return when (this) {
+fun JsObject.stripLineNumbers(): JsObject = when (this) {
     is JsFunctionBytecode -> {
       copy(
         debug = debug?.copy(pc2Line = ByteString.EMPTY),
@@ -44,4 +43,3 @@ fun JsObject.stripLineNumbers(): JsObject {
     }
     else -> this
   }
-}

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/transformSourceMap.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/transformSourceMap.kt
@@ -24,29 +24,23 @@ fun SourceMap.clean(): SourceMap {
 
 private fun SourceMap.transformFilePaths(
   filePathTransformer: (String) -> String,
-): SourceMap {
-  return SourceMap(
+): SourceMap = SourceMap(
     version = version,
     file = file?.let(filePathTransformer),
     sourcesContent = sourcesContent,
     groups = groups.map { it.transformFilePaths(filePathTransformer) },
   )
-}
 
 private fun Group.transformFilePaths(
   filePathTransformer: (String) -> String,
-): Group {
-  return Group(segments.map { it.transformFilePaths(filePathTransformer) })
-}
+): Group = Group(segments.map { it.transformFilePaths(filePathTransformer) })
 
 private fun Segment.transformFilePaths(
   filePathTransformer: (String) -> String,
-): Segment {
-  return Segment(
+): Segment = Segment(
     startingColumn = startingColumn,
     source = source?.let(filePathTransformer),
     sourceLine = sourceLine,
     sourceColumn = sourceColumn,
     name = name,
   )
-}

--- a/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/types.kt
+++ b/zipline-bytecode/src/main/kotlin/app/cash/zipline/bytecode/types.kt
@@ -43,12 +43,10 @@ data class JsString(
     }
 }
 
-fun String.toJsString(): JsString {
-  return when (length) {
+fun String.toJsString(): JsString = when (length) {
     utf8Size().toInt() -> JsString(isWideChar = false, bytes = encodeUtf8())
     else -> JsString(isWideChar = true, bytes = encode(Charsets.UTF_16LE))
   }
-}
 
 data class JsFunctionBytecode(
   val flags: Int,

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Compile.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Compile.kt
@@ -30,8 +30,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import okio.ByteString.Companion.decodeHex
 
 internal class Compile : CliktCommand("compile") {
-  override fun help(context: Context) =
-    "Compile .js files to .zipline files"
+  override fun help(context: Context) = "Compile .js files to .zipline files"
 
   private val inputDir by option("--input").file().required()
     .help("Directory from which .js files will be loaded.")

--- a/zipline-cli/src/test/kotlin/app/cash/zipline/cli/ZiplineCompilerTest.kt
+++ b/zipline-cli/src/test/kotlin/app/cash/zipline/cli/ZiplineCompilerTest.kt
@@ -225,7 +225,5 @@ class ZiplineCompilerTest {
   }
 
   @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") // Access :zipline internals.
-  private fun loadJsModule(quickJs: QuickJs, id: String, bytecode: ByteArray) {
-    return app.cash.zipline.internal.loadJsModule(quickJs, id, bytecode)
-  }
+  private fun loadJsModule(quickJs: QuickJs, id: String, bytecode: ByteArray) = app.cash.zipline.internal.loadJsModule(quickJs, id, bytecode)
 }

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDevelopmentServer.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDevelopmentServer.kt
@@ -63,14 +63,17 @@ internal open class ZiplineDevelopmentServer internal constructor(
 
         // Offer a web socket for reload events.
         addServlet(
-          ServletHolder("ws", object : JettyWebSocketServlet() {
+          ServletHolder(
+            "ws",
+            object : JettyWebSocketServlet() {
             public override fun configure(factory: JettyWebSocketServletFactory) {
               factory.addMapping("/ws") { _, _ ->
                 ZiplineWebSocket().also { webSockets.add(it) }
               }
             }
-          }),
-          "/ws"
+          },
+          ),
+          "/ws",
         )
 
         // Serve .zipline bytecode and manifest JSON files at the file system root.
@@ -82,7 +85,7 @@ internal open class ZiplineDevelopmentServer internal constructor(
             setInitParameter("cacheControl", "no-cache")
             setInitParameter("etags", "true")
           },
-          "/*"
+          "/*",
         )
       }
 
@@ -100,9 +103,7 @@ internal open class ZiplineDevelopmentServer internal constructor(
   }
 
   @Suppress("unused") // Invoked reflectively by ZiplineServeTask.
-  fun sendReloadToAllWebSockets(): Int {
-    return sendMessageToAllWebSockets(RELOAD_MESSAGE)
-  }
+  fun sendReloadToAllWebSockets(): Int = sendMessageToAllWebSockets(RELOAD_MESSAGE)
 
   /** Returns the number of web sockets notified. */
   private fun sendMessageToAllWebSockets(message: String): Int {

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplinePlugin.kt
@@ -216,11 +216,9 @@ class ZiplinePlugin : KotlinCompilerPluginSupportPlugin {
 
   override fun applyToCompilation(
     kotlinCompilation: KotlinCompilation<*>,
-  ): Provider<List<SubpluginOption>> {
-    return kotlinCompilation.target.project.provider {
+  ): Provider<List<SubpluginOption>> = kotlinCompilation.target.project.provider {
       listOf() // No options.
     }
-  }
 
   private fun createGenerateKeyPairTasks(project: Project) {
     project.tasks.register("generateZiplineManifestKeyPairEd25519") { task ->

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/jsProductionTasks.kt
@@ -42,8 +42,7 @@ internal interface JsProductionTask {
 }
 
 /** Output of the Kotlin compiler. */
-internal fun JsIrBinary.asJsProductionTask(): JsProductionTask {
-  return object : JsProductionTask {
+internal fun JsIrBinary.asJsProductionTask(): JsProductionTask = object : JsProductionTask {
     override val name get() = linkTaskName
     override val targetName get() = target.name
     override val toolName = null
@@ -53,11 +52,9 @@ internal fun JsIrBinary.asJsProductionTask(): JsProductionTask {
         .file(kotlinJsIrLink.compilerOptions.moduleName.map { "$it.js" })
     }
   }
-}
 
 /** Output of the Kotlin compiler, post-processed by a Webpack toolchain. */
-internal fun KotlinWebpack.asJsProductionTask(): JsProductionTask {
-  return object : JsProductionTask {
+internal fun KotlinWebpack.asJsProductionTask(): JsProductionTask = object : JsProductionTask {
     override val name = this@asJsProductionTask.name
     override val targetName = compilation.target.name
     override val toolName = "Webpack"
@@ -68,4 +65,3 @@ internal fun KotlinWebpack.asJsProductionTask(): JsProductionTask {
     }
     override val outputFile get() = this@asJsProductionTask.mainOutputFile
   }
-}

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/util.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/util.kt
@@ -28,10 +28,8 @@ internal fun <T : Any> Iterable<Provider<T>>.flatten(): Provider<List<T>> {
   }
 }
 
-internal fun String.capitalize(): String {
-  return lowercase(locale = Locale.US)
+internal fun String.capitalize(): String = lowercase(locale = Locale.US)
     .replaceFirstChar { it.titlecase(locale = Locale.US) }
-}
 
 internal fun Project.ziplineDependency(artifactId: String): Any {
   // Indicates when the plugin is applied inside the Zipline repo to Zipline's own modules. This

--- a/zipline-gradle-plugin/src/test/projects/crash/lib/src/jsMain/kotlin/app/cash/zipline/tests/launchCrashServiceJs.kt
+++ b/zipline-gradle-plugin/src/test/projects/crash/lib/src/jsMain/kotlin/app/cash/zipline/tests/launchCrashServiceJs.kt
@@ -28,9 +28,7 @@ fun launchCrashService() {
       goBoom() // More calls to get a more interesting stack traces.
     }
 
-    fun goBoom() {
-      throw Exception("boom!")
-    }
+    fun goBoom(): Unit = throw Exception("boom!")
   }
 
   zipline.bind<CrashService>("crashService", crashService)

--- a/zipline-kotlin-plugin-tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin-tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -123,9 +123,7 @@ class ZiplineKotlinPluginTest {
     val (bridgeA, bridgeB) = ZiplineTestInternals.newEndpointPair()
 
     val testingEchoService = object : EchoZiplineService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        return EchoResponse("greetings from the compiler plugin, ${request.message}")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = EchoResponse("greetings from the compiler plugin, ${request.message}")
     }
     ZiplineTestInternals.bindEchoZiplineService(bridgeB, "helloService", testingEchoService)
 
@@ -252,9 +250,7 @@ class ZiplineKotlinPluginTest {
     val (bridgeA, bridgeB) = ZiplineTestInternals.newEndpointPair()
 
     val testingService = object : GenericEchoService<String> {
-      override fun genericEcho(request: String): List<String> {
-        return listOf("received a generic $request!")
-      }
+      override fun genericEcho(request: String): List<String> = listOf("received a generic $request!")
     }
     ZiplineTestInternals.bindGenericEchoService(bridgeB, "genericService", testingService)
 
@@ -422,18 +418,14 @@ class ZiplineKotlinPluginTest {
 fun compile(
   sourceFiles: List<SourceFile>,
   plugin: CompilerPluginRegistrar = ZiplineCompilerPluginRegistrar(),
-): JvmCompilationResult {
-  return KotlinCompilation().apply {
+): JvmCompilationResult = KotlinCompilation().apply {
     sources = sourceFiles
     compilerPluginRegistrars = listOf(plugin)
     inheritClassPath = true
   }.compile()
-}
 
 @ExperimentalCompilerApi
 fun compile(
   sourceFile: SourceFile,
   plugin: CompilerPluginRegistrar = ZiplineCompilerPluginRegistrar(),
-): JvmCompilationResult {
-  return compile(listOf(sourceFile), plugin)
-}
+): JvmCompilationResult = compile(listOf(sourceFile), plugin)

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -595,7 +595,7 @@ internal class AdapterGenerator(
             +functionCall
             irUnit()
           }
-        }
+        },
       )
     }
 
@@ -647,8 +647,7 @@ internal class AdapterGenerator(
     ziplineFunctionClass: IrClass,
     callFunction: IrSimpleFunction,
     bridgedFunction: IrSimpleFunctionSymbol,
-  ): IrExpression {
-    return irCall(
+  ): IrExpression = irCall(
       type = bridgedInterface.resolveTypeParameters(bridgedFunction.owner.returnType)
         .remapTypeParameters(original, ziplineFunctionClass),
       callee = bridgedFunction,
@@ -669,7 +668,6 @@ internal class AdapterGenerator(
         )
       }
     }
-  }
 
   /** Override `ZiplineServiceAdapter.outboundService(...)`. */
   private fun irOutboundServiceFunction(
@@ -893,7 +891,7 @@ internal class AdapterGenerator(
           elementType = pluginContext.symbols.any.defaultType.makeNullable(),
           values = result.parameters
             .filter { it.kind == IrParameterKind.Regular }
-            .map { irGet(type = it.type, variable = it.symbol) }
+            .map { irGet(type = it.type, variable = it.symbol) },
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -107,12 +107,10 @@ internal class BridgedInterface(
     statementsBuilder: IrStatementsBuilder<*>,
     serializersModuleParameter: IrValueParameter,
     serializersExpression: IrVariable,
-  ): Map<IrType, IrVariable> {
-    return statementsBuilder.irDeclareSerializerTemporaries(
+  ): Map<IrType, IrVariable> = statementsBuilder.irDeclareSerializerTemporaries(
       serializersModuleParameter = serializersModuleParameter,
       serializersExpression = serializersExpression,
     )
-  }
 
   private fun IrStatementsBuilder<*>.irDeclareSerializerTemporaries(
     serializersModuleParameter: IrValueParameter,
@@ -237,7 +235,7 @@ internal class BridgedInterface(
         wrapWithNullableSerializerIfNeeded(
           type,
           contextualSerializerExpression,
-          ziplineApis.nullableSerializer
+          ziplineApis.nullableSerializer,
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -143,15 +143,13 @@ internal fun IrBuilderWithScope.irReturn(
   value: IrExpression,
   returnTargetSymbol: IrReturnTargetSymbol,
   type: IrType = value.type,
-): IrReturn {
-  return IrReturnImpl(
+): IrReturn = IrReturnImpl(
     startOffset = startOffset,
     endOffset = endOffset,
     type = type,
     returnTargetSymbol = returnTargetSymbol,
     value = value,
   )
-}
 
 /** Set up reasonable defaults for a generated function or constructor. */
 fun IrFunctionBuilder.initDefaults(original: IrElement) {
@@ -182,12 +180,10 @@ fun IrValueParameterBuilder.initDefaults(original: IrElement) {
  * use `UNDEFINED_OFFSET`. Make sure we don't propagate this further into generated code; that
  * causes LLVM code generation to fail.
  */
-private fun Int.toSyntheticIfUnknown(): Int {
-  return when (this) {
+private fun Int.toSyntheticIfUnknown(): Int = when (this) {
     UNDEFINED_OFFSET -> SYNTHETIC_OFFSET
     else -> this
   }
-}
 
 fun IrConstructor.irConstructorBody(
   context: IrGeneratorContext,
@@ -233,14 +229,12 @@ fun DeclarationIrBuilder.irDelegatingConstructorCall(
 fun DeclarationIrBuilder.irInstanceInitializerCall(
   context: IrGeneratorContext,
   classSymbol: IrClassSymbol,
-): IrInstanceInitializerCall {
-  return IrInstanceInitializerCallImpl(
+): IrInstanceInitializerCall = IrInstanceInitializerCallImpl(
     startOffset = startOffset,
     endOffset = endOffset,
     classSymbol = classSymbol,
     type = context.irBuiltIns.unitType,
   )
-}
 
 fun IrSimpleFunction.irFunctionBody(
   context: IrGeneratorContext,
@@ -355,41 +349,35 @@ fun irVal(
 
 internal fun IrBuilderWithScope.irKClass(
   containerClass: IrClass,
-): IrClassReferenceImpl {
-  return IrClassReferenceImpl(
+): IrClassReferenceImpl = IrClassReferenceImpl(
     startOffset = startOffset,
     endOffset = endOffset,
     type = context.irBuiltIns.kClassClass.typeWith(containerClass.defaultType),
     symbol = containerClass.symbol,
     classType = containerClass.defaultType,
   )
-}
 
 fun irBlockBodyBuilder(
   irPluginContext: IrGeneratorContext,
   scopeWithIr: ScopeWithIr,
   original: IrElement,
-): IrBlockBodyBuilder {
-  return IrBlockBodyBuilder(
+): IrBlockBodyBuilder = IrBlockBodyBuilder(
     context = irPluginContext,
     scope = scopeWithIr.scope,
     startOffset = original.startOffset.toSyntheticIfUnknown(),
     endOffset = original.endOffset.toSyntheticIfUnknown(),
   )
-}
 
 fun irBlockBuilder(
   irPluginContext: IrGeneratorContext,
   scopeWithIr: ScopeWithIr,
   original: IrElement,
-): IrBlockBuilder {
-  return IrBlockBuilder(
+): IrBlockBuilder = IrBlockBuilder(
     context = irPluginContext,
     scope = scopeWithIr.scope,
     startOffset = original.startOffset.toSyntheticIfUnknown(),
     endOffset = original.endOffset.toSyntheticIfUnknown(),
   )
-}
 
 /** This creates `companion object` if it doesn't exist already. */
 fun getOrCreateCompanion(
@@ -457,8 +445,7 @@ fun IrBuilderWithScope.irInvoke(
   typeArguments: List<IrType?>,
   valueArguments: List<IrExpression>,
   returnTypeHint: IrType? = null,
-): IrMemberAccessExpression<*> =
-  irInvoke(
+): IrMemberAccessExpression<*> = irInvoke(
     dispatchReceiver,
     callee,
     *valueArguments.toTypedArray(),

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/package.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/package.kt
@@ -9,18 +9,10 @@ import org.jetbrains.kotlin.name.Name
 @JvmInline
 value class FqPackageName(val fqName: FqName)
 
-fun FqPackageName(name: String): FqPackageName {
-  return FqPackageName(FqName(name))
-}
+fun FqPackageName(name: String): FqPackageName = FqPackageName(FqName(name))
 
-fun FqPackageName.classId(name: String): ClassId {
-  return ClassId(fqName, Name.identifier(name))
-}
+fun FqPackageName.classId(name: String): ClassId = ClassId(fqName, Name.identifier(name))
 
-fun FqPackageName.callableId(name: String): CallableId {
-  return CallableId(fqName, Name.identifier(name))
-}
+fun FqPackageName.callableId(name: String): CallableId = CallableId(fqName, Name.identifier(name))
 
-fun ClassId.callableId(name: String): CallableId {
-  return CallableId(this, Name.identifier(name))
-}
+fun ClassId.callableId(name: String): CallableId = CallableId(this, Name.identifier(name))

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
@@ -18,8 +18,7 @@ import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 /** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
-fun IrSimpleType.asString(): String =
-  classifier.asString() +
+fun IrSimpleType.asString(): String = classifier.asString() +
     (
       arguments.ifNotEmpty {
       joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }

--- a/zipline-loader/src/androidInstrumentedTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
+++ b/zipline-loader/src/androidInstrumentedTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
@@ -25,8 +25,7 @@ import okio.ByteString.Companion.toByteString
 // Note that we don't run Android tests because we don't have the right QuickJS or SQLite to run
 // them on the JVM.
 
-internal actual fun testSqlDriverFactory(): SqlDriverFactory =
-  error("testSqlDriverFactory not available for Android")
+internal actual fun testSqlDriverFactory(): SqlDriverFactory = error("testSqlDriverFactory not available for Android")
 
 actual fun randomByteString(size: Int): ByteString {
   val byteArray = ByteArray(size)

--- a/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
+++ b/zipline-loader/src/androidMain/kotlin/app/cash/zipline/loader/loaderAndroid.kt
@@ -26,27 +26,23 @@ fun ZiplineCache(
   directory: Path,
   maxSizeInBytes: Long,
   loaderEventListener: LoaderEventListener,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     sqlDriverFactory = AndroidSqliteDriverFactory(context),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = loaderEventListener,
   )
-}
 
 fun ZiplineCache(
   context: Context,
   fileSystem: FileSystem,
   directory: Path,
   maxSizeInBytes: Long,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     context = context,
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = LoaderEventListener.None,
   )
-}

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FastCodeUpdates.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FastCodeUpdates.kt
@@ -36,8 +36,7 @@ import kotlinx.coroutines.flow.transformLatest
 fun Flow<String>.withDevelopmentServerPush(
   httpClient: ZiplineHttpClient,
   pollingInterval: Duration = 500.milliseconds,
-): Flow<String> {
-  return transformLatest { manifestUrl ->
+): Flow<String> = transformLatest { manifestUrl ->
     // Attempt once before any websocket setup or polling.
     emit(manifestUrl)
 
@@ -62,7 +61,6 @@ fun Flow<String>.withDevelopmentServerPush(
       emit(manifestUrl)
     }
   }
-}
 
 /**
  * Returns a string like "http://host:8080" given a full URL like "http://host:8080/path?query".

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/FreshnessChecker.kt
@@ -38,7 +38,5 @@ interface FreshnessChecker {
 
 /** A FreshnessChecker that never loads locally-cached applications. */
 object DefaultFreshnessCheckerNotFresh : FreshnessChecker {
-  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean {
-    return false
-  }
+  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean = false
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -143,8 +143,7 @@ class ZiplineLoader internal constructor(
     cache: ZiplineCache? = this.cache,
     cacheDispatcher: CoroutineDispatcher? = this.cacheDispatcher,
     eventListenerFactory: EventListener.Factory = this.eventListenerFactory,
-  ): ZiplineLoader {
-    return ZiplineLoader(
+  ): ZiplineLoader = ZiplineLoader(
       dispatcher = dispatcher,
       manifestVerifier = manifestVerifier,
       httpFetcher = httpFetcher,
@@ -155,7 +154,6 @@ class ZiplineLoader internal constructor(
       cache = cache,
       cacheDispatcher = cacheDispatcher,
     )
-  }
 
   private var concurrentDownloadsSemaphore = Semaphore(3)
 
@@ -285,15 +283,13 @@ class ZiplineLoader internal constructor(
     manifestUrlFlow: Flow<String>,
     serializersModule: SerializersModule = EmptySerializersModule(),
     initializer: (Zipline) -> Unit = {},
-  ): Flow<LoadResult> {
-    return load(
+  ): Flow<LoadResult> = load(
       applicationName = applicationName,
       freshnessChecker = freshnessChecker,
       manifestUrlFlow = manifestUrlFlow,
       serializersModule = serializersModule,
       initializer = { zipline -> initializer(zipline) },
     )
-  }
 
   /**
    * Downloads ZiplineManifest each time [manifestUrlFlow] emits and loads Zipline with the newly
@@ -316,15 +312,13 @@ class ZiplineLoader internal constructor(
     manifestUrlFlow: Flow<String>,
     serializersModule: SerializersModule = EmptySerializersModule(),
     initializer: (Zipline) -> Unit = {},
-  ): Flow<LoadResult> {
-    return load(
+  ): Flow<LoadResult> = load(
       applicationName = applicationName,
       freshnessChecker = DefaultFreshnessCheckerNotFresh,
       manifestUrlFlow = manifestUrlFlow,
       serializersModule = serializersModule,
       initializer = initializer,
     )
-  }
 
   /**
    * Fetches ZiplineManifest from network, and after a successful fetch, loads Zipline with newly

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/FsCachingFetcher.kt
@@ -51,11 +51,9 @@ internal class FsCachingFetcher(
     }
   }
 
-  suspend fun loadPinnedManifest(applicationName: String, nowEpochMs: Long): LoadedManifest? {
-    return withContext(cacheDispatcher) {
+  suspend fun loadPinnedManifest(applicationName: String, nowEpochMs: Long): LoadedManifest? = withContext(cacheDispatcher) {
       cache.getPinnedManifest(applicationName, nowEpochMs)
     }
-  }
 
   /**
    * Permits all downloads for [applicationName] not in [loadedManifest] to be pruned.
@@ -63,20 +61,16 @@ internal class FsCachingFetcher(
    * This assumes that all artifacts in [loadedManifest] are currently pinned. Fetchers do not
    * necessarily enforce this assumption.
    */
-  suspend fun pin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) {
-    return withContext(cacheDispatcher) {
+  suspend fun pin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) = withContext(cacheDispatcher) {
       cache.pinManifest(applicationName, loadedManifest, nowEpochMs)
     }
-  }
 
   /**
    * Removes the pins for [applicationName] in [loadedManifest] so they may be pruned.
    */
-  suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) {
-    return withContext(cacheDispatcher) {
+  suspend fun unpin(applicationName: String, loadedManifest: LoadedManifest, nowEpochMs: Long) = withContext(cacheDispatcher) {
       cache.unpinManifest(applicationName, loadedManifest, nowEpochMs)
     }
-  }
 
   /**
    * Updates freshAt timestamp for manifests that in later network fetch is still the freshest.
@@ -85,9 +79,7 @@ internal class FsCachingFetcher(
     applicationName: String,
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
-  ) {
-    return withContext(cacheDispatcher) {
+  ) = withContext(cacheDispatcher) {
       cache.updateManifestFreshAt(applicationName, loadedManifest, nowEpochMs)
     }
-  }
 }

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/internalCommon.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/internalCommon.kt
@@ -24,18 +24,15 @@ internal expect fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: S
 
 internal const val MANIFEST_FILE_NAME = "manifest.zipline.json"
 
-internal fun getApplicationManifestFileName(applicationName: String) =
-  "$applicationName.$MANIFEST_FILE_NAME"
+internal fun getApplicationManifestFileName(applicationName: String) = "$applicationName.$MANIFEST_FILE_NAME"
 
 /** ECDSA P-256. https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm */
 internal expect val ecdsaP256: SignatureAlgorithm
 
-internal fun SignatureAlgorithmId.get(): SignatureAlgorithm {
-  return when (this) {
+internal fun SignatureAlgorithmId.get(): SignatureAlgorithm = when (this) {
     SignatureAlgorithmId.Ed25519 -> Ed25519
     SignatureAlgorithmId.EcdsaP256 -> ecdsaP256
   }
-}
 
 internal expect val systemEpochMsClock: () -> Long
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519.kt
@@ -650,9 +650,7 @@ internal object Ed25519 : SignatureAlgorithm {
    * Preconditions:
    * `a[31] <= 127`
    */
-  fun scalarMultWithBaseToBytes(a: ByteString): ByteString {
-    return scalarMultWithBase(a.toByteArray()).toBytes().toByteString()
-  }
+  fun scalarMultWithBaseToBytes(a: ByteString): ByteString = scalarMultWithBase(a.toByteArray()).toBytes().toByteString()
 
   private fun slide(a: ByteArray): ByteArray {
     val r = ByteArray(256)
@@ -763,9 +761,7 @@ internal object Ed25519 : SignatureAlgorithm {
   /**
    * Returns the least significant bit of [`in`].
    */
-  private fun getLsb(inLongArray: LongArray): Int {
-    return Field25519.contract(inLongArray)[0].toInt() and 1
-  }
+  private fun getLsb(inLongArray: LongArray): Int = Field25519.contract(inLongArray)[0].toInt() and 1
 
   /**
    * Negates all values in [in1] and store it in [out].

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/FakeZiplineHttpClient.kt
@@ -46,9 +46,7 @@ class FakeZiplineHttpClient : ZiplineHttpClient() {
   override suspend fun download(
     url: String,
     requestHeaders: List<Pair<String, String>>,
-  ): ByteString {
-    return filePathToByteString[url] ?: throw IOException("404: $url not found")
-  }
+  ): ByteString = filePathToByteString[url] ?: throw IOException("404: $url not found")
 
   override suspend fun openDevelopmentServerWebSocket(
     url: String,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderConcurrencyTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderConcurrencyTest.kt
@@ -92,7 +92,9 @@ class LoaderConcurrencyTest {
     }
   }
 
-  inner class TestEventListener : EventListener(), EventListener.Factory {
+  inner class TestEventListener :
+    EventListener(),
+    EventListener.Factory {
     override fun create(applicationName: String, manifestUrl: String?) = this
 
     override fun cacheHit(applicationName: String, url: String, fileSize: Long) {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -191,11 +191,9 @@ class LoaderTester(
   }
 
   /** Returns the delta in the number of files, like -3 if 3 files were deleted. */
-  suspend fun prune(): Int {
-    return countFiles {
+  suspend fun prune(): Int = countFiles {
       cache.prune(0L)
     }
-  }
 
   /** Returns the delta in the number of files, like 3 if 3 files were added. */
   suspend fun countFiles(block: suspend () -> Unit): Int {
@@ -206,9 +204,7 @@ class LoaderTester(
   }
 
   /** Returns the file if it exists. */
-  fun file(path: String): ByteString? {
-    return httpClient.filePathToByteString["$baseUrl/$path"]
-  }
+  fun file(path: String): ByteString? = httpClient.filePathToByteString["$baseUrl/$path"]
 
   suspend fun failureManifestFetchFails(applicationName: String): String {
     val seed = "fail"
@@ -404,7 +400,5 @@ class LoaderTester(
 }
 
 object FakeFreshnessCheckerFresh : FreshnessChecker {
-  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean {
-    return true
-  }
+  override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long): Boolean = true
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ProductionFetcherReceiverTest.kt
@@ -143,8 +143,7 @@ class ProductionFetcherReceiverTest {
     applicationName: String,
     manifest: ZiplineManifest,
     initializer: (Zipline) -> Unit = {},
-  ): Zipline {
-    return loadFromManifest(
+  ): Zipline = loadFromManifest(
       applicationName = applicationName,
       eventListener = EventListener.NONE,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
@@ -152,5 +151,4 @@ class ProductionFetcherReceiverTest {
       initializer = initializer,
       nowEpochMs = nowMillis,
     )
-  }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -417,8 +417,7 @@ class ZiplineLoaderTest {
     applicationName: String,
     manifest: ZiplineManifest,
     initializer: (Zipline) -> Unit = {},
-  ): Zipline {
-    return loadFromManifest(
+  ): Zipline = loadFromManifest(
       applicationName = applicationName,
       eventListener = EventListener.NONE,
       loadedManifest = LoadedManifest(ByteString.EMPTY, manifest, 1L),
@@ -426,5 +425,4 @@ class ZiplineLoaderTest {
       initializer = initializer,
       nowEpochMs = systemEpochMsClock(),
     )
-  }
 }

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
@@ -423,8 +423,7 @@ class ZiplineCacheTest {
     download: suspend () -> ByteString,
   ) = getOrPut(applicationName, sha256, nowMillis, download)
 
-  private fun ZiplineCache.getPinnedManifest(applicationName: String) =
-    getPinnedManifest(applicationName, nowMillis)
+  private fun ZiplineCache.getPinnedManifest(applicationName: String) = getPinnedManifest(applicationName, nowMillis)
 
   private fun ZiplineCache.pinManifest(
     applicationName: String,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519Sign.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519Sign.kt
@@ -39,9 +39,7 @@ internal class Ed25519Sign private constructor(
   private val hashedPrivateKey: ByteString,
   private val publicKey: ByteString,
 ) {
-  fun sign(data: ByteString): ByteString {
-    return sign(data, publicKey, hashedPrivateKey)
-  }
+  fun sign(data: ByteString): ByteString = sign(data, publicKey, hashedPrivateKey)
 
   companion object {
     private const val SECRET_KEY_LEN = Field25519.FIELD_LEN

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/wycheproof.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/tink/subtle/wycheproof.kt
@@ -74,13 +74,9 @@ class Key(
 
 private val wycheproofDir = ziplineRoot / "zipline-loader/src/commonTest/resources/wycheproof/"
 
-fun loadEddsaTestJson(): WycheproofTestJson {
-  return loadWycheproofTestJson(wycheproofDir / "eddsa_test.json")
-}
+fun loadEddsaTestJson(): WycheproofTestJson = loadWycheproofTestJson(wycheproofDir / "eddsa_test.json")
 
-fun loadEcdsaP256TestJson(): WycheproofTestJson {
-  return loadWycheproofTestJson(wycheproofDir / "ecdsa_secp256r1_sha256_test.json")
-}
+fun loadEcdsaP256TestJson(): WycheproofTestJson = loadWycheproofTestJson(wycheproofDir / "ecdsa_secp256r1_sha256_test.json")
 
 fun loadWycheproofTestJson(path: Path): WycheproofTestJson {
   val wycheproofTestJson = systemFileSystem.read(path) {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/loaderTestsCommon.kt
@@ -80,6 +80,4 @@ fun prettyPrint(jsonString: String): String {
  * Returns a new `<publicKey / privateKey>` KeyPair. The PRNG for this function is not secure on all
  * platforms and should not be used for production code.
  */
-internal fun generateKeyPairForTest(): KeyPair {
-  return newKeyPairFromSeed(randomByteString(Field25519.FIELD_LEN))
-}
+internal fun generateKeyPairForTest(): KeyPair = newKeyPairFromSeed(randomByteString(Field25519.FIELD_LEN))

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/EcdsaP256.kt
@@ -58,9 +58,7 @@ internal class EcdsaP256(
     return signer.sign().toByteString()
   }
 
-  override fun sign(message: ByteString, privateKey: ByteString): ByteString {
-    return sign(decodePkcs8EcPrivateKey(privateKey), message)
-  }
+  override fun sign(message: ByteString, privateKey: ByteString): ByteString = sign(decodePkcs8EcPrivateKey(privateKey), message)
 
   fun verify(publicKey: PublicKey, signature: ByteString, data: ByteString): Boolean {
     val verifier = Signature.getInstance("SHA256withECDSA")
@@ -85,13 +83,11 @@ internal fun decodePkcs8EcPrivateKey(privateKey: ByteString): PrivateKey {
   return keyFactory.generatePrivate(keySpec)
 }
 
-internal fun ECPublicKey.encodeAnsiX963(): ByteString {
-  return Buffer()
+internal fun ECPublicKey.encodeAnsiX963(): ByteString = Buffer()
     .writeByte(4)
     .write(w.affineX.toUnsignedFixedWidth(32))
     .write(w.affineY.toUnsignedFixedWidth(32))
     .readByteString()
-}
 
 internal fun ByteString.decodeAnsiX963(): ECPublicKey {
   val buffer = Buffer().write(this)

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/internalJni.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/internalJni.kt
@@ -19,8 +19,7 @@ import app.cash.zipline.Zipline
 import java.security.SecureRandom
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
-internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) =
-  loadJsModule(bytecode, id)
+internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) = loadJsModule(bytecode, id)
 
 internal actual val ecdsaP256: SignatureAlgorithm = EcdsaP256(secureRandom())
 
@@ -30,6 +29,4 @@ internal fun secureRandom(): SecureRandom {
 
 internal actual val systemEpochMsClock: () -> Long = System::currentTimeMillis
 
-internal actual fun resolveUrl(baseUrl: String, link: String): String {
-  return baseUrl.toHttpUrl().resolve(link)!!.toString()
-}
+internal actual fun resolveUrl(baseUrl: String, link: String): String = baseUrl.toHttpUrl().resolve(link)!!.toString()

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/loaderJni.kt
@@ -26,14 +26,12 @@ fun ZiplineLoader(
   httpClient: OkHttpClient,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = systemEpochMsClock,
-): ZiplineLoader {
-  return ZiplineLoader(
+): ZiplineLoader = ZiplineLoader(
     dispatcher = dispatcher,
     manifestVerifier = manifestVerifier,
     httpClient = httpClient.asZiplineHttpClient(),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
   )
-}
 
 fun OkHttpClient.asZiplineHttpClient(): ZiplineHttpClient = OkHttpZiplineHttpClient(this)

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/internalJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/internal/internalJvm.kt
@@ -29,9 +29,7 @@ internal fun generateEd25519KeyPair(): KeyPair {
   return newKeyPairFromSeed(secretSeed.toByteString())
 }
 
-internal fun generateKeyPair(signatureAlgorithmId: SignatureAlgorithmId): KeyPair {
-  return when (signatureAlgorithmId) {
+internal fun generateKeyPair(signatureAlgorithmId: SignatureAlgorithmId): KeyPair = when (signatureAlgorithmId) {
     SignatureAlgorithmId.Ed25519 -> generateEd25519KeyPair()
     SignatureAlgorithmId.EcdsaP256 -> EcdsaP256(secureRandom()).generateKeyPair()
   }
-}

--- a/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
+++ b/zipline-loader/src/jvmMain/kotlin/app/cash/zipline/loader/loaderJvm.kt
@@ -24,25 +24,21 @@ fun ZiplineCache(
   directory: Path,
   maxSizeInBytes: Long,
   loaderEventListener: LoaderEventListener,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     sqlDriverFactory = JdbcSqliteDriverFactory(),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = loaderEventListener,
   )
-}
 
 fun ZiplineCache(
   fileSystem: FileSystem,
   directory: Path,
   maxSizeInBytes: Long,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = LoaderEventListener.None,
   )
-}

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/internalNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/internalNative.kt
@@ -20,14 +20,11 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSURL
 import platform.Foundation.timeIntervalSince1970
 
-internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) =
-  loadJsModule(bytecode, id)
+internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) = loadJsModule(bytecode, id)
 
 internal actual val ecdsaP256: SignatureAlgorithm = EcdsaP256()
 
 internal actual val systemEpochMsClock: () -> Long =
   { (NSDate().timeIntervalSince1970() * 1000).toLong() }
 
-internal actual fun resolveUrl(baseUrl: String, link: String): String {
-  return NSURL(string = link, relativeToURL = NSURL(string = baseUrl)).absoluteString!!
-}
+internal actual fun resolveUrl(baseUrl: String, link: String): String = NSURL(string = link, relativeToURL = NSURL(string = baseUrl)).absoluteString!!

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/loaderNative.kt
@@ -28,28 +28,24 @@ fun ZiplineCache(
   directory: Path,
   maxSizeInBytes: Long,
   loaderEventListener: LoaderEventListener,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     sqlDriverFactory = NativeSqliteDriverFactory(),
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = loaderEventListener,
   )
-}
 
 fun ZiplineCache(
   fileSystem: FileSystem,
   directory: Path,
   maxSizeInBytes: Long,
-): ZiplineCache {
-  return ZiplineCache(
+): ZiplineCache = ZiplineCache(
     fileSystem = fileSystem,
     directory = directory,
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = LoaderEventListener.None,
   )
-}
 
 fun ZiplineLoader(
   dispatcher: CoroutineDispatcher,
@@ -57,14 +53,12 @@ fun ZiplineLoader(
   urlSession: NSURLSession,
   eventListener: EventListener = EventListener.NONE,
   nowEpochMs: () -> Long = systemEpochMsClock,
-): ZiplineLoader {
-  return ZiplineLoader(
+): ZiplineLoader = ZiplineLoader(
     dispatcher = dispatcher,
     manifestVerifier = manifestVerifier,
     httpClient = urlSession.asZiplineHttpClient(),
     eventListener = eventListener,
     nowEpochMs = nowEpochMs,
   )
-}
 
 fun NSURLSession.asZiplineHttpClient(): ZiplineHttpClient = URLSessionZiplineHttpClient(this)

--- a/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
+++ b/zipline-loader/src/nativeTest/kotlin/app/cash/zipline/loader/loaderTestsNative.kt
@@ -23,8 +23,6 @@ import okio.ByteString.Companion.toByteString
 
 internal actual fun testSqlDriverFactory(): SqlDriverFactory = NativeSqliteDriverFactory()
 
-actual fun randomByteString(size: Int): ByteString {
-  return Random.nextBytes(size).toByteString()
-}
+actual fun randomByteString(size: Int): ByteString = Random.nextBytes(size).toByteString()
 
 internal actual fun canSignEcdsaP256() = false

--- a/zipline-profiler/src/commonMain/kotlin/app/cash/zipline/profiler/SamplingProfiler.kt
+++ b/zipline-profiler/src/commonMain/kotlin/app/cash/zipline/profiler/SamplingProfiler.kt
@@ -57,7 +57,8 @@ fun QuickJs.startCpuSampling(hprofSink: BufferedSink): Closeable {
 internal class SamplingProfiler internal constructor(
   private val quickJs: QuickJs,
   private val hprofWriter: HprofWriter,
-) : Closeable, InterruptHandler {
+) : Closeable,
+  InterruptHandler {
   private var nextId = 1
 
   /** Placeholder value for the JavaScript thread. */

--- a/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/adapters.kt
+++ b/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/adapters.kt
@@ -48,9 +48,7 @@ internal object AdaptersRequestSerializer : KSerializer<AdaptersRequest> {
     encoder.encodeString(value.message)
   }
 
-  override fun deserialize(decoder: Decoder): AdaptersRequest {
-    return AdaptersRequest(decoder.decodeString())
-  }
+  override fun deserialize(decoder: Decoder): AdaptersRequest = AdaptersRequest(decoder.decodeString())
 }
 
 internal object AdaptersResponseSerializer : KSerializer<AdaptersResponse> {
@@ -63,9 +61,7 @@ internal object AdaptersResponseSerializer : KSerializer<AdaptersResponse> {
     encoder.encodeString(value.message)
   }
 
-  override fun deserialize(decoder: Decoder): AdaptersResponse {
-    return AdaptersResponse(decoder.decodeString())
-  }
+  override fun deserialize(decoder: Decoder): AdaptersResponse = AdaptersResponse(decoder.decodeString())
 }
 
 val AdaptersRequestSerializersModule: SerializersModule = SerializersModule {

--- a/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
+++ b/zipline-testing/src/commonMain/kotlin/app/cash/zipline/testing/endpoints.kt
@@ -51,13 +51,9 @@ fun newEndpointPair(
       userSerializersModule = serializersModule,
       eventListener = listenerA,
       outboundChannel = object : CallChannel {
-        override fun call(callJson: String): String {
-          return b.inboundChannel.call(callJson)
-        }
+        override fun call(callJson: String): String = b.inboundChannel.call(callJson)
 
-        override fun disconnect(instanceName: String): Boolean {
-          return b.inboundChannel.disconnect(instanceName)
-        }
+        override fun disconnect(instanceName: String): Boolean = b.inboundChannel.disconnect(instanceName)
       },
       oppositeProvider = { bEndpointService },
     )

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -22,7 +22,9 @@ import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.ZiplineService
 
-class LoggingEventListener : EventListener(), EventListener.Factory {
+class LoggingEventListener :
+  EventListener(),
+  EventListener.Factory {
   private var nextCallId = 1
   private val log = ArrayDeque<LogEntry>()
 

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/SignatureHash.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/SignatureHash.kt
@@ -33,5 +33,4 @@ import okio.ByteString.Companion.encodeUtf8
  * Don't change how this works! Doing so will break upgrades for programs compiled with different
  * identifiers.
  */
-fun String.signatureHash(): String =
-  encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
+fun String.signatureHash(): String = encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/ZiplineTestInternals.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/ZiplineTestInternals.kt
@@ -57,9 +57,7 @@ object ZiplineTestInternals {
   }
 
   /** Simulate generated code for outbound calls.  */
-  fun takeEchoClient(endpoint: Endpoint, name: String): EchoService {
-    return endpoint.take(name, ZiplineScope(), EchoServiceAdapter())
-  }
+  fun takeEchoClient(endpoint: Endpoint, name: String): EchoService = endpoint.take(name, ZiplineScope(), EchoServiceAdapter())
 
   /** Simulate generated code for inbound calls.  */
   fun bindEchoService(endpoint: Endpoint, name: String, echoService: EchoService) {
@@ -67,9 +65,7 @@ object ZiplineTestInternals {
   }
 
   /** Simulate generated code for outbound calls.  */
-  fun takeGenericEchoService(endpoint: Endpoint, name: String): GenericEchoService<String> {
-    return endpoint.take(name, ZiplineScope(), GenericEchoServiceAdapter())
-  }
+  fun takeGenericEchoService(endpoint: Endpoint, name: String): GenericEchoService<String> = endpoint.take(name, ZiplineScope(), GenericEchoServiceAdapter())
 
   /** Simulate generated code for inbound calls.  */
   fun bindGenericEchoService(
@@ -90,9 +86,7 @@ object ZiplineTestInternals {
   }
 
   /** Simulate generated code for outbound calls.  */
-  fun takeEchoZiplineService(endpoint: Endpoint, name: String): EchoZiplineService {
-    return endpoint.take(name, ZiplineScope(), EchoZiplineServiceAdapter())
-  }
+  fun takeEchoZiplineService(endpoint: Endpoint, name: String): EchoZiplineService = endpoint.take(name, ZiplineScope(), EchoZiplineServiceAdapter())
 
   /** Simulate a generated subclass of ZiplineServiceAdapter.  */
   class EchoServiceAdapter : ZiplineServiceAdapter<EchoService>() {
@@ -117,24 +111,19 @@ object ZiplineTestInternals {
           listOf(requestSerializer),
           responseSerializer,
         ) {
-          override fun call(service: EchoService, args: List<*>): Any {
-            return service.echo(args[0] as EchoRequest)
-          }
+          override fun call(service: EchoService, args: List<*>): Any = service.echo(args[0] as EchoRequest)
         },
       )
     }
 
-    override fun outboundService(callHandler: OutboundCallHandler): EchoService {
-      return GeneratedOutboundService(callHandler)
-    }
+    override fun outboundService(callHandler: OutboundCallHandler): EchoService = GeneratedOutboundService(callHandler)
 
     private class GeneratedOutboundService(
       override val callHandler: OutboundCallHandler,
-    ) : EchoService, OutboundService {
+    ) : EchoService,
+      OutboundService {
 
-      override fun echo(request: EchoRequest): EchoResponse {
-        return callHandler.call(this, 0, request) as EchoResponse
-      }
+      override fun echo(request: EchoRequest): EchoResponse = callHandler.call(this, 0, request) as EchoResponse
     }
   }
 
@@ -160,23 +149,18 @@ object ZiplineTestInternals {
           listOf(requestSerializer),
           responseSerializer,
         ) {
-          override fun call(service: GenericEchoService<String>, args: List<*>): Any {
-            return service.genericEcho(args[0] as String)
-          }
+          override fun call(service: GenericEchoService<String>, args: List<*>): Any = service.genericEcho(args[0] as String)
         },
       )
     }
 
-    override fun outboundService(callHandler: OutboundCallHandler): GenericEchoService<String> {
-      return GeneratedOutboundService(callHandler)
-    }
+    override fun outboundService(callHandler: OutboundCallHandler): GenericEchoService<String> = GeneratedOutboundService(callHandler)
 
     private class GeneratedOutboundService(override val callHandler: OutboundCallHandler) :
-      GenericEchoService<String>, OutboundService {
+      GenericEchoService<String>,
+      OutboundService {
 
-      override fun genericEcho(request: String): List<String> {
-        return callHandler.call(this, 0, request) as List<String>
-      }
+      override fun genericEcho(request: String): List<String> = callHandler.call(this, 0, request) as List<String>
     }
   }
 
@@ -203,23 +187,18 @@ object ZiplineTestInternals {
           listOf(requestSerializer),
           responseSerializer,
         ) {
-          override fun call(service: EchoZiplineService, args: List<*>): Any {
-            return service.echo(args[0] as EchoRequest)
-          }
+          override fun call(service: EchoZiplineService, args: List<*>): Any = service.echo(args[0] as EchoRequest)
         },
       )
     }
 
-    override fun outboundService(callHandler: OutboundCallHandler): EchoZiplineService {
-      return GeneratedOutboundService(callHandler)
-    }
+    override fun outboundService(callHandler: OutboundCallHandler): EchoZiplineService = GeneratedOutboundService(callHandler)
 
     private class GeneratedOutboundService(override val callHandler: OutboundCallHandler) :
-      EchoZiplineService, OutboundService {
+      EchoZiplineService,
+      OutboundService {
 
-      override fun echo(request: EchoRequest): EchoResponse {
-        return callHandler.call(this, 0, request) as EchoResponse
-      }
+      override fun echo(request: EchoRequest): EchoResponse = callHandler.call(this, 0, request) as EchoResponse
     }
   }
 }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/adaptersJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/adaptersJs.kt
@@ -18,9 +18,7 @@ package app.cash.zipline.testing
 import app.cash.zipline.Zipline
 
 class JsAdaptersService : AdaptersService {
-  override fun echo(request: AdaptersRequest): AdaptersResponse {
-    return AdaptersResponse("thank you for using your serializers, ${request.message}")
-  }
+  override fun echo(request: AdaptersRequest): AdaptersResponse = AdaptersResponse("thank you for using your serializers, ${request.message}")
 }
 
 private val zipline by lazy { Zipline.get(AdaptersSerializersModule) }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/console.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/console.kt
@@ -54,6 +54,4 @@ private fun goBoom2(): Nothing {
   goBoom1()
 }
 
-private fun goBoom1(): Nothing {
-  throw IllegalStateException("boom!")
-}
+private fun goBoom1(): Nothing = throw IllegalStateException("boom!")

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/echoJs.kt
@@ -22,9 +22,7 @@ import app.cash.zipline.sourceType
 class JsEchoService(
   private val greeting: String,
 ) : EchoService {
-  override fun echo(request: EchoRequest): EchoResponse {
-    return EchoResponse("$greeting from JavaScript, ${request.message}")
-  }
+  override fun echo(request: EchoRequest): EchoResponse = EchoResponse("$greeting from JavaScript, ${request.message}")
 }
 
 private val zipline by lazy { Zipline.get() }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/encodingJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/encodingJs.kt
@@ -18,9 +18,7 @@ package app.cash.zipline.testing
 import app.cash.zipline.Zipline
 
 class JsEncodingService : EncodingService {
-  override fun echoLong(request: Long): Long {
-    return request
-  }
+  override fun echoLong(request: Long): Long = request
 }
 
 private val zipline by lazy { Zipline.get() }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/incompatibleService.kt
@@ -8,9 +8,7 @@ import kotlinx.coroutines.launch
 class JsSuspendingPotatoService(
   private val greeting: String,
 ) : SuspendingPotatoService {
-  override suspend fun echo(): EchoResponse {
-    return EchoResponse("$greeting from suspending JavaScript, anonymous")
-  }
+  override suspend fun echo(): EchoResponse = EchoResponse("$greeting from suspending JavaScript, anonymous")
 }
 
 private val zipline by lazy { Zipline.get() }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/interfaceSerializersJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/interfaceSerializersJs.kt
@@ -17,12 +17,12 @@ package app.cash.zipline.testing
 
 import app.cash.zipline.Zipline
 
-class JsMessageInterfaceService : RequestInterfaceService, ResponseInterfaceService {
-  override fun echo(request: MessageInterface) =
-    "JS received an interface, ${request.message}"
+class JsMessageInterfaceService :
+  RequestInterfaceService,
+  ResponseInterfaceService {
+  override fun echo(request: MessageInterface) = "JS received an interface, ${request.message}"
 
-  override fun echo(request: String) =
-    RealMessageInterface("JS returned an interface, $request")
+  override fun echo(request: String) = RealMessageInterface("JS returned an interface, $request")
 }
 
 private val zipline by lazy { Zipline.get(MessageInterfaceSerializersModule) }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/sealedClassSerializersJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/sealedClassSerializersJs.kt
@@ -22,12 +22,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class JsSealedClassMessageService : SealedClassMessageService {
-  override fun colorSwap(request: SealedMessage): SealedMessage {
-    return when (request) {
+  override fun colorSwap(request: SealedMessage): SealedMessage = when (request) {
       is BlueMessage -> RedMessage(request.message)
       is RedMessage -> BlueMessage(request.message)
     }
-  }
 
   override fun colorSwapFlow(flow: Flow<SealedMessage>) = flow.map(::colorSwap)
 }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/throwingJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/throwingJs.kt
@@ -27,26 +27,16 @@ class JsThrowingEchoService : EchoService {
   private fun goBoom2(): Nothing {
     goBoom1()
   }
-  private fun goBoom1(): Nothing {
-    throw IllegalStateException("boom!")
-  }
+  private fun goBoom1(): Nothing = throw IllegalStateException("boom!")
 }
 
 class JsDelegatingEchoService(
   private val delegate: EchoService,
 ) : EchoService {
-  override fun echo(request: EchoRequest): EchoResponse {
-    return delegate3(request)
-  }
-  private fun delegate3(request: EchoRequest): EchoResponse {
-    return delegate2(request)
-  }
-  private fun delegate2(request: EchoRequest): EchoResponse {
-    return delegate1(request)
-  }
-  private fun delegate1(request: EchoRequest): EchoResponse {
-    return delegate.echo(request)
-  }
+  override fun echo(request: EchoRequest): EchoResponse = delegate3(request)
+  private fun delegate3(request: EchoRequest): EchoResponse = delegate2(request)
+  private fun delegate2(request: EchoRequest): EchoResponse = delegate1(request)
+  private fun delegate1(request: EchoRequest): EchoResponse = delegate.echo(request)
 }
 
 private val zipline by lazy { Zipline.get() }

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/utf8Js.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/utf8Js.kt
@@ -24,9 +24,7 @@ fun prepareNonAsciiInputAndOutput() {
   zipline.bind<Formatter>(
     "formatter",
     object : Formatter {
-    override fun format(message: String): String {
-      return "($message, $message)"
-    }
+    override fun format(message: String): String = "($message, $message)"
   },
   )
 }
@@ -36,9 +34,7 @@ fun prepareNonAsciiThrower() {
   zipline.bind<Formatter>(
     "formatter",
     object : Formatter {
-    override fun format(message: String): String {
-      throw Exception("a🐝cdefg")
-    }
+    override fun format(message: String): String = throw Exception("a🐝cdefg")
   },
   )
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/GuestService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/GuestService.kt
@@ -20,7 +20,9 @@ import app.cash.zipline.ZiplineService
 /**
  * Guest functions for use by host code.
  */
-internal interface GuestService : EndpointService, ZiplineService {
+internal interface GuestService :
+  EndpointService,
+  ZiplineService {
   /** Run the job enqueued by [HostService.setTimeout]. */
   fun runJob(timeoutId: Int)
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/HostService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/HostService.kt
@@ -23,7 +23,9 @@ import app.cash.zipline.ZiplineService
  * Unlike typical interfaces that collect functions that share a purpose, this interface collects
  * functions that share a common implementation mechanism: the host platform.
  */
-internal interface HostService : EndpointService, ZiplineService {
+internal interface HostService :
+  EndpointService,
+  ZiplineService {
   fun setTimeout(timeoutId: Int, delayMillis: Int)
 
   fun clearTimeout(timeoutId: Int)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/Endpoint.kt
@@ -110,9 +110,7 @@ internal class Endpoint internal constructor(
       }
     }
 
-    override fun disconnect(instanceName: String): Boolean {
-      return remove(instanceName) != null
-    }
+    override fun disconnect(instanceName: String): Boolean = remove(instanceName) != null
   }
 
   private val serviceTypeCache = mutableMapOf<String, RealZiplineServiceType<*>>()
@@ -187,13 +185,9 @@ internal class Endpoint internal constructor(
   }
 
   @PublishedApi
-  internal fun remove(name: String): InboundService<*>? {
-    return inboundServices.remove(name)
-  }
+  internal fun remove(name: String): InboundService<*>? = inboundServices.remove(name)
 
-  internal fun generatePassByReferenceName(): String {
-    return "$passByReferencePrefix${nextId++}"
-  }
+  internal fun generatePassByReferenceName(): String = "$passByReferencePrefix${nextId++}"
 
   override fun serviceType(name: String): SerializableZiplineServiceType? {
     val type = inboundServices[name]?.type ?: return null
@@ -226,9 +220,7 @@ internal class Endpoint internal constructor(
     open fun serviceLeaked(name: String) {
     }
 
-    open fun callStart(call: Call): Any? {
-      return null
-    }
+    open fun callStart(call: Call): Any? = null
 
     open fun callEnd(call: Call, result: CallResult, startValue: Any?) {
     }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -45,8 +45,7 @@ internal class OutboundCallHandler(
    * Returns a copy of this call handler that targets the same service, but that applies [scope] to
    * outbound services produced by this service.
    */
-  fun withScope(scope: ZiplineScope): OutboundCallHandler {
-    return OutboundCallHandler(
+  fun withScope(scope: ZiplineScope): OutboundCallHandler = OutboundCallHandler(
       sourceType,
       serviceName,
       endpoint,
@@ -54,16 +53,13 @@ internal class OutboundCallHandler(
       scope,
       serviceState,
     )
-  }
 
   /** Returns the type of this service as reported by the opposite endpoint. */
   val targetType: SerializableZiplineServiceType?
     get() = endpoint.opposite.serviceType(serviceName)
 
   /** Returns a new service that uses this to send calls. */
-  fun <T : ZiplineService> outboundService(): T {
-    return adapter.outboundService(this) as T
-  }
+  fun <T : ZiplineService> outboundService(): T = adapter.outboundService(this) as T
 
   /** Used by generated code to call a function. */
   fun call(
@@ -226,7 +222,9 @@ internal class OutboundCallHandler(
   }
 
   private inner class RealSuspendCallback<R> :
-    SuspendCallback<R>, HasPassByReferenceName, ZiplineScoped {
+    SuspendCallback<R>,
+    HasPassByReferenceName,
+    ZiplineScoped {
     lateinit var internalCall: InternalCall
     lateinit var externalCall: Call
     lateinit var continuation: Continuation<R>

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -57,8 +57,7 @@ internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<
     return reference.take(this)
   }
 
-  override fun equals(other: Any?) =
-    other is ZiplineServiceAdapter<*> &&
+  override fun equals(other: Any?) = other is ZiplineServiceAdapter<*> &&
     this::class == other::class &&
     serializers == other.serializers
 
@@ -75,26 +74,21 @@ internal fun <T : ZiplineService> ziplineServiceAdapter(): ZiplineServiceAdapter
 @PublishedApi
 internal fun <T : ZiplineService> ziplineServiceAdapter(
   ziplineServiceAdapter: ZiplineServiceAdapter<T>,
-): ZiplineServiceAdapter<T> {
-  return ziplineServiceAdapter
-}
+): ZiplineServiceAdapter<T> = ziplineServiceAdapter
 
 /**
  * Returns a string like `kotlinx.coroutines.Flow<kotlin.String>`. This can be used as a unique
  * key to identify a serializer for [typeName] that has [serializers] for its type arguments.
  */
 @PublishedApi
-internal fun serialName(typeName: String, serializers: List<KSerializer<*>>): String {
-  return buildString {
+internal fun serialName(typeName: String, serializers: List<KSerializer<*>>): String = buildString {
     append(typeName)
     serializers.joinTo(this, separator = ",", prefix = "<", postfix = ">") {
       descriptorName(it.descriptor)
     }
   }
-}
 
-private fun descriptorName(typeName: SerialDescriptor): String {
-  return buildString {
+private fun descriptorName(typeName: SerialDescriptor): String = buildString {
     append(typeName.serialName)
 
     if (typeName.elementsCount > 0) {
@@ -111,4 +105,3 @@ private fun descriptorName(typeName: SerialDescriptor): String {
       append('>')
     }
   }
-}

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
@@ -60,8 +60,7 @@ internal class InternalCall(
 
   val args: List<*>,
 ) {
-  override fun toString() =
-    "Call(receiver=$serviceName, function=${function.signature}, args=$args)"
+  override fun toString() = "Call(receiver=$serviceName, function=${function.signature}, args=$args)"
 }
 
 /** This uses [Int] as a placeholder; in practice the element type depends on the argument type. */
@@ -183,8 +182,7 @@ internal class RealCallSerializer(
   }
 
   /** Returns a fake service that implements no functions. */
-  private fun unknownService(): InboundService<*> {
-    return InboundService(
+  private fun unknownService(): InboundService<*> = InboundService(
       type = RealZiplineServiceType<ZiplineService>(
         name = "Unknown",
         functions = listOf(),
@@ -192,7 +190,6 @@ internal class RealCallSerializer(
       service = object : ZiplineService {},
       endpoint = endpoint,
     )
-  }
 
   /** Returns a function that always throws [ZiplineApiMismatchException] when called. */
   private fun <T : ZiplineService> unknownFunction(
@@ -209,8 +206,7 @@ internal class RealCallSerializer(
         resultSerializer = Int.serializer(),
         suspendCallbackSerializer = failureSuspendCallbackSerializer,
       ) {
-        override suspend fun callSuspending(service: T, args: List<*>) =
-          throw ZiplineApiMismatchException(message)
+        override suspend fun callSuspending(service: T, args: List<*>) = throw ZiplineApiMismatchException(message)
       }
     } else {
       return object : ReturningZiplineFunction<T>(
@@ -220,8 +216,7 @@ internal class RealCallSerializer(
         // Placeholder; we're only encoding failures.
         resultSerializer = Int.serializer(),
       ) {
-        override fun call(service: T, args: List<*>) =
-          throw ZiplineApiMismatchException(message)
+        override fun call(service: T, args: List<*>) = throw ZiplineApiMismatchException(message)
       }
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
@@ -57,8 +57,7 @@ internal class FlowSerializer<T>(
     return encoder.encodeSerializableValue(delegateSerializer, service)
   }
 
-  private fun Flow<T>.toZiplineService(): FlowZiplineService<T> {
-    return object : FlowZiplineService<T> {
+  private fun Flow<T>.toZiplineService(): FlowZiplineService<T> = object : FlowZiplineService<T> {
       override suspend fun collect(collector: FlowZiplineCollector<T>) {
         try {
           this@toZiplineService.collect(collector::emit)
@@ -69,25 +68,21 @@ internal class FlowSerializer<T>(
 
       override fun toString() = this@toZiplineService.toString()
     }
-  }
 
   override fun deserialize(decoder: Decoder): Flow<T> {
     val service = decoder.decodeSerializableValue(delegateSerializer)
     return service.toFlow()
   }
 
-  private fun FlowZiplineService<T>.toFlow(): Flow<T> {
-    return channelFlow {
+  private fun FlowZiplineService<T>.toFlow(): Flow<T> = channelFlow {
       this@toFlow.collect(object : FlowZiplineCollector<T> {
         override suspend fun emit(value: T) {
           this@channelFlow.send(value)
         }
       })
     }
-  }
 
-  override fun equals(other: Any?) =
-    other is FlowSerializer<*> && other.delegateSerializer == delegateSerializer
+  override fun equals(other: Any?) = other is FlowSerializer<*> && other.delegateSerializer == delegateSerializer
 
   override fun hashCode() = delegateSerializer.hashCode()
 }
@@ -108,8 +103,7 @@ internal class StateFlowSerializer<T>(
     return encoder.encodeSerializableValue(delegateSerializer, service)
   }
 
-  private fun StateFlow<T>.toZiplineService(): StateFlowZiplineService<T> {
-    return object : StateFlowZiplineService<T> {
+  private fun StateFlow<T>.toZiplineService(): StateFlowZiplineService<T> = object : StateFlowZiplineService<T> {
       override suspend fun collect(collector: FlowZiplineCollector<T>) {
         try {
           this@toZiplineService.collect(collector::emit)
@@ -122,15 +116,13 @@ internal class StateFlowSerializer<T>(
 
       override fun toString() = this@toZiplineService.toString()
     }
-  }
 
   override fun deserialize(decoder: Decoder): StateFlow<T> {
     val service = decoder.decodeSerializableValue(delegateSerializer)
     return service.toStateFlow()
   }
 
-  private fun StateFlowZiplineService<T>.toStateFlow(): StateFlow<T> {
-    return object : StateFlow<T> {
+  private fun StateFlowZiplineService<T>.toStateFlow(): StateFlow<T> = object : StateFlow<T> {
       override suspend fun collect(collector: FlowCollector<T>): Nothing {
         channelFlow {
           this@toStateFlow.collect(object : FlowZiplineCollector<T> {
@@ -146,10 +138,8 @@ internal class StateFlowSerializer<T>(
 
       override val replayCache: List<T> get() = listOf(value)
     }
-  }
 
-  override fun equals(other: Any?) =
-    other is StateFlowSerializer<*> && other.delegateSerializer == delegateSerializer
+  override fun equals(other: Any?) = other is StateFlowSerializer<*> && other.delegateSerializer == delegateSerializer
 
   override fun hashCode() = delegateSerializer.hashCode()
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/longs.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/longs.kt
@@ -35,12 +35,10 @@ internal object LongSerializer : KSerializer<Long> {
     PrimitiveKind.LONG,
   )
 
-  override fun deserialize(decoder: Decoder): Long {
-    return when (val jsonElement = (decoder as JsonDecoder).decodeJsonElement()) {
+  override fun deserialize(decoder: Decoder): Long = when (val jsonElement = (decoder as JsonDecoder).decodeJsonElement()) {
       is JsonArray, is JsonObject, JsonNull -> throw SerializationException("expected a Long")
       is JsonPrimitive -> jsonElement.long
     }
-  }
 
   override fun serialize(encoder: Encoder, value: Long) {
     if (value in MIN_SAFE_INTEGER..MAX_SAFE_INTEGER) {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/throwables.kt
@@ -117,17 +117,13 @@ internal object ThrowableSerializer : KSerializer<Throwable> {
     return toInboundThrowable(stacktraceString, constructor)
   }
 
-  private fun knownTypeNames(throwable: Throwable): List<String> {
-    return when (throwable) {
+  private fun knownTypeNames(throwable: Throwable): List<String> = when (throwable) {
       is ZiplineApiMismatchException -> listOf("ZiplineApiMismatchException")
       else -> listOf()
     }
-  }
 
-  private fun knownTypeConstructor(typeName: String): ((String) -> Throwable)? {
-    return when (typeName) {
+  private fun knownTypeConstructor(typeName: String): ((String) -> Throwable)? = when (typeName) {
       "ZiplineApiMismatchException" -> ::ZiplineApiMismatchException
       else -> null
     }
-  }
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/serializers.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/serializers.kt
@@ -72,6 +72,4 @@ fun <T : ZiplineService> ziplineServiceSerializer(
 @PublishedApi
 internal fun <T : ZiplineService> ziplineServiceSerializer(
   ziplineServiceAdapter: ZiplineServiceAdapter<T>,
-): KSerializer<T> {
-  return ziplineServiceAdapter
-}
+): KSerializer<T> = ziplineServiceAdapter

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/EventListener.kt
@@ -38,9 +38,7 @@ abstract class EventListener {
    * @return any object. This value will be passed back to [callEnd] when the call is completed. The
    *   base function always returns null.
    */
-  open fun callStart(zipline: Zipline, call: Call): Any? {
-    return null
-  }
+  open fun callStart(zipline: Zipline, call: Call): Any? = null
 
   /**
    * Invoked when a service function call completes.
@@ -68,9 +66,7 @@ abstract class EventListener {
   open fun applicationLoadStart(
     applicationName: String,
     manifestUrl: String?,
-  ): Any? {
-    return null
-  }
+  ): Any? = null
 
   /**
    * Invoked when an application load was skipped because the code is unchanged.
@@ -131,9 +127,7 @@ abstract class EventListener {
   open fun downloadStart(
     applicationName: String,
     url: String,
-  ): Any? {
-    return null
-  }
+  ): Any? = null
 
   /**
    * Invoked when a network download succeeds.
@@ -210,9 +204,7 @@ abstract class EventListener {
    * @return any object. This value will be passed back to [moduleLoadEnd] when the call is
    *   completed. The base function always returns null.
    */
-  open fun moduleLoadStart(zipline: Zipline, moduleId: String): Any? {
-    return null
-  }
+  open fun moduleLoadStart(zipline: Zipline, moduleId: String): Any? = null
 
   /**
    * Invoked when a module load completes.
@@ -226,9 +218,7 @@ abstract class EventListener {
   /**
    * Initializer runs before the mainFunction and executes on the host platform.
    */
-  open fun initializerStart(zipline: Zipline, applicationName: String): Any? {
-    return null
-  }
+  open fun initializerStart(zipline: Zipline, applicationName: String): Any? = null
 
   /**
    * Invoked when initializer is finished. Failure is not recorded separately as it is unrecoverable.
@@ -239,9 +229,7 @@ abstract class EventListener {
   /**
    * Invoked when mainFunction is run within the JS platform to start an application.
    */
-  open fun mainFunctionStart(zipline: Zipline, applicationName: String): Any? {
-    return null
-  }
+  open fun mainFunctionStart(zipline: Zipline, applicationName: String): Any? = null
 
   /**
    * Invoked when mainFunction is finished. Failure is not recorded separately as it is unrecoverable.

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/Zipline.kt
@@ -65,9 +65,7 @@ actual class Zipline private constructor(
         return jsInboundBridge.call(callJson)
       }
 
-      override fun disconnect(instanceName: String): Boolean {
-        return jsInboundBridge.disconnect(instanceName)
-      }
+      override fun disconnect(instanceName: String): Boolean = jsInboundBridge.disconnect(instanceName)
     },
     oppositeProvider = {
       guest

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/ZiplineManifest.kt
@@ -215,8 +215,7 @@ data class ZiplineManifest private constructor(
       version: String? = null,
       builtAtEpochMs: Long? = null,
       baseUrl: String? = null,
-    ): ZiplineManifest {
-      return create(
+    ): ZiplineManifest = create(
         modules = modules,
         mainFunction = mainFunction,
         mainModuleId = mainModuleId,
@@ -225,7 +224,6 @@ data class ZiplineManifest private constructor(
         baseUrl = baseUrl,
         metadata = mapOf(),
       )
-    }
 
     fun create(
       modules: Map<String, Module>,

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/EventListenerAdapter.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/EventListenerAdapter.kt
@@ -39,9 +39,7 @@ internal class EventListenerAdapter(
     delegate.serviceLeaked(zipline, name)
   }
 
-  override fun callStart(call: Call): Any? {
-    return delegate.callStart(zipline, call)
-  }
+  override fun callStart(call: Call): Any? = delegate.callStart(zipline, call)
 
   override fun callEnd(call: Call, result: CallResult, startValue: Any?) {
     delegate.callEnd(zipline, call, result, startValue)

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
@@ -18,8 +18,6 @@ package app.cash.zipline.internal
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
-internal actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T =
-  decodeFromString(deserializer, string)
+internal actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T = decodeFromString(deserializer, string)
 
-internal actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String =
-  encodeToString(serializer, value)
+internal actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String = encodeToString(serializer, value)

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/quickJsExtensions.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/quickJsExtensions.kt
@@ -14,9 +14,7 @@ internal fun getModuleDependencies(quickJs: QuickJs): List<String> {
   return Json.decodeFromString(dependenciesString)
 }
 
-internal fun QuickJs.getGlobalThis(key: String): String? {
-  return evaluate("globalThis.$key", "getGlobalThis.js") as String?
-}
+internal fun QuickJs.getGlobalThis(key: String): String? = evaluate("globalThis.$key", "getGlobalThis.js") as String?
 
 internal fun getLog(quickJs: QuickJs): String? = quickJs.getGlobalThis("log")
 

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/serializers.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/serializers.kt
@@ -35,9 +35,7 @@ internal object ByteStringAsHexSerializer : KSerializer<ByteString> {
     encoder.encodeString(value.hex())
   }
 
-  override fun deserialize(decoder: Decoder): ByteString {
-    return decoder.decodeString().decodeHex()
-  }
+  override fun deserialize(decoder: Decoder): ByteString = decoder.decodeString().decodeHex()
 }
 
 internal val jsonForManifest = Json {

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -139,9 +139,7 @@ internal class EndpointTest {
     val (endpointA, endpointB) = newEndpointPair(this)
 
     val service = object : EchoService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        throw IllegalStateException("boom!")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = throw IllegalStateException("boom!")
     }
 
     endpointA.bind<EchoService>("helloService", service)
@@ -158,9 +156,7 @@ internal class EndpointTest {
     val (endpointA, endpointB) = newEndpointPair(this)
 
     val service = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        throw IllegalStateException("boom!")
-      }
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = throw IllegalStateException("boom!")
     }
 
     endpointA.bind<SuspendingEchoService>("helloService", service)
@@ -206,15 +202,13 @@ internal class EndpointTest {
     val requests = Channel<String>(1)
     val cancels = Channel<Throwable?>(1)
     val service = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return suspendCancellableCoroutine { continuation ->
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = suspendCancellableCoroutine { continuation ->
           continuation.invokeOnCancellation { throwable ->
             cancels.trySend(throwable)
           }
           requests.trySend(request.message)
           // This continuation never resumes normally!
         }
-      }
     }
 
     endpointA.bind<SuspendingEchoService>("helloService", service)
@@ -236,15 +230,13 @@ internal class EndpointTest {
     val requests = Channel<String>(1)
     val cancels = Channel<Throwable?>(1)
     val service = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return suspendCancellableCoroutine { continuation ->
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = suspendCancellableCoroutine { continuation ->
           continuation.invokeOnCancellation { throwable ->
             cancels.trySend(throwable)
           }
           requests.trySend(request.message)
           // This continuation never resumes normally!
         }
-      }
     }
 
     endpointA.bind<SuspendingEchoService>("helloService", service)
@@ -293,17 +285,13 @@ internal class EndpointTest {
     val (endpointA, endpointB) = newEndpointPair(this, kotlinBuiltInSerializersModule)
 
     val stringService = object : GenericEchoService<String> {
-      override fun genericEcho(request: String): List<String> {
-        return listOf("x", request)
-      }
+      override fun genericEcho(request: String): List<String> = listOf("x", request)
     }
     endpointA.bind<GenericEchoService<String>>("strings", stringService)
     val stringClient = endpointB.take<GenericEchoService<String>>("strings")
 
     val mapsService = object : GenericEchoService<Map<String, Int>> {
-      override fun genericEcho(request: Map<String, Int>): List<Map<String, Int>> {
-        return listOf(mapOf(), request)
-      }
+      override fun genericEcho(request: Map<String, Int>): List<Map<String, Int>> = listOf(mapOf(), request)
     }
     endpointA.bind<GenericEchoService<Map<String, Int>>>("maps", mapsService)
     val mapsClient = endpointB.take<GenericEchoService<Map<String, Int>>>("maps")
@@ -325,14 +313,12 @@ internal class EndpointTest {
     val channel = Channel<String>(1)
 
     val service = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return suspendCancellableCoroutine {
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = suspendCancellableCoroutine {
           it.invokeOnCancellation {
             channel.trySend("Canceled on $dispatcher")
           }
           channel.trySend("Invoked on $dispatcher")
         }
-      }
     }
 
     endpointA.bind<SuspendingEchoService>("helloService", service)
@@ -528,9 +514,7 @@ internal class EndpointTest {
     val (endpointA, endpointB) = newEndpointPair(this)
 
     val service = object : EchoService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        throw ZiplineApiMismatchException("boom!")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = throw ZiplineApiMismatchException("boom!")
     }
     endpointA.bind<EchoService>("service", service)
     val client = endpointB.take<EchoService>("service")
@@ -541,7 +525,9 @@ internal class EndpointTest {
     assertTrue("boom!" in e.message)
   }
 
-  interface ExtendsEchoService : ZiplineService, ExtendableInterface
+  interface ExtendsEchoService :
+    ZiplineService,
+    ExtendableInterface
 
   interface ExtendableInterface {
     fun echo(request: EchoRequest): EchoResponse

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/EventListenerEndpointTest.kt
@@ -56,9 +56,7 @@ internal class EventListenerEndpointTest {
     )
 
     val service = object : EchoService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        return EchoResponse("pong")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = EchoResponse("pong")
     }
 
     serviceEndpoint.bind<EchoService>("echoService", service)
@@ -357,25 +355,19 @@ internal class EventListenerEndpointTest {
     )
 
     val service = object : EchoTransformer {
-      override fun transform(prefix: String, service: EchoService): EchoService {
-        return object : EchoService {
-          override fun echo(request: EchoRequest): EchoResponse {
-            return EchoResponse("$prefix ${request.message}")
-          }
+      override fun transform(prefix: String, service: EchoService): EchoService = object : EchoService {
+          override fun echo(request: EchoRequest): EchoResponse = EchoResponse("$prefix ${request.message}")
 
           override fun close() {
             service.close()
           }
         }
-      }
     }
 
     serviceEndpoint.bind<EchoTransformer>("echoTransformer", service)
     val client = clientEndpoint.take<EchoTransformer>("echoTransformer")
     val serviceArgument = object : EchoService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        return EchoResponse("pong")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = EchoResponse("pong")
     }
     val transformedService = client.transform("hello", serviceArgument)
 

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ExceptionsTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ExceptionsTest.kt
@@ -114,8 +114,6 @@ class ExceptionsTest {
     private fun goBoom2(): Nothing {
       goBoom1()
     }
-    private fun goBoom1(): Nothing {
-      throw IllegalStateException("boom!")
-    }
+    private fun goBoom1(): Nothing = throw IllegalStateException("boom!")
   }
 }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/FlowTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/FlowTest.kt
@@ -43,21 +43,19 @@ internal class FlowTest {
     suspend fun flowParameter(flow: Flow<String>): Int
   }
 
-  class RealFlowEchoService : FlowEchoService, ZiplineScoped {
+  class RealFlowEchoService :
+    FlowEchoService,
+    ZiplineScoped {
     override val scope = ZiplineScope()
 
-    override fun createFlow(message: String, count: Int): Flow<String> {
-      return flow {
+    override fun createFlow(message: String, count: Int): Flow<String> = flow {
         for (i in 0 until count) {
           forceSuspend() // Ensure we can send async through the reference.
           emit("$i $message")
         }
       }
-    }
 
-    override suspend fun flowParameter(flow: Flow<String>): Int {
-      return flow.count()
-    }
+    override suspend fun flowParameter(flow: Flow<String>): Int = flow.count()
 
     override fun close() {
       scope.close()
@@ -123,9 +121,7 @@ internal class FlowTest {
 
     val (endpointA, endpointB) = newEndpointPair(this)
     val service = object : FlowEchoService {
-      override fun createFlow(message: String, count: Int): Flow<String> {
-        return channel.consumeAsFlow()
-      }
+      override fun createFlow(message: String, count: Int): Flow<String> = channel.consumeAsFlow()
 
       override suspend fun flowParameter(flow: Flow<String>): Int = error("unexpected call")
     }
@@ -167,9 +163,7 @@ internal class FlowTest {
 
     val (endpointA, endpointB) = newEndpointPair(this)
     val service = object : FlowEchoService {
-      override fun createFlow(message: String, count: Int): Flow<String> {
-        return channel.consumeAsFlow()
-      }
+      override fun createFlow(message: String, count: Int): Flow<String> = channel.consumeAsFlow()
 
       override suspend fun flowParameter(flow: Flow<String>): Int = error("unexpected call")
     }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ManualCallEncodingTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ManualCallEncodingTest.kt
@@ -117,9 +117,7 @@ internal class ManualCallEncodingTest {
     val (endpointA, endpointB) = newEndpointPair(this)
 
     val service = object : ReceiveService {
-      override fun receive(): MessageWithDefaults {
-        return MessageWithDefaults()
-      }
+      override fun receive(): MessageWithDefaults = MessageWithDefaults()
     }
     endpointA.bind<ReceiveService>("service", service)
 

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/QuickJsInterruptTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/QuickJsInterruptTest.kt
@@ -68,9 +68,7 @@ class QuickJsInterruptTest {
 
   @Test fun interruptionReturnsTrueToTerminateWork() {
     quickJs.interruptHandler = object : InterruptHandler {
-      override fun poll(): Boolean {
-        return true
-      }
+      override fun poll(): Boolean = true
     }
 
     val e = assertFailsWith<QuickJsException> {

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/SampleService.kt
@@ -49,12 +49,10 @@ interface SampleService<T> : ZiplineService {
 
   companion object {
     /** This function's body is what callers use to create a properly-typed adapter. */
-    internal inline fun <reified T> manualAdapter(): ManualAdapter<T> {
-      return ManualAdapter<T>(
+    internal inline fun <reified T> manualAdapter(): ManualAdapter<T> = ManualAdapter<T>(
         listOf(serializer<T>()),
         typeOf<ManualAdapter<T>>().toString(),
       )
-    }
 
     /**
      * We expect this manually-written adapter to be consistent with the generated one. This exists
@@ -76,8 +74,7 @@ interface SampleService<T> : ZiplineService {
         argSerializers = argSerializers,
         resultSerializer = resultSerializer,
       ) {
-        override fun call(service: SampleService<TF>, args: List<*>): Any? =
-          service.ping(args[0] as SampleRequest)
+        override fun call(service: SampleService<TF>, args: List<*>): Any? = service.ping(args[0] as SampleRequest)
       }
 
       class ZiplineFunction1<TF>(
@@ -91,8 +88,7 @@ interface SampleService<T> : ZiplineService {
         resultSerializer = resultSerializer,
         suspendCallbackSerializer = suspendCallbackSerializer,
       ) {
-        override suspend fun callSuspending(service: SampleService<TF>, args: List<*>) =
-          service.reduce(args[0] as List<TF>)
+        override suspend fun callSuspending(service: SampleService<TF>, args: List<*>) = service.reduce(args[0] as List<TF>)
       }
 
       class ZiplineFunction2<TF>(
@@ -135,7 +131,8 @@ interface SampleService<T> : ZiplineService {
 
       private class GeneratedOutboundService<TS>(
         override val callHandler: OutboundCallHandler,
-      ) : SampleService<TS>, OutboundService {
+      ) : SampleService<TS>,
+        OutboundService {
         override fun ping(request: SampleRequest): SampleResponse {
           val callHandler = callHandler
           return callHandler.call(this, 0, request) as SampleResponse

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/SerializersTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/SerializersTest.kt
@@ -105,8 +105,6 @@ class SerializersTest {
   }
 
   private class HostAdaptersService : AdaptersService {
-    override fun echo(request: AdaptersRequest): AdaptersResponse {
-      return AdaptersResponse("nice adapters, ${request.message}")
-    }
+    override fun echo(request: AdaptersRequest): AdaptersResponse = AdaptersResponse("nice adapters, ${request.message}")
   }
 }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/StateFlowTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/StateFlowTest.kt
@@ -40,29 +40,25 @@ internal class StateFlowTest {
     suspend fun take(flow: StateFlow<String>, count: Int): List<String>
   }
 
-  class RealStateFlowEchoService(initialValue: String = "") : StateFlowEchoService, ZiplineScoped {
+  class RealStateFlowEchoService(initialValue: String = "") :
+    StateFlowEchoService,
+    ZiplineScoped {
     override val scope = ZiplineScope()
     val mutableFlow = MutableStateFlow(initialValue)
     override val flow: StateFlow<String> get() = mutableFlow
 
-    override suspend fun createFlow(initialValue: String): StateFlow<String> {
-      return MutableStateFlow(initialValue)
-    }
+    override suspend fun createFlow(initialValue: String): StateFlow<String> = MutableStateFlow(initialValue)
 
     lateinit var coroutineScope: CoroutineScope
 
-    override suspend fun createFlow(initialValue: String, values: List<String>): StateFlow<String> {
-      return flow {
+    override suspend fun createFlow(initialValue: String, values: List<String>): StateFlow<String> = flow {
         for (value in values) {
           forceSuspend()
           emit(value)
         }
       }.stateIn(coroutineScope, SharingStarted.Lazily, initialValue)
-    }
 
-    override suspend fun take(flow: StateFlow<String>, count: Int): List<String> {
-      return flow.take(count).toList()
-    }
+    override suspend fun take(flow: StateFlow<String>, count: Int): List<String> = flow.take(count).toList()
 
     override fun close() {
       scope.close()

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/Utf8Test.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/Utf8Test.kt
@@ -92,9 +92,7 @@ class Utf8Test {
     zipline.bind<Formatter>(
       "formatter",
       object : Formatter {
-        override fun format(message: String): String {
-          return "($message, $message)"
-        }
+        override fun format(message: String): String = "($message, $message)"
       },
     )
     assertEquals(
@@ -118,9 +116,7 @@ class Utf8Test {
     zipline.bind<Formatter>(
       "formatter",
       object : Formatter {
-        override fun format(message: String): String {
-          throw RuntimeException("a\uD83D\uDC1Dcdefg")
-        }
+        override fun format(message: String): String = throw RuntimeException("a\uD83D\uDC1Dcdefg")
       },
     )
     val t = assertFailsWith<RuntimeException> {

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineCryptographyTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineCryptographyTest.kt
@@ -54,9 +54,7 @@ class ZiplineCryptographyTest {
   fun secureRandomWorks() = runBlocking(dispatcher) {
     if (isLinux) return@runBlocking
     val fakeZiplineCryptographyService = object : ZiplineCryptographyService {
-      override fun nextSecureRandomBytes(size: Int): ByteArray {
-        return ByteArray(size) { index -> (index + 1).toByte() }
-      }
+      override fun nextSecureRandomBytes(size: Int): ByteArray = ByteArray(size) { index -> (index + 1).toByte() }
     }
 
     zipline.installCryptographyServiceInternal(fakeZiplineCryptographyService)

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -163,15 +163,11 @@ internal class ZiplineServiceTest {
   }
 
   class GreetingService(val greeting: String) : EchoService {
-    override fun echo(request: EchoRequest): EchoResponse {
-      return EchoResponse("$greeting ${request.message}")
-    }
+    override fun echo(request: EchoRequest): EchoResponse = EchoResponse("$greeting ${request.message}")
   }
 
   class FactoryService : EchoServiceFactory {
-    override fun create(greeting: String): EchoService {
-      return GreetingService(greeting)
-    }
+    override fun create(greeting: String): EchoService = GreetingService(greeting)
   }
 
   @Serializable
@@ -185,8 +181,6 @@ internal class ZiplineServiceTest {
   }
 
   class RealGreetingAndEchoServiceFactory : GreetingAndEchoServiceFactory {
-    override fun create(greeting: String): GreetingAndEchoService {
-      return GreetingAndEchoService(greeting, GreetingService(greeting))
-    }
+    override fun create(greeting: String): GreetingAndEchoService = GreetingAndEchoService(greeting, GreetingService(greeting))
   }
 }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/internal/TopologicalSortTest.kt
@@ -137,9 +137,7 @@ class TopologicalSortTest {
   }
 
   /** Each string is two characters, source and destination of an edge. */
-  private fun edges(vararg edges: String): (String) -> List<String> {
-    return { node: String ->
+  private fun edges(vararg edges: String): (String) -> List<String> = { node: String ->
       edges.filter { it.startsWith(node) }.map { it.substring(1) }
     }
-  }
 }

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -21,8 +21,7 @@ internal class JniCallChannel(
   private val quickJs: QuickJs,
   private val instance: Long,
 ) : CallChannel {
-  override fun call(callJson: String) =
-    call(quickJs.context, instance, callJson)
+  override fun call(callJson: String) = call(quickJs.context, instance, callJson)
 
   private external fun call(
     context: Long,
@@ -30,8 +29,7 @@ internal class JniCallChannel(
     callJson: String,
   ): String
 
-  override fun disconnect(instanceName: String): Boolean =
-    disconnect(quickJs.context, instance, instanceName)
+  override fun disconnect(instanceName: String): Boolean = disconnect(quickJs.context, instance, instanceName)
 
   private external fun disconnect(
     context: Long,

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -30,7 +30,8 @@ import java.io.Closeable
 @EngineApi
 actual class QuickJs private constructor(
   internal var context: Long,
-) : AutoCloseable, Closeable {
+) : AutoCloseable,
+  Closeable {
   actual companion object {
     init {
       loadNativeLibrary()
@@ -135,18 +136,14 @@ actual class QuickJs private constructor(
    *
    * @throws QuickJsException if the sourceCode could not be compiled.
    */
-  actual fun compile(sourceCode: String, fileName: String): ByteArray {
-    return compile(context, sourceCode, fileName)
-  }
+  actual fun compile(sourceCode: String, fileName: String): ByteArray = compile(context, sourceCode, fileName)
 
   /**
    * Load and execute [bytecode] and return the result.
    *
    * @throws QuickJsException if there is an error loading or executing the code.
    */
-  actual fun execute(bytecode: ByteArray): Any? {
-    return execute(context, bytecode)
-  }
+  actual fun execute(bytecode: ByteArray): Any? = execute(context, bytecode)
 
   actual override fun close() {
     val contextToClose = context

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/EventListenerTest.kt
@@ -68,9 +68,7 @@ class EventListenerTest {
 
   @Test fun jsCallJvmService() = runTest(dispatcher) {
     val jvmEchoService = object : EchoService {
-      override fun echo(request: EchoRequest): EchoResponse {
-        return EchoResponse("sup from the JVM, ${request.message}")
-      }
+      override fun echo(request: EchoRequest): EchoResponse = EchoResponse("sup from the JVM, ${request.message}")
     }
     zipline.bind<EchoService>("supService", jvmEchoService)
 
@@ -103,9 +101,7 @@ class EventListenerTest {
 
   @Test fun suspendingJsCallJvmService() = runTest(dispatcher) {
     val jvmSuspendingEchoService = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return EchoResponse("hello from the suspending JVM, ${request.message}")
-      }
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = EchoResponse("hello from the suspending JVM, ${request.message}")
     }
 
     zipline.bind<SuspendingEchoService>(

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/InterfaceSerializersTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/InterfaceSerializersTest.kt
@@ -125,11 +125,11 @@ class InterfaceSerializersTest {
     )
   }
 
-  private class JvmMessageInterfaceService : RequestInterfaceService, ResponseInterfaceService {
-    override fun echo(request: MessageInterface) =
-      "JVM received an interface, ${request.message}"
+  private class JvmMessageInterfaceService :
+    RequestInterfaceService,
+    ResponseInterfaceService {
+    override fun echo(request: MessageInterface) = "JVM received an interface, ${request.message}"
 
-    override fun echo(request: String) =
-      RealMessageInterface("JVM returned an interface, $request")
+    override fun echo(request: String) = RealMessageInterface("JVM returned an interface, $request")
   }
 }

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/NewServicesTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/NewServicesTest.kt
@@ -411,18 +411,14 @@ class NewSerializersTest {
 
   private fun <T> suspendCallbackSerializer(
     resultSerializer: KSerializer<T>,
-  ): KSerializer<SuspendCallback<T>> {
-    return ziplineServiceSerializer(
+  ): KSerializer<SuspendCallback<T>> = ziplineServiceSerializer(
       SuspendCallback::class,
       listOf(resultSerializer),
     )
-  }
 
-  private fun <T> flowSerializer(elementSerializer: KSerializer<T>): KSerializer<Flow<T>> {
-    return FlowSerializer(
+  private fun <T> flowSerializer(elementSerializer: KSerializer<T>): KSerializer<Flow<T>> = FlowSerializer(
       ziplineServiceSerializer(FlowZiplineService::class, listOf(elementSerializer)),
     )
-  }
 
   private fun <T : ZiplineService> onlyZiplineFunction(
     serviceSerializer: KSerializer<T>,
@@ -445,9 +441,7 @@ class NewSerializersTest {
   object RequiresContextualSerializer : KSerializer<RequiresContextual> {
     override val descriptor = String.serializer().descriptor
 
-    override fun deserialize(decoder: Decoder): RequiresContextual {
-      return RequiresContextual(decoder.decodeString())
-    }
+    override fun deserialize(decoder: Decoder): RequiresContextual = RequiresContextual(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, value: RequiresContextual) {
       encoder.encodeString(value.string)

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -143,9 +143,7 @@ class ZiplineTest {
 
   @Test fun suspendingJsCallJvmService() = runTest(dispatcher) {
     val jvmSuspendingEchoService = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return EchoResponse("hello from the suspending JVM, ${request.message}")
-      }
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = EchoResponse("hello from the suspending JVM, ${request.message}")
     }
 
     zipline.bind<SuspendingEchoService>(
@@ -160,9 +158,7 @@ class ZiplineTest {
 
   @Test fun suspendingJsCallJvmServiceUsingDynamicFunction() = runTest(dispatcher) {
     val jvmSuspendingEchoService = object : SuspendingEchoService {
-      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
-        return EchoResponse("hello dynamic and suspending, ${request.message}")
-      }
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse = EchoResponse("hello dynamic and suspending, ${request.message}")
     }
 
     zipline.bind<SuspendingEchoService>(
@@ -497,14 +493,10 @@ class ZiplineTest {
   }
 
   private class JvmEchoService(private val greeting: String) : EchoService {
-    override fun echo(request: EchoRequest): EchoResponse {
-      return EchoResponse("$greeting from the JVM, ${request.message}")
-    }
+    override fun echo(request: EchoRequest): EchoResponse = EchoResponse("$greeting from the JVM, ${request.message}")
   }
 
   private class JvmPotatoService(private val greeting: String) : PotatoService {
-    override fun echo(): EchoResponse {
-      return EchoResponse("$greeting from the JVM, anonymous")
-    }
+    override fun echo(): EchoResponse = EchoResponse("$greeting from the JVM, anonymous")
   }
 }

--- a/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
+++ b/zipline/src/jsMain/kotlin/app/cash/zipline/ziplineJs.kt
@@ -47,13 +47,9 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
       private val jsOutboundChannel: CallChannel
         get() = js("globalThis.app_cash_zipline_outboundChannel")
 
-      override fun call(callJson: String): String {
-        return jsOutboundChannel.call(callJson)
-      }
+      override fun call(callJson: String): String = jsOutboundChannel.call(callJson)
 
-      override fun disconnect(instanceName: String): Boolean {
-        return jsOutboundChannel.disconnect(instanceName)
-      }
+      override fun disconnect(instanceName: String): Boolean = jsOutboundChannel.disconnect(instanceName)
     },
     oppositeProvider = {
       host
@@ -97,9 +93,7 @@ actual class Zipline internal constructor(userSerializersModule: SerializersModu
     name: String,
     scope: ZiplineScope = ZiplineScope(),
     adapter: ZiplineServiceAdapter<T>,
-  ): T {
-    return endpoint.take(name, scope, adapter)
-  }
+  ): T = endpoint.take(name, scope, adapter)
 
   actual fun <T : Any> getOrPutAttachment(key: KClass<T>, compute: () -> T): T {
     val value = attachments.getOrPut(key, compute)

--- a/zipline/src/jsTest/kotlin/app/cash/zipline/DynamicFunctionTest.kt
+++ b/zipline/src/jsTest/kotlin/app/cash/zipline/DynamicFunctionTest.kt
@@ -231,13 +231,9 @@ internal class DynamicFunctionTest {
         assertThat(argument).isEqualTo(kotlinValue)
       }
 
-      override fun blockingProduce(): T {
-        return kotlinValue
-      }
+      override fun blockingProduce(): T = kotlinValue
 
-      override suspend fun suspendingProduce(): T {
-        return kotlinValue
-      }
+      override suspend fun suspendingProduce(): T = kotlinValue
     }
 
     endpointA.bind<AcceptProduceService<T>>("service", service)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -427,8 +427,7 @@ actual class QuickJs private constructor(
     throw QuickJsException(message, stack)
   }
 
-  internal fun CValue<JSValue>.toKotlinInstanceOrNull(): Any? {
-    return when (JsValueGetNormTag(this)) {
+  internal fun CValue<JSValue>.toKotlinInstanceOrNull(): Any? = when (JsValueGetNormTag(this)) {
       JS_TAG_EXCEPTION -> throwJsException()
       JS_TAG_STRING -> JS_ToCString(context, this)!!.toKStringFromUtf8()
       JS_TAG_BOOL -> JsValueGetBool(this) != 0
@@ -453,11 +452,8 @@ actual class QuickJs private constructor(
       }
       else -> null
     }
-  }
 
-  private fun Boolean.toJsValue(): CValue<JSValue> {
-    return if (this) JsTrue() else JsFalse()
-  }
+  private fun Boolean.toJsValue(): CValue<JSValue> = if (this) JsTrue() else JsFalse()
 }
 
 internal fun jsInterruptHandlerGlobal(runtime: CPointer<JSRuntime>?, opaque: COpaquePointer?): Int {


### PR DESCRIPTION
- Applied Spotless Kotlin formatting to resolve 111 formatting violations
- Upgraded JVM toolchain from Java 11 to Java 17 for Jetty 12.1.1 compatibility Jetty 12.1.1 requires Java 17+ and was causing plugin validation failures
- Downgraded dev.zacsweers.kctfork:core from 0.9.0 to 0.8.0 Version 0.9.0 was bringing in kotlin-compiler-embeddable 2.2.20 which is incompatible with the project's Kotlin 2.2.10

