### PR TITLE
Track compiler plugin API deprecation

### DIFF
--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineCompilerPluginRegistrar.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/ZiplineCompilerPluginRegistrar.kt
@@ -16,10 +16,10 @@
 package app.cash.zipline.kotlin
 
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
 @OptIn(ExperimentalCompilerApi::class)
@@ -29,7 +29,7 @@ class ZiplineCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
     val messageCollector = configuration.get(
-      CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+      CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
       MessageCollector.NONE,
     )
     IrGenerationExtension.registerExtension(


### PR DESCRIPTION
This becomes an error in Kotlin 2.3.20.