### PR TITLE
Fix cString and functionList memory leaks

### DIFF
--- a/zipline/src/nativeInterop/cinterop/quickjs.def
+++ b/zipline/src/nativeInterop/cinterop/quickjs.def
@@ -1,6 +1,7 @@
 noStringConversion = \
 	JS_Eval \
-	JS_NewString
+	JS_NewString \
+	JS_FreeCString
 
 ---
 

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -403,6 +403,7 @@ actual class QuickJs private constructor(
       functionList?.let { ptr ->
         nativeHeap.free(ptr)
       }
+      functionList = null
       JS_FreeContext(contextForCompiling)
       JS_FreeContext(context)
       JS_FreeRuntime(runtime)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -20,6 +20,7 @@ package app.cash.zipline
 import app.cash.zipline.internal.bridge.CallChannel
 import app.cash.zipline.internal.bridge.INBOUND_CHANNEL_NAME
 import app.cash.zipline.internal.bridge.OUTBOUND_CHANNEL_NAME
+import app.cash.zipline.quickjs.JSCFunctionListEntry
 import app.cash.zipline.quickjs.JSClassDef
 import app.cash.zipline.quickjs.JSClassIDVar
 import app.cash.zipline.quickjs.JSContext
@@ -103,6 +104,7 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.cstr
+import kotlinx.cinterop.free
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
@@ -160,6 +162,7 @@ actual class QuickJs private constructor(
 
   private var closed = false
   private var outboundChannel: CallChannel? = null
+  private var functionList: CArrayPointer<JSCFunctionListEntry>? = null
 
   internal fun jsInterruptHandler(runtime: CPointer<JSRuntime>?): Int {
     val interruptHandler = interruptHandler ?: return 0
@@ -351,7 +354,7 @@ actual class QuickJs private constructor(
         throwJsException()
       }
 
-      val functionList = nativeHeap.allocArrayOf(
+      functionList = nativeHeap.allocArrayOf(
         JsCallFunction(staticCFunction(::outboundCall)),
         JsDisconnectFunction(staticCFunction(::outboundDisconnect)),
       )
@@ -397,6 +400,9 @@ actual class QuickJs private constructor(
 
   actual override fun close() {
     if (!closed) {
+      functionList?.let { ptr ->
+        nativeHeap.free(ptr)
+      }
       JS_FreeContext(contextForCompiling)
       JS_FreeContext(context)
       JS_FreeRuntime(runtime)

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -33,6 +33,7 @@ import app.cash.zipline.quickjs.JS_EVAL_FLAG_STRICT
 import app.cash.zipline.quickjs.JS_Eval
 import app.cash.zipline.quickjs.JS_EvalFunction
 import app.cash.zipline.quickjs.JS_FreeAtom
+import app.cash.zipline.quickjs.JS_FreeCString
 import app.cash.zipline.quickjs.JS_FreeContext
 import app.cash.zipline.quickjs.JS_FreeRuntime
 import app.cash.zipline.quickjs.JS_FreeValue
@@ -430,7 +431,13 @@ actual class QuickJs private constructor(
   internal fun CValue<JSValue>.toKotlinInstanceOrNull(): Any? {
     return when (JsValueGetNormTag(this)) {
       JS_TAG_EXCEPTION -> throwJsException()
-      JS_TAG_STRING -> JS_ToCString(context, this)!!.toKStringFromUtf8()
+      JS_TAG_STRING -> {
+        val cString = JS_ToCString(context, this)!!
+        val string = cString.toKStringFromUtf8()
+        JS_FreeCString(context, cString)
+        string
+      }
+
       JS_TAG_BOOL -> JsValueGetBool(this) != 0
       JS_TAG_INT -> JsValueGetInt(this)
       JS_TAG_FLOAT64 -> JsValueGetFloat64(this)


### PR DESCRIPTION
This PR closes https://github.com/cashapp/zipline/issues/1746 and #1423.

## Description

This PR fixes 2 memory leaks for the `native` target:
1. `JS_ToCString` call in `CValue<JSValue>.toKotlinInstanceOrNull` allocates memory that is never freed
2. `PropertyFunctionList` passed to QuickJS with `JS_SetPropertyFunctionList` is not deallocated with Kotlin `QuickJs` instance.

## Changelist

1. Deallocate result of `JS_ToCString` in `QuickJs.toKotlinInstanceOrNull` after conversion to a kotlin.String
2. Save pointer for the `PropertyFunctionList` and release it in `QuickJs.close`

## Reproducer
This reproducer now contains the fix as well.
https://github.com/adevone/zipline/pull/2