### PR TITLE
Use fresher manifest between cached and embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
  * Fix: Prevent StackOverflow when serializing recursive class definitions. The serial name
    description now ends when encountering a recursive descriptor.
-
+ * Fix: Embedded code will now be used first if it is fresher than cached network code.
 
 ## [1.25.0] - 2026-01-12
 [1.25.0]: https://github.com/cashapp/zipline/releases/tag/1.25.0

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -22,6 +22,7 @@ import app.cash.zipline.loader.internal.fetcher.FsCachingFetcher
 import app.cash.zipline.loader.internal.fetcher.FsEmbeddedFetcher
 import app.cash.zipline.loader.internal.fetcher.HttpFetcher
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
+import app.cash.zipline.loader.internal.fetcher.LoadedManifestComparator
 import app.cash.zipline.loader.internal.fetcher.fetch
 import app.cash.zipline.loader.internal.getApplicationManifestFileName
 import app.cash.zipline.loader.internal.receiver.FsSaveReceiver
@@ -664,9 +665,15 @@ class ZiplineLoader internal constructor(
     eventListener: EventListener,
     nowEpochMs: Long,
   ): LoadedManifest? {
-    val result = cachingFetcher?.loadPinnedManifest(applicationName, nowEpochMs)
-      ?: embeddedFetcher?.loadEmbeddedManifest(applicationName)
-      ?: return null
+    val pinnedManifest = cachingFetcher?.loadPinnedManifest(applicationName, nowEpochMs)
+    val embeddedManifest = embeddedFetcher?.loadEmbeddedManifest(applicationName)
+
+    // If both are available, pick the freshest of the two
+    val result = if (pinnedManifest != null && embeddedManifest != null) {
+      maxOf(pinnedManifest, embeddedManifest, LoadedManifestComparator)
+    } else {
+      pinnedManifest ?: embeddedManifest ?: return null
+    }
 
     // Defend against changes to the locally-cached copy.
     val verifiedKey = manifestVerifier.verify(result.manifestBytes, result.manifest)

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/LoadedManifest.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/internal/fetcher/LoadedManifest.kt
@@ -49,3 +49,12 @@ internal fun LoadedManifest(manifestBytes: ByteString): LoadedManifest {
     ?: error("freshAtEpochMs is required for loaded manifests, but was null")
   return LoadedManifest(manifestBytes, manifest, freshAtEpochMs)
 }
+
+internal object LoadedManifestComparator : Comparator<LoadedManifest> {
+  override fun compare(
+    a: LoadedManifest,
+    b: LoadedManifest,
+  ): Int {
+    return a.freshAtEpochMs.compareTo(b.freshAtEpochMs)
+  }
+}

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/LoaderTester.kt
@@ -94,7 +94,7 @@ class LoaderTester(
     cache.close()
   }
 
-  fun seedEmbedded(applicationName: String, seed: String) {
+  fun seedEmbedded(applicationName: String, seed: String, freshAtEpochMs: Long = 5L) {
     embeddedFileSystem.createDirectories(embeddedDir)
     val ziplineFileByteString =
       testFixtures.createZiplineFile(LoaderTestFixtures.createJs(seed), "$seed.js")
@@ -102,7 +102,7 @@ class LoaderTester(
     val embeddedManifest = LoaderTestFixtures.createRelativeEmbeddedManifest(
       seed = seed,
       seedFileSha256 = sha256,
-      seedFreshAtEpochMs = 5L,
+      seedFreshAtEpochMs = freshAtEpochMs,
       includeUnknownFieldInJson = includeUnknownFieldInJson,
     )
     embeddedFileSystem.write(embeddedDir / sha256.hex()) {

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -53,6 +53,7 @@ class ZiplineLoaderTest {
   private lateinit var httpClient: FakeZiplineHttpClient
   private lateinit var embeddedFileSystem: FileSystem
   private lateinit var embeddedDir: Path
+  private lateinit var cache: ZiplineCache
 
   private val testFixtures = LoaderTestFixtures()
 
@@ -63,6 +64,7 @@ class ZiplineLoaderTest {
     httpClient = tester.httpClient
     embeddedFileSystem = tester.embeddedFileSystem
     embeddedDir = tester.embeddedDir
+    cache = tester.cache
   }
 
   @AfterTest
@@ -408,6 +410,32 @@ class ZiplineLoaderTest {
       )
       awaitComplete()
     }
+  }
+
+  @Test
+  fun freshestCachedOrEmbeddedManifestTakesPrecedence() = runBlocking {
+    cache.pinManifest("test", LoadedManifest(testFixtures.manifestByteString, freshAtEpochMs = 25L), tester.nowMillis)
+
+    // Embedded code is fresher than cached code
+    tester.seedEmbedded("test", "test", freshAtEpochMs = 100L)
+
+    val zipline = (
+      loader.loadOnce(
+        applicationName = "test",
+        freshnessChecker = FakeFreshnessCheckerFresh,
+        manifestUrl = MANIFEST_URL,
+      ) as LoadResult.Success
+      ).zipline
+
+    // Loaded the embedded "test" code, not the cached "alpha/bravo" code
+    assertEquals(
+      """
+      |test loaded
+      |
+      """.trimMargin(),
+      zipline.getLog(),
+    )
+    zipline.close()
   }
 
   @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") // Access :zipline-loader internals.


### PR DESCRIPTION
Previously a cached manifest would _always_ take precedence over any embedded manifests.

In practice we often have users who don't open the app for months, but whose app does update in the background from their app store. Their app launch experience is bad because the loader chooses to load potentially months-old code instead of the embedded code that may be very fresh.