### PR TITLE
Split JVM and native tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,20 +31,10 @@ jobs:
           path: zipline/src/jvmMain/resources/jni
           if-no-files-found: error
 
-  platform-tests:
+  jvm-test-binary:
     needs:
       - zig
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - os: macos-13
-            task: macosX64Test
-          - os: macos-latest
-            task: macosArm64Test
-          - os: ubuntu-latest
-            task: linuxX64Test
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -57,25 +47,61 @@ jobs:
           name: jni-binaries
           path: zipline/src/jvmMain/resources/jni
 
-      - run: ./gradlew jvmTest ${{ matrix.platform.task }}
+      - run: ./gradlew :zipline:installJvmTestDistribution
 
       - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
         with:
-          name: test-report-${{ matrix.platform.os }}
-          path: '**/build/reports/tests/**'
-          retention-days: 1
+          name: jvm-tests
+          path: zipline/build/install/jvmTest
+          if-no-files-found: error
 
-  simulator-tests:
+  jvm-tests:
     needs:
-      - zig
-    runs-on: macos-latest
+      - jvm-test-binary
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - task: iosSimulatorArm64Test
-          - task: tvosSimulatorArm64Test
+          - macos-15-intel
+          - macos-15
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/workflows/.java-version
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version-file: .github/workflows/.java-version
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: jvm-tests
+
+      - name: Run JVM tests
+        run: |
+          chmod +x bin/zipline-test
+          bin/zipline-test
+
+  native-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: macos-15-intel
+            task: macosX64Test
+          - os: macos-latest
+            task: macosArm64Test
+          - os: ubuntu-latest
+            task: linuxX64Test
+          - os: macos-latest
+            task: iosSimulatorArm64Test
+          - os: macos-latest
+            task: tvosSimulatorArm64Test
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -84,6 +110,13 @@ jobs:
           java-version-file: .github/workflows/.java-version
 
       - run: ./gradlew ${{ matrix.platform.task }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: test-report-native-${{ matrix.platform.task }}
+          path: '**/build/reports/tests/**'
+          retention-days: 1
 
   check:
     runs-on: macos-latest
@@ -101,14 +134,14 @@ jobs:
           name: jni-binaries
           path: zipline/src/jvmMain/resources/jni
 
-      # Disable jvmTest and native tests because they're run in platform-tests and simulator-tests.
+      # Disable Zipline jvmTest and native tests because they're run in jvm-tests and native-tests.
       - run: >
           ./gradlew
           check
           -x allTests
           -x iosSimulatorArm64Test
           -x iosX64Test
-          -x jvmTest
+          -x :zipline:jvmTest
           -x linuxX64Test
           -x macosArm64Test
           -x macosX64Test
@@ -177,8 +210,8 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs:
-      - platform-tests
-      - simulator-tests
+      - jvm-tests
+      - native-tests
       - check
       - sample-check
       - android-tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ buildscript {
     classpath(libs.cklib.gradle.plugin)
     classpath(libs.sqldelight.gradle.plugin)
     classpath(libs.google.ksp)
+    classpath(libs.testDistributionGradlePlugin)
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ sqldelight-driver-native = { module = "app.cash.sqldelight:native-driver", versi
 sqldelight-driver-sqlite = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version = "3.50.3.0" }
+testDistributionGradlePlugin = "com.jakewharton.gradle:test-distribution-gradle-plugin:0.2.0"
 turbine = { module = "app.cash.turbine:turbine", version = "1.2.1" }
 
 [plugins]

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   id("co.touchlab.cklib")
   id("com.github.gmazzo.buildconfig")
   id("binary-compatibility-validator")
+  id("com.jakewharton.test-distribution")
 }
 
 val copyTestingJs = tasks.register<Copy>("copyTestingJs") {


### PR DESCRIPTION
This lets us run them on different subsets of platforms. Add Linux ARM to JVM tests.