### PR TITLE
Fix Windows build failures for cklib and CMake tasks

### DIFF
--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -182,7 +182,11 @@ cklib {
       listOf(
         //"-DDUMP_LEAKS=1", // For local testing ONLY!
         "-DKONAN_MI_MALLOC=1",
-        "-DCONFIG_VERSION=\"${quickJsVersion()}\"",
+        if (isWindows()) {
+          "-DCONFIG_VERSION=\"\\\"${quickJsVersion()}\\\"\""
+        } else {
+          "-DCONFIG_VERSION=\"${quickJsVersion()}\""
+        },
         "-Wno-unknown-pragmas",
         "-ftls-model=initial-exec",
         "-Wno-unused-function",
@@ -212,9 +216,13 @@ android {
 
     externalNativeBuild {
       cmake {
-        arguments("-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static")
-        cFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
-        cppFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
+        arguments(
+          "-DANDROID_TOOLCHAIN=clang",
+          "-DANDROID_STL=c++_static",
+          "-DQUICKJS_VERSION=${quickJsVersion()}"
+        )
+        cFlags("-fstrict-aliasing")
+        cppFlags("-fstrict-aliasing")
       }
     }
 
@@ -285,6 +293,7 @@ android {
 fun quickJsVersion(): String {
   return File(projectDir, "native/quickjs/VERSION").readText().trim()
 }
+fun isWindows(): Boolean { return System.getProperty("os.name")?.contains("windows", ignoreCase = true) == true }
 
 configure<MavenPublishBaseExtension> {
   configure(

--- a/zipline/src/androidMain/CMakeLists.txt
+++ b/zipline/src/androidMain/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
+if(DEFINED QUICKJS_VERSION)
+  add_compile_definitions(CONFIG_VERSION="${QUICKJS_VERSION}")
+endif()
+
 file(GLOB_RECURSE sources "../../native/*.c" "../../native/*.cpp")
 
 add_library(quickjs SHARED ${sources})


### PR DESCRIPTION
- **This PR mainly fixes some errors caused by compiling the project on Windows. After modification, it is also verified that the project can be compiled successfully on Windows WSL Ubuntu system.**

- Fixed a CONFIG_VERSION escaping issue on Windows and verified that the project compiles successfully on WSL Ubuntu.**

- The testing tasks are as follows:
`./gradlew zipline:buildCMakeDebug`
`./gradlew zipline:allQuickjs`

# Reproducing the issue
<img width="2559" height="1439" alt="cklib_error_windows" src="https://github.com/user-attachments/assets/ba09b336-5dd7-4d04-9ef1-413228e0270b" />
<img width="2559" height="1439" alt="cmake_error_windows" src="https://github.com/user-attachments/assets/a47df307-45ea-4c1f-b97e-4ae81939a733" />


# Fix
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/0bf15f3d-1daa-4f88-b8f2-84f84c5a70db" />

