### PR TITLE
Use AGP API to disable host-side tests

### DIFF
--- a/zipline-loader/build.gradle.kts
+++ b/zipline-loader/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -127,20 +128,17 @@ android {
   }
 }
 
+androidComponents {
+  beforeVariants { variant ->
+    variant.hostTests[UNIT_TEST_TYPE]?.enable = false
+  }
+}
+
 sqldelight {
   databases {
     create("Database") {
       packageName.set("app.cash.zipline.loader.internal.cache")
     }
-  }
-}
-
-afterEvaluate {
-  tasks.named("compileDebugUnitTestKotlinAndroid") {
-    enabled = false
-  }
-  tasks.named("compileReleaseUnitTestKotlinAndroid") {
-    enabled = false
   }
 }
 


### PR DESCRIPTION
This will also work in AGP 9, whereas the current approach breaks.