### PR TITLE
Create a wider gap between date captures

### DIFF
--- a/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsJvmTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/QuickJsJvmTest.kt
@@ -55,7 +55,9 @@ class QuickJsJvmTest {
 
   @Test fun dateNow() {
     val beforeMillis = System.currentTimeMillis().toDouble()
+    Thread.sleep(100)
     val nowMillis = quickjs.evaluate("Date.now()") as Double
+    Thread.sleep(100)
     val afterMillis = System.currentTimeMillis().toDouble()
     assertTrue(
       "$beforeMillis <= $nowMillis <= $afterMillis",


### PR DESCRIPTION
This avoids cases where the JVM returns the same timestamp for both captures (on Windows).

    1) dateNow(app.cash.zipline.QuickJsJvmTest)
    java.lang.AssertionError: 1.759945097065E12 <= 1.759945097066E12 <= 1.759945097065E12
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at app.cash.zipline.QuickJsJvmTest.dateNow(QuickJsJvmTest.kt:60)