### PR TITLE
Overhaul CI to add coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
       - '**'
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false -Dorg.gradle.logging.stacktrace=full"
 
 jobs:
   zig:
@@ -44,9 +44,7 @@ jobs:
             task: macosArm64Test
           - os: ubuntu-latest
             task: linuxX64Test
-
     runs-on: ${{ matrix.platform.os }}
-
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -59,7 +57,7 @@ jobs:
           name: jni-binaries
           path: zipline/src/jvmMain/resources/jni
 
-      - run: ./gradlew jvmTest ${{ matrix.platform.task }} apiCheck --stacktrace
+      - run: ./gradlew jvmTest ${{ matrix.platform.task }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
@@ -68,11 +66,29 @@ jobs:
           path: '**/build/reports/tests/**'
           retention-days: 1
 
-  samples:
+  simulator-tests:
+    needs:
+      - zig
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - task: iosSimulatorArm64Test
+          - task: tvosSimulatorArm64Test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version-file: .github/workflows/.java-version
+
+      - run: ./gradlew ${{ matrix.platform.task }}
+
+  check:
     runs-on: macos-latest
     needs:
       - zig
-
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -85,7 +101,37 @@ jobs:
           name: jni-binaries
           path: zipline/src/jvmMain/resources/jni
 
-      - run: ./gradlew -p samples check --stacktrace
+      # Disable jvmTest and native tests because they're run in platform-tests and simulator-tests.
+      - run: >
+          ./gradlew
+          check
+          -x allTests
+          -x iosSimulatorArm64Test
+          -x iosX64Test
+          -x jvmTest
+          -x linuxX64Test
+          -x macosArm64Test
+          -x macosX64Test
+          -x tvosSimulatorArm64Test
+          -x tvosX64Test
+
+  sample-check:
+    runs-on: macos-latest
+    needs:
+      - zig
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version-file: .github/workflows/.java-version
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: jni-binaries
+          path: zipline/src/jvmMain/resources/jni
+
+      - run: ./gradlew -p samples check
 
   android-tests:
     runs-on: ubuntu-latest
@@ -127,14 +173,30 @@ jobs:
           pod install
           xcodebuild -workspace WorldClock.xcworkspace -scheme WorldClock -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
 
-  build:
-    runs-on: macos-latest
+  final-status:
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
     needs:
       - platform-tests
-      - samples
+      - simulator-tests
+      - check
+      - sample-check
       - android-tests
       - ios-app
+    steps:
+      - name: Check
+        run: |
+          results=$(tr -d '\n' <<< '${{ toJSON(needs.*.result) }}')
+          if ! grep -q -v -E '(failure|cancelled)' <<< "$results"; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi
 
+  publish:
+    if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/zipline' }}
+    runs-on: macos-latest
+    needs:
+      - final-status
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -147,25 +209,14 @@ jobs:
           name: jni-binaries
           path: zipline/src/jvmMain/resources/jni
 
-      - run: ./gradlew assemble :dokkaHtmlMultiModule
+      - run: ./gradlew publishToMavenCentral
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: zipline-jvm.jar
-          path: zipline/build/libs/zipline-jvm-*.jar
-          if-no-files-found: error
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: zipline-android.aar
-          path: zipline/build/outputs/aar/*-release.aar
-          if-no-files-found: error
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: zipline-cli.zip
-          path: zipline-cli/build/distributions/zipline-cli-*.zip
-          if-no-files-found: error
+      - run: ./gradlew :dokkaHtmlMultiModule
 
       - uses: actions/upload-artifact@v4
         with:
@@ -173,16 +224,7 @@ jobs:
           path: build/dokka/htmlMultiModule/
           if-no-files-found: error
 
-      - run: ./gradlew publishToMavenCentral
-        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/zipline' }}
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-
       - name: Deploy docs to website
-        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/zipline' }}
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ jetty-ee10Servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", vers
 jetty-ee10WebsocketJettyServer = { module = "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server", version.ref = "jetty" }
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 junit = { module = "junit:junit", version = "4.13.2" }
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.9.0" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.8.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-compose-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/FirZiplineApiReader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/FirZiplineApiReader.kt
@@ -196,7 +196,7 @@ internal class FirZiplineApiReader(
       visitor = object : FirDefaultVisitor<Unit, MutableList<FirRegularClass>>() {
         override fun visitRegularClass(
           regularClass: FirRegularClass,
-          data: MutableList<FirRegularClass>
+          data: MutableList<FirRegularClass>,
         ) {
           super.visitRegularClass(regularClass, data)
           data.add(regularClass)
@@ -204,7 +204,7 @@ internal class FirZiplineApiReader(
 
         override fun visitElement(
           element: FirElement,
-          data: MutableList<FirRegularClass>
+          data: MutableList<FirRegularClass>,
         ) {
           element.acceptChildren(this, data)
         }

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/KotlinFirLoader.kt
@@ -110,6 +110,7 @@ internal class KotlinFirLoader(
     }
 
     val sourceFiles = files.mapTo(mutableSetOf(), ::KtVirtualFileSourceFile)
+
     @OptIn(LegacyK2CliPipeline::class)
     val input = ModuleCompilerInput(
       targetId = TargetId(JvmProtoBufUtil.DEFAULT_MODULE_NAME, targetName),

--- a/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/ZiplineApis.kt
+++ b/zipline-api-validator/src/main/kotlin/app/cash/zipline/api/validator/fir/ZiplineApis.kt
@@ -17,8 +17,7 @@ package app.cash.zipline.api.validator.fir
 
 import okio.ByteString.Companion.encodeUtf8
 
-internal fun String.signatureHash(): String =
-  encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
+internal fun String.signatureHash(): String = encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
 
 /** Don't bridge these. */
 internal val NON_INTERFACE_FUNCTION_NAMES = setOf(

--- a/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Compile.kt
+++ b/zipline-cli/src/main/kotlin/app/cash/zipline/cli/Compile.kt
@@ -30,8 +30,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import okio.ByteString.Companion.decodeHex
 
 internal class Compile : CliktCommand("compile") {
-  override fun help(context: Context) =
-    "Compile .js files to .zipline files"
+  override fun help(context: Context) = "Compile .js files to .zipline files"
 
   private val inputDir by option("--input").file().required()
     .help("Directory from which .js files will be loaded.")

--- a/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDevelopmentServer.kt
+++ b/zipline-gradle-plugin/src/main/kotlin/app/cash/zipline/gradle/ZiplineDevelopmentServer.kt
@@ -63,14 +63,17 @@ internal open class ZiplineDevelopmentServer internal constructor(
 
         // Offer a web socket for reload events.
         addServlet(
-          ServletHolder("ws", object : JettyWebSocketServlet() {
+          ServletHolder(
+            "ws",
+            object : JettyWebSocketServlet() {
             public override fun configure(factory: JettyWebSocketServletFactory) {
               factory.addMapping("/ws") { _, _ ->
                 ZiplineWebSocket().also { webSockets.add(it) }
               }
             }
-          }),
-          "/ws"
+          },
+          ),
+          "/ws",
         )
 
         // Serve .zipline bytecode and manifest JSON files at the file system root.
@@ -82,7 +85,7 @@ internal open class ZiplineDevelopmentServer internal constructor(
             setInitParameter("cacheControl", "no-cache")
             setInitParameter("etags", "true")
           },
-          "/*"
+          "/*",
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -595,7 +595,7 @@ internal class AdapterGenerator(
             +functionCall
             irUnit()
           }
-        }
+        },
       )
     }
 
@@ -893,7 +893,7 @@ internal class AdapterGenerator(
           elementType = pluginContext.symbols.any.defaultType.makeNullable(),
           values = result.parameters
             .filter { it.kind == IrParameterKind.Regular }
-            .map { irGet(type = it.type, variable = it.symbol) }
+            .map { irGet(type = it.type, variable = it.symbol) },
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/BridgedInterface.kt
@@ -237,7 +237,7 @@ internal class BridgedInterface(
         wrapWithNullableSerializerIfNeeded(
           type,
           contextualSerializerExpression,
-          ziplineApis.nullableSerializer
+          ziplineApis.nullableSerializer,
         )
       }
 

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ir.kt
@@ -457,8 +457,7 @@ fun IrBuilderWithScope.irInvoke(
   typeArguments: List<IrType?>,
   valueArguments: List<IrExpression>,
   returnTypeHint: IrType? = null,
-): IrMemberAccessExpression<*> =
-  irInvoke(
+): IrMemberAccessExpression<*> = irInvoke(
     dispatchReceiver,
     callee,
     *valueArguments.toTypedArray(),

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/typeToString.kt
@@ -18,8 +18,7 @@ import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 /** Inspired by [org.jetbrains.kotlin.ir.backend.js.utils.asString]. */
-fun IrSimpleType.asString(): String =
-  classifier.asString() +
+fun IrSimpleType.asString(): String = classifier.asString() +
     (
       arguments.ifNotEmpty {
       joinToString(separator = ",", prefix = "<", postfix = ">") { it.asString() }

--- a/zipline-loader/src/androidInstrumentedTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
+++ b/zipline-loader/src/androidInstrumentedTest/kotlin/app/cash/zipline/loader/loaderTestsAndroid.kt
@@ -25,8 +25,7 @@ import okio.ByteString.Companion.toByteString
 // Note that we don't run Android tests because we don't have the right QuickJS or SQLite to run
 // them on the JVM.
 
-internal actual fun testSqlDriverFactory(): SqlDriverFactory =
-  error("testSqlDriverFactory not available for Android")
+internal actual fun testSqlDriverFactory(): SqlDriverFactory = error("testSqlDriverFactory not available for Android")
 
 actual fun randomByteString(size: Int): ByteString {
   val byteArray = ByteArray(size)

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/internalCommon.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/internalCommon.kt
@@ -24,8 +24,7 @@ internal expect fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: S
 
 internal const val MANIFEST_FILE_NAME = "manifest.zipline.json"
 
-internal fun getApplicationManifestFileName(applicationName: String) =
-  "$applicationName.$MANIFEST_FILE_NAME"
+internal fun getApplicationManifestFileName(applicationName: String) = "$applicationName.$MANIFEST_FILE_NAME"
 
 /** ECDSA P-256. https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm */
 internal expect val ecdsaP256: SignatureAlgorithm

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/tink/subtle/Ed25519.kt
@@ -265,7 +265,7 @@ internal object Ed25519 : SignatureAlgorithm {
   }
 
   /**
-   * Partial projective point representation ((X:Z),(Y:T)) satisfying x=X/Z, y=Y/T
+   * Partial projective point representation ((X:Z), (Y:T)) satisfying x=X/Z, y=Y/T
    *
    * Note that this is referred as complete form in the original ref10 impl (ge_p1p1).
    * Also note that t = T below following Java coding style.

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderConcurrencyTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderConcurrencyTest.kt
@@ -92,7 +92,9 @@ class LoaderConcurrencyTest {
     }
   }
 
-  inner class TestEventListener : EventListener(), EventListener.Factory {
+  inner class TestEventListener :
+    EventListener(),
+    EventListener.Factory {
     override fun create(applicationName: String, manifestUrl: String?) = this
 
     override fun cacheHit(applicationName: String, url: String, fileSize: Long) {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
@@ -423,8 +423,7 @@ class ZiplineCacheTest {
     download: suspend () -> ByteString,
   ) = getOrPut(applicationName, sha256, nowMillis, download)
 
-  private fun ZiplineCache.getPinnedManifest(applicationName: String) =
-    getPinnedManifest(applicationName, nowMillis)
+  private fun ZiplineCache.getPinnedManifest(applicationName: String) = getPinnedManifest(applicationName, nowMillis)
 
   private fun ZiplineCache.pinManifest(
     applicationName: String,

--- a/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/internalJni.kt
+++ b/zipline-loader/src/jniMain/kotlin/app/cash/zipline/loader/internal/internalJni.kt
@@ -19,8 +19,7 @@ import app.cash.zipline.Zipline
 import java.security.SecureRandom
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
-internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) =
-  loadJsModule(bytecode, id)
+internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) = loadJsModule(bytecode, id)
 
 internal actual val ecdsaP256: SignatureAlgorithm = EcdsaP256(secureRandom())
 

--- a/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/internalNative.kt
+++ b/zipline-loader/src/nativeMain/kotlin/app/cash/zipline/loader/internal/internalNative.kt
@@ -20,8 +20,7 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSURL
 import platform.Foundation.timeIntervalSince1970
 
-internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) =
-  loadJsModule(bytecode, id)
+internal actual fun Zipline.multiplatformLoadJsModule(bytecode: ByteArray, id: String) = loadJsModule(bytecode, id)
 
 internal actual val ecdsaP256: SignatureAlgorithm = EcdsaP256()
 

--- a/zipline-profiler/src/commonMain/kotlin/app/cash/zipline/profiler/SamplingProfiler.kt
+++ b/zipline-profiler/src/commonMain/kotlin/app/cash/zipline/profiler/SamplingProfiler.kt
@@ -57,7 +57,8 @@ fun QuickJs.startCpuSampling(hprofSink: BufferedSink): Closeable {
 internal class SamplingProfiler internal constructor(
   private val quickJs: QuickJs,
   private val hprofWriter: HprofWriter,
-) : Closeable, InterruptHandler {
+) : Closeable,
+  InterruptHandler {
   private var nextId = 1
 
   /** Placeholder value for the JavaScript thread. */

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/LoggingEventListener.kt
@@ -22,7 +22,9 @@ import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.ZiplineService
 
-class LoggingEventListener : EventListener(), EventListener.Factory {
+class LoggingEventListener :
+  EventListener(),
+  EventListener.Factory {
   private var nextCallId = 1
   private val log = ArrayDeque<LogEntry>()
 

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/SignatureHash.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/SignatureHash.kt
@@ -33,5 +33,4 @@ import okio.ByteString.Companion.encodeUtf8
  * Don't change how this works! Doing so will break upgrades for programs compiled with different
  * identifiers.
  */
-fun String.signatureHash(): String =
-  encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.
+fun String.signatureHash(): String = encodeUtf8().sha256().substring(0, 6).base64() // In base64, 6 bytes takes 8 chars.

--- a/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/ZiplineTestInternals.kt
+++ b/zipline-testing/src/hostMain/kotlin/app/cash/zipline/testing/ZiplineTestInternals.kt
@@ -130,7 +130,8 @@ object ZiplineTestInternals {
 
     private class GeneratedOutboundService(
       override val callHandler: OutboundCallHandler,
-    ) : EchoService, OutboundService {
+    ) : EchoService,
+      OutboundService {
 
       override fun echo(request: EchoRequest): EchoResponse {
         return callHandler.call(this, 0, request) as EchoResponse
@@ -172,7 +173,8 @@ object ZiplineTestInternals {
     }
 
     private class GeneratedOutboundService(override val callHandler: OutboundCallHandler) :
-      GenericEchoService<String>, OutboundService {
+      GenericEchoService<String>,
+      OutboundService {
 
       override fun genericEcho(request: String): List<String> {
         return callHandler.call(this, 0, request) as List<String>
@@ -215,7 +217,8 @@ object ZiplineTestInternals {
     }
 
     private class GeneratedOutboundService(override val callHandler: OutboundCallHandler) :
-      EchoZiplineService, OutboundService {
+      EchoZiplineService,
+      OutboundService {
 
       override fun echo(request: EchoRequest): EchoResponse {
         return callHandler.call(this, 0, request) as EchoResponse

--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/interfaceSerializersJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/interfaceSerializersJs.kt
@@ -17,12 +17,12 @@ package app.cash.zipline.testing
 
 import app.cash.zipline.Zipline
 
-class JsMessageInterfaceService : RequestInterfaceService, ResponseInterfaceService {
-  override fun echo(request: MessageInterface) =
-    "JS received an interface, ${request.message}"
+class JsMessageInterfaceService :
+  RequestInterfaceService,
+  ResponseInterfaceService {
+  override fun echo(request: MessageInterface) = "JS received an interface, ${request.message}"
 
-  override fun echo(request: String) =
-    RealMessageInterface("JS returned an interface, $request")
+  override fun echo(request: String) = RealMessageInterface("JS returned an interface, $request")
 }
 
 private val zipline by lazy { Zipline.get(MessageInterfaceSerializersModule) }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/GuestService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/GuestService.kt
@@ -20,7 +20,9 @@ import app.cash.zipline.ZiplineService
 /**
  * Guest functions for use by host code.
  */
-internal interface GuestService : EndpointService, ZiplineService {
+internal interface GuestService :
+  EndpointService,
+  ZiplineService {
   /** Run the job enqueued by [HostService.setTimeout]. */
   fun runJob(timeoutId: Int)
 }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/HostService.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/HostService.kt
@@ -23,7 +23,9 @@ import app.cash.zipline.ZiplineService
  * Unlike typical interfaces that collect functions that share a purpose, this interface collects
  * functions that share a common implementation mechanism: the host platform.
  */
-internal interface HostService : EndpointService, ZiplineService {
+internal interface HostService :
+  EndpointService,
+  ZiplineService {
   fun setTimeout(timeoutId: Int, delayMillis: Int)
 
   fun clearTimeout(timeoutId: Int)

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -226,7 +226,9 @@ internal class OutboundCallHandler(
   }
 
   private inner class RealSuspendCallback<R> :
-    SuspendCallback<R>, HasPassByReferenceName, ZiplineScoped {
+    SuspendCallback<R>,
+    HasPassByReferenceName,
+    ZiplineScoped {
     lateinit var internalCall: InternalCall
     lateinit var externalCall: Call
     lateinit var continuation: Continuation<R>

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/ZiplineServiceAdapter.kt
@@ -57,8 +57,7 @@ internal abstract class ZiplineServiceAdapter<T : ZiplineService> : KSerializer<
     return reference.take(this)
   }
 
-  override fun equals(other: Any?) =
-    other is ZiplineServiceAdapter<*> &&
+  override fun equals(other: Any?) = other is ZiplineServiceAdapter<*> &&
     this::class == other::class &&
     serializers == other.serializers
 

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/calls.kt
@@ -60,8 +60,7 @@ internal class InternalCall(
 
   val args: List<*>,
 ) {
-  override fun toString() =
-    "Call(receiver=$serviceName, function=${function.signature}, args=$args)"
+  override fun toString() = "Call(receiver=$serviceName, function=${function.signature}, args=$args)"
 }
 
 /** This uses [Int] as a placeholder; in practice the element type depends on the argument type. */
@@ -209,8 +208,7 @@ internal class RealCallSerializer(
         resultSerializer = Int.serializer(),
         suspendCallbackSerializer = failureSuspendCallbackSerializer,
       ) {
-        override suspend fun callSuspending(service: T, args: List<*>) =
-          throw ZiplineApiMismatchException(message)
+        override suspend fun callSuspending(service: T, args: List<*>) = throw ZiplineApiMismatchException(message)
       }
     } else {
       return object : ReturningZiplineFunction<T>(
@@ -220,8 +218,7 @@ internal class RealCallSerializer(
         // Placeholder; we're only encoding failures.
         resultSerializer = Int.serializer(),
       ) {
-        override fun call(service: T, args: List<*>) =
-          throw ZiplineApiMismatchException(message)
+        override fun call(service: T, args: List<*>) = throw ZiplineApiMismatchException(message)
       }
     }
   }

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/flows.kt
@@ -86,8 +86,7 @@ internal class FlowSerializer<T>(
     }
   }
 
-  override fun equals(other: Any?) =
-    other is FlowSerializer<*> && other.delegateSerializer == delegateSerializer
+  override fun equals(other: Any?) = other is FlowSerializer<*> && other.delegateSerializer == delegateSerializer
 
   override fun hashCode() = delegateSerializer.hashCode()
 }
@@ -148,8 +147,7 @@ internal class StateFlowSerializer<T>(
     }
   }
 
-  override fun equals(other: Any?) =
-    other is StateFlowSerializer<*> && other.delegateSerializer == delegateSerializer
+  override fun equals(other: Any?) = other is StateFlowSerializer<*> && other.delegateSerializer == delegateSerializer
 
   override fun hashCode() = delegateSerializer.hashCode()
 }

--- a/zipline/src/hostMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
+++ b/zipline/src/hostMain/kotlin/app/cash/zipline/internal/jsonEngine.kt
@@ -18,8 +18,6 @@ package app.cash.zipline.internal
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
-internal actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T =
-  decodeFromString(deserializer, string)
+internal actual fun <T> Json.decodeFromStringFast(deserializer: KSerializer<T>, string: String): T = decodeFromString(deserializer, string)
 
-internal actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String =
-  encodeToString(serializer, value)
+internal actual fun <T> Json.encodeToStringFast(serializer: KSerializer<T>, value: T): String = encodeToString(serializer, value)

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/EndpointTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/EndpointTest.kt
@@ -541,7 +541,9 @@ internal class EndpointTest {
     assertTrue("boom!" in e.message)
   }
 
-  interface ExtendsEchoService : ZiplineService, ExtendableInterface
+  interface ExtendsEchoService :
+    ZiplineService,
+    ExtendableInterface
 
   interface ExtendableInterface {
     fun echo(request: EchoRequest): EchoResponse

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/FlowTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/FlowTest.kt
@@ -43,7 +43,9 @@ internal class FlowTest {
     suspend fun flowParameter(flow: Flow<String>): Int
   }
 
-  class RealFlowEchoService : FlowEchoService, ZiplineScoped {
+  class RealFlowEchoService :
+    FlowEchoService,
+    ZiplineScoped {
     override val scope = ZiplineScope()
 
     override fun createFlow(message: String, count: Int): Flow<String> {

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/SampleService.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/SampleService.kt
@@ -76,8 +76,7 @@ interface SampleService<T> : ZiplineService {
         argSerializers = argSerializers,
         resultSerializer = resultSerializer,
       ) {
-        override fun call(service: SampleService<TF>, args: List<*>): Any? =
-          service.ping(args[0] as SampleRequest)
+        override fun call(service: SampleService<TF>, args: List<*>): Any? = service.ping(args[0] as SampleRequest)
       }
 
       class ZiplineFunction1<TF>(
@@ -91,8 +90,7 @@ interface SampleService<T> : ZiplineService {
         resultSerializer = resultSerializer,
         suspendCallbackSerializer = suspendCallbackSerializer,
       ) {
-        override suspend fun callSuspending(service: SampleService<TF>, args: List<*>) =
-          service.reduce(args[0] as List<TF>)
+        override suspend fun callSuspending(service: SampleService<TF>, args: List<*>) = service.reduce(args[0] as List<TF>)
       }
 
       class ZiplineFunction2<TF>(
@@ -135,7 +133,8 @@ interface SampleService<T> : ZiplineService {
 
       private class GeneratedOutboundService<TS>(
         override val callHandler: OutboundCallHandler,
-      ) : SampleService<TS>, OutboundService {
+      ) : SampleService<TS>,
+        OutboundService {
         override fun ping(request: SampleRequest): SampleResponse {
           val callHandler = callHandler
           return callHandler.call(this, 0, request) as SampleResponse

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/StateFlowTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/StateFlowTest.kt
@@ -40,7 +40,9 @@ internal class StateFlowTest {
     suspend fun take(flow: StateFlow<String>, count: Int): List<String>
   }
 
-  class RealStateFlowEchoService(initialValue: String = "") : StateFlowEchoService, ZiplineScoped {
+  class RealStateFlowEchoService(initialValue: String = "") :
+    StateFlowEchoService,
+    ZiplineScoped {
     override val scope = ZiplineScope()
     val mutableFlow = MutableStateFlow(initialValue)
     override val flow: StateFlow<String> get() = mutableFlow

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/JniCallChannel.kt
@@ -21,8 +21,7 @@ internal class JniCallChannel(
   private val quickJs: QuickJs,
   private val instance: Long,
 ) : CallChannel {
-  override fun call(callJson: String) =
-    call(quickJs.context, instance, callJson)
+  override fun call(callJson: String) = call(quickJs.context, instance, callJson)
 
   private external fun call(
     context: Long,
@@ -30,8 +29,7 @@ internal class JniCallChannel(
     callJson: String,
   ): String
 
-  override fun disconnect(instanceName: String): Boolean =
-    disconnect(quickJs.context, instance, instanceName)
+  override fun disconnect(instanceName: String): Boolean = disconnect(quickJs.context, instance, instanceName)
 
   private external fun disconnect(
     context: Long,

--- a/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/jniMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -30,7 +30,8 @@ import java.io.Closeable
 @EngineApi
 actual class QuickJs private constructor(
   internal var context: Long,
-) : AutoCloseable, Closeable {
+) : AutoCloseable,
+  Closeable {
   actual companion object {
     init {
       loadNativeLibrary()

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/InterfaceSerializersTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/InterfaceSerializersTest.kt
@@ -125,11 +125,11 @@ class InterfaceSerializersTest {
     )
   }
 
-  private class JvmMessageInterfaceService : RequestInterfaceService, ResponseInterfaceService {
-    override fun echo(request: MessageInterface) =
-      "JVM received an interface, ${request.message}"
+  private class JvmMessageInterfaceService :
+    RequestInterfaceService,
+    ResponseInterfaceService {
+    override fun echo(request: MessageInterface) = "JVM received an interface, ${request.message}"
 
-    override fun echo(request: String) =
-      RealMessageInterface("JVM returned an interface, $request")
+    override fun echo(request: String) = RealMessageInterface("JVM returned an interface, $request")
   }
 }


### PR DESCRIPTION
This runs the check task on the root project (sans tests we run elsewhere) which should start catching everything. It removes apiCheck from the platform test shards as that requires building all targets, so they should get faster and work on Windows.