### PR TITLE
Add Windows Build Script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.16.0-dev.238+580b6d1fa
 
       - run: zig build -p src/jvmMain/resources/jni
         working-directory: zipline

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.16.0-dev.238+580b6d1fa
 
       - run: zig build -p src/jvmMain/resources/jni
         working-directory: zipline

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ generated-zipline-webpack-config.js
 # Zig
 .zig-cache
 zig-out
+zipline/src/jvmMain/resources/jni

--- a/zipline/Zig.md
+++ b/zipline/Zig.md
@@ -1,0 +1,11 @@
+# ZIG
+
+### `zig.build` compatibility
+
+**Version:** `0.16.0-dev.234+32a1aabff`
+
+---
+
+### Downloads
+
+[Download ZIG](https://ziglang.org/download/)

--- a/zipline/build.zig
+++ b/zipline/build.zig
@@ -5,28 +5,32 @@ pub fn build(b: *std.Build) !void {
   const deleteLib = b.addRemoveDirTree(.{ .cwd_relative = b.getInstallPath(.prefix, "lib") });
   b.getInstallStep().dependOn(&deleteLib.step);
 
-  try setupTarget(b, &deleteLib.step, .linux, .aarch64, "aarch64");
-  try setupTarget(b, &deleteLib.step, .linux, .x86_64, "amd64");
-  try setupTarget(b, &deleteLib.step, .macos, .aarch64, "aarch64");
-  try setupTarget(b, &deleteLib.step, .macos, .x86_64, "x86_64");
+  try setupTarget(b, &deleteLib.step, .linux, .aarch64, "linux_aarch64");
+  try setupTarget(b, &deleteLib.step, .linux, .x86_64, "linux_amd64");
+  try setupTarget(b, &deleteLib.step, .macos, .aarch64, "macos_aarch64");
+  try setupTarget(b, &deleteLib.step, .macos, .x86_64, "macos_x86_64");
+  try setupTarget(b, &deleteLib.step, .windows, .x86_64, "windows_amd64");
 }
 
 fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch, dir: []const u8) !void {
-  const lib = b.addSharedLibrary(.{
+  const lib = b.addLibrary(.{
     .name = "quickjs",
-    .target = b.resolveTargetQuery(.{
-      .cpu_arch = arch,
-      .os_tag = tag,
-      // We need to explicitly specify gnu for linux, as otherwise it defaults to musl.
-      // See https://github.com/ziglang/zig/issues/16624#issuecomment-1801175600.
-      .abi = if (tag == .linux) .gnu else null,
+    .linkage = .dynamic,
+    .root_module = b.createModule(.{
+      .target = b.resolveTargetQuery(.{
+        .cpu_arch = arch,
+        .os_tag = tag,
+        // We need to explicitly specify gnu for linux, as otherwise it defaults to musl.
+        // See https://github.com/ziglang/zig/issues/16624#issuecomment-1801175600.
+        .abi = if (tag == .linux) .gnu else null,
+      }),
+      .optimize = .ReleaseSmall,
     }),
-    .optimize = .ReleaseSmall,
   });
 
   var version_buf: [11]u8 = undefined;
   const version = try readVersionFile(&version_buf);
-  var quoted_version_buf: [12]u8 = undefined;
+  var quoted_version_buf: [14]u8 = undefined;
   const quoted_version = try std.fmt.bufPrint(&quoted_version_buf, "\"{s}\"", .{ version });
   lib.root_module.addCMacro("CONFIG_VERSION", quoted_version);
 
@@ -73,12 +77,20 @@ fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arc
   const install = b.addInstallArtifact(lib, .{
     .dest_dir = .{
       .override = .{
+        .custom = b.fmt("../src/jvmMain/resources/jni/{s}", .{dir}),
+      },
+    },
+  });
+  const installDefault = b.addInstallArtifact(lib, .{
+    .dest_dir = .{
+      .override = .{
         .custom = dir,
       },
     },
   });
 
   step.dependOn(&install.step);
+  step.dependOn(&installDefault.step);
 }
 
 fn readVersionFile(version_buf: []u8) ![]u8 {
@@ -88,8 +100,15 @@ fn readVersionFile(version_buf: []u8) ![]u8 {
   );
   defer version_file.close();
 
-  var version_file_reader = std.io.bufferedReader(version_file.reader());
-  var version_file_stream = version_file_reader.reader();
-  const version = try version_file_stream.readUntilDelimiterOrEof(version_buf, '\n');
-  return version.?;
+  var buffer: [256]u8 = undefined;
+  var file_reader = version_file.reader(&buffer);
+  const bytes_read = try file_reader.read(version_buf);
+
+  // remove all '\r' and '\n'
+  var end_pos = bytes_read;
+  while (end_pos > 0 and (version_buf[end_pos - 1] == '\n' or version_buf[end_pos - 1] == '\r')) {
+    end_pos -= 1;
+  }
+
+  return version_buf[0..end_pos];
 }

--- a/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
+++ b/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
@@ -17,6 +17,9 @@ package app.cash.zipline
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.Locale.US
 
 @Suppress("UnsafeDynamicallyLoadedCode") // Only loading from our own JAR contents.
@@ -34,20 +37,18 @@ internal actual fun loadNativeLibrary() {
   }
 
   val nativeLibraryUrl = QuickJs::class.java.getResource(nativeLibraryJarPath)
-      ?: throw IllegalStateException("Unable to read $nativeLibraryJarPath from JAR")
-  val nativeLibraryFile: File
+    ?: throw IllegalStateException("Unable to read $nativeLibraryJarPath from JAR")
+  val nativeLibraryFile: Path
   try {
-    nativeLibraryFile = File.createTempFile("quickjs", null)
+    nativeLibraryFile = Files.createTempFile("quickjs", null)
 
     // File-based deleteOnExit() uses a special internal shutdown hook that always runs last.
-    nativeLibraryFile.deleteOnExit()
+    nativeLibraryFile.toFile().deleteOnExit()
     nativeLibraryUrl.openStream().use { nativeLibrary ->
-      nativeLibraryFile.outputStream().use { output ->
-        nativeLibrary.copyTo(output)
-      }
+      Files.copy(nativeLibrary, nativeLibraryFile, StandardCopyOption.REPLACE_EXISTING)
     }
   } catch (e: IOException) {
     throw RuntimeException("Unable to extract native library from JAR", e)
   }
-  System.load(nativeLibraryFile.absolutePath)
+  System.load(nativeLibraryFile.toAbsolutePath().toString())
 }

--- a/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
+++ b/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
@@ -15,10 +15,8 @@
  */
 package app.cash.zipline
 
+import java.io.File
 import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.Locale.US
 
 @Suppress("UnsafeDynamicallyLoadedCode") // Only loading from our own JAR contents.
@@ -26,25 +24,30 @@ internal actual fun loadNativeLibrary() {
   val osName = System.getProperty("os.name").lowercase(US)
   val osArch = System.getProperty("os.arch").lowercase(US)
   val nativeLibraryJarPath = if (osName.contains("linux")) {
-    "/jni/$osArch/libquickjs.so"
+    "/jni/linux_$osArch/libquickjs.so"
   } else if (osName.contains("mac")) {
-    "/jni/$osArch/libquickjs.dylib"
+    "/jni/macos_$osArch/libquickjs.dylib"
+  } else if(osName.contains("windows")) {
+    "/jni/windows_$osArch/quickjs.dll"
   } else {
     throw IllegalStateException("Unsupported OS: $osName")
   }
+
   val nativeLibraryUrl = QuickJs::class.java.getResource(nativeLibraryJarPath)
       ?: throw IllegalStateException("Unable to read $nativeLibraryJarPath from JAR")
-  val nativeLibraryFile: Path
+  val nativeLibraryFile: File
   try {
-    nativeLibraryFile = Files.createTempFile("quickjs", null)
+    nativeLibraryFile = File.createTempFile("quickjs", null)
 
     // File-based deleteOnExit() uses a special internal shutdown hook that always runs last.
-    nativeLibraryFile.toFile().deleteOnExit()
+    nativeLibraryFile.deleteOnExit()
     nativeLibraryUrl.openStream().use { nativeLibrary ->
-      Files.copy(nativeLibrary, nativeLibraryFile, REPLACE_EXISTING)
+      nativeLibraryFile.outputStream().use { output ->
+        nativeLibrary.copyTo(output)
+      }
     }
   } catch (e: IOException) {
     throw RuntimeException("Unable to extract native library from JAR", e)
   }
-  System.load(nativeLibraryFile.toAbsolutePath().toString())
+  System.load(nativeLibraryFile.absolutePath)
 }


### PR DESCRIPTION
# Changelog

## Updates

1. **Update `build.zig` for zig 0.16.0 Compatibility**
   - The build script is now compatible with zig-0.16.0.
   - Deprecated and removed APIs in the new zig version have been properly handled.

2. **Add Windows x86_64 QuickJS DLL Build Support**
   - `build.zig` now supports building `quickjs.dll` for Windows x86_64.
   - Folder naming conventions for Linux and macOS have been revised to prevent output conflicts, ensuring that `zig build` no longer causes macOS artifacts to overwrite Linux ones.

3. **Enhanced Build Output**
   - In addition to outputting to `zig-out`, library artifacts are now also copied to `src/jvmMain/resources` to support direct execution of test files on Windows.

4. **Update `QuickJsNativeLoader.kt`**
   - Added Windows support for the native loader, improving cross-platform compatibility.

5. **Testing**
   - Successfully passed tests in `zipline/src/hostTest/kotlin/app/cash/zipline/QuickJsTest.kt`, confirming the effectiveness of the above changes.

---
- I will continue to test the compatibility of zipline windows and quickjs and multiple tests on this branch. For now, I will submit it to the windows-dev branch and keep the latest code synchronized from the trunk branch.
---