### PR TITLE
Disable gradle parallel builds on native tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
           distribution: 'zulu'
           java-version-file: .github/workflows/.java-version
 
-      - run: ./gradlew ${{ matrix.platform.task }}
+      - run: ./gradlew ${{ matrix.platform.task }} --no-parallel --max-workers=1
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}


### PR DESCRIPTION
Maybe fix a concurrent modification exception?