### PR TITLE
Add Windows Jvm build support

### DIFF
--- a/zipline/Zig.md
+++ b/zipline/Zig.md
@@ -1,0 +1,16 @@
+# ZIG
+
+### `zig.build` compatibility
+
+**Version:** `0.14.0`
+
+---
+
+### Downloads
+
+[Download ZIG](https://ziglang.org/download/)
+
+### Build
+
+`zip build`
+`zig build -p src/jvmMain/resources/jni`

--- a/zipline/build.zig
+++ b/zipline/build.zig
@@ -5,10 +5,11 @@ pub fn build(b: *std.Build) !void {
   const deleteLib = b.addRemoveDirTree(.{ .cwd_relative = b.getInstallPath(.prefix, "lib") });
   b.getInstallStep().dependOn(&deleteLib.step);
 
-  try setupTarget(b, &deleteLib.step, .linux, .aarch64, "aarch64");
-  try setupTarget(b, &deleteLib.step, .linux, .x86_64, "amd64");
-  try setupTarget(b, &deleteLib.step, .macos, .aarch64, "aarch64");
-  try setupTarget(b, &deleteLib.step, .macos, .x86_64, "x86_64");
+  try setupTarget(b, &deleteLib.step, .linux, .aarch64, "linux_aarch64");
+  try setupTarget(b, &deleteLib.step, .linux, .x86_64, "linux_amd64");
+  try setupTarget(b, &deleteLib.step, .macos, .aarch64, "macos_aarch64");
+  try setupTarget(b, &deleteLib.step, .macos, .x86_64, "macos_x86_64");
+  try setupTarget(b, &deleteLib.step, .windows, .x86_64, "windows_amd64");
 }
 
 fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch, dir: []const u8) !void {
@@ -24,9 +25,9 @@ fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arc
     .optimize = .ReleaseSmall,
   });
 
-  var version_buf: [11]u8 = undefined;
+  var version_buf: [64]u8 = undefined;
   const version = try readVersionFile(&version_buf);
-  var quoted_version_buf: [12]u8 = undefined;
+  var quoted_version_buf: [64]u8 = undefined;
   const quoted_version = try std.fmt.bufPrint(&quoted_version_buf, "\"{s}\"", .{ version });
   lib.root_module.addCMacro("CONFIG_VERSION", quoted_version);
 
@@ -81,7 +82,7 @@ fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arc
   step.dependOn(&install.step);
 }
 
-fn readVersionFile(version_buf: []u8) ![]u8 {
+fn readVersionFile(version_buf: []u8) ![]const u8 {
   const version_file = try std.fs.cwd().openFile(
     "native/quickjs/VERSION",
     .{ },
@@ -90,6 +91,7 @@ fn readVersionFile(version_buf: []u8) ![]u8 {
 
   var version_file_reader = std.io.bufferedReader(version_file.reader());
   var version_file_stream = version_file_reader.reader();
+
   const version = try version_file_stream.readUntilDelimiterOrEof(version_buf, '\n');
-  return version.?;
+  return std.mem.trim(u8, version.?, " \t\r\n");
 }

--- a/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
+++ b/zipline/src/jvmMain/kotlin/app/cash/zipline/QuickJsNativeLoader.kt
@@ -26,9 +26,11 @@ internal actual fun loadNativeLibrary() {
   val osName = System.getProperty("os.name").lowercase(US)
   val osArch = System.getProperty("os.arch").lowercase(US)
   val nativeLibraryJarPath = if (osName.contains("linux")) {
-    "/jni/$osArch/libquickjs.so"
+    "/jni/linux_$osArch/libquickjs.so"
   } else if (osName.contains("mac")) {
-    "/jni/$osArch/libquickjs.dylib"
+    "/jni/macos_$osArch/libquickjs.dylib"
+  } else if(osName.contains("windows")) {
+    "/jni/windows_$osArch/quickjs.dll"
   } else {
     throw IllegalStateException("Unsupported OS: $osName")
   }


### PR DESCRIPTION
## PR
- **This pull request primarily adds support for compiling and packaging on the Windows JVM platform. Compilation has also been verified on a Windows WSL Ubuntu system. It has been released to Maven and can be included in Compose Desktop. Zipline support on Windows platforms works as expected.**

## ChangeList
- **Added: JvmNativeLoader.kt adds Windows support.**
- **Modified: Changed QuickJS Library naming to resolve overwriting of folders on different platforms.**
- **Modified: Fixed an error in Zig reading the QuickJS version number on Windows.**

# Fix
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/0bf15f3d-1daa-4f88-b8f2-84f84c5a70db" />

# Release
<img width="1846" height="1013" alt="Maven" src="https://github.com/user-attachments/assets/e61ceba0-42cf-40f7-96ce-09053a79dc11" />