### PR TITLE
Guard ZiplineCache against use-after-close crashes

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -20,6 +20,7 @@ import app.cash.zipline.loader.internal.cache.Database
 import app.cash.zipline.loader.internal.cache.FileState
 import app.cash.zipline.loader.internal.cache.Files
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
+import kotlin.concurrent.Volatile
 import app.cash.zipline.loader.internal.cache.createDatabase
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
 import okio.ByteString
@@ -51,6 +52,7 @@ class ZiplineCache private constructor(
   private val maxSizeInBytes: Long,
   private val loaderEventListener: LoaderEventListener,
   private var hasWriteFailures: Boolean,
+  @Volatile private var closed: Boolean = false,
 ) : Closeable {
 
   /*
@@ -77,6 +79,7 @@ class ZiplineCache private constructor(
    */
 
   override fun close() {
+    closed = true
     driver.close()
   }
 
@@ -119,7 +122,7 @@ class ZiplineCache private constructor(
     nowEpochMs: Long,
     download: suspend () -> ByteString,
   ): ByteString {
-    if (hasWriteFailures) return download()
+    if (hasWriteFailures || closed) return download()
 
     try {
       val read = read(sha256, nowEpochMs)
@@ -169,6 +172,7 @@ class ZiplineCache private constructor(
     sha256: ByteString,
     nowEpochMs: Long,
   ): ByteString? {
+    if (closed) return null
     val metadata = database.filesQueries.get(sha256.hex()).executeAsOneOrNull() ?: return null
     return read(metadata, nowEpochMs)
   }
@@ -209,13 +213,14 @@ class ZiplineCache private constructor(
   }
 
   internal fun unpin(applicationName: String, sha256: ByteString) {
+    if (closed) return
     val fileId = database.filesQueries.get(sha256.hex()).executeAsOneOrNull()?.id ?: return
     database.pinsQueries.delete_pin(applicationName, fileId)
   }
 
   /** Returns null if there is no pinned manifest. */
   internal fun getPinnedManifest(applicationName: String, nowEpochMs: Long): LoadedManifest? {
-    if (hasWriteFailures) return null // This cache is broken.
+    if (hasWriteFailures || closed) return null // This cache is broken.
 
     try {
       val manifestFile = database.filesQueries
@@ -236,7 +241,7 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures) return // This cache is broken.
+    if (hasWriteFailures || closed) return // This cache is broken.
 
     try {
       val manifestBytes = loadedManifest.manifestBytes
@@ -275,7 +280,7 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures) return // This cache is broken.
+    if (hasWriteFailures || closed) return // This cache is broken.
 
     try {
       val unpinManifestBytes = loadedManifest.manifestBytes
@@ -463,7 +468,7 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures) return // This cache is broken.
+    if (hasWriteFailures || closed) return // This cache is broken.
 
     try {
       val freshAtMs = loadedManifest.freshAtEpochMs

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -20,9 +20,9 @@ import app.cash.zipline.loader.internal.cache.Database
 import app.cash.zipline.loader.internal.cache.FileState
 import app.cash.zipline.loader.internal.cache.Files
 import app.cash.zipline.loader.internal.cache.SqlDriverFactory
-import kotlin.concurrent.Volatile
 import app.cash.zipline.loader.internal.cache.createDatabase
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
+import kotlin.concurrent.Volatile
 import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import okio.Closeable
@@ -52,8 +52,9 @@ class ZiplineCache private constructor(
   private val maxSizeInBytes: Long,
   private val loaderEventListener: LoaderEventListener,
   private var hasWriteFailures: Boolean,
-  @Volatile private var closed: Boolean = false,
 ) : Closeable {
+
+  @Volatile private var closed: Boolean = false
 
   /*
    * Files are named by their SHA-256 hashes. We use a SQLite database for file metadata: which
@@ -441,6 +442,7 @@ class ZiplineCache private constructor(
    * have opened them.
    */
   internal fun prune(maxSizeInBytes: Long = this.maxSizeInBytes) {
+    if (closed) return
     while (true) {
       val currentSize = database.filesQueries.selectCacheSumBytes().executeAsOne().SUM ?: 0L
       if (currentSize <= maxSizeInBytes) return
@@ -453,10 +455,16 @@ class ZiplineCache private constructor(
   }
 
   /** Returns the number of files in the cache DB. */
-  internal fun countFiles() = database.filesQueries.count().executeAsOne().toInt()
+  internal fun countFiles(): Int {
+    if (closed) return 0
+    return database.filesQueries.count().executeAsOne().toInt()
+  }
 
   /** Returns the number of pins in the cache DB. */
-  internal fun countPins() = database.pinsQueries.count().executeAsOne().toInt()
+  internal fun countPins(): Int {
+    if (closed) return 0
+    return database.pinsQueries.count().executeAsOne().toInt()
+  }
 
   private fun path(metadata: Files): Path = directory / "entry-${metadata.id}.bin"
 

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -91,14 +91,14 @@ class ZiplineCache private constructor(
     nowEpochMs: Long,
     isManifest: Boolean = false,
     manifestFreshAtMs: Long? = null,
-  ): Files {
+  ): Files? {
     val metadata = openForWrite(
       applicationName = applicationName,
       sha256 = sha256,
       nowEpochMs = nowEpochMs,
       isManifest = isManifest,
       manifestFreshAtMs = manifestFreshAtMs,
-    )
+    ) ?: return null
     write(metadata, content, nowEpochMs)
     return metadata
   }
@@ -156,7 +156,7 @@ class ZiplineCache private constructor(
     content: ByteString,
     putFreshAtMs: Long,
     nowEpochMs: Long,
-  ): Files {
+  ): Files? {
     val sha256 = content.sha256()
     val metadata = getOrNull(sha256)
     return metadata ?: write(
@@ -251,7 +251,7 @@ class ZiplineCache private constructor(
         content = manifestBytes,
         putFreshAtMs = loadedManifest.freshAtEpochMs,
         nowEpochMs = nowEpochMs,
-      )
+      ) ?: return
 
       database.transaction {
         database.pinsQueries.delete_application_pins(applicationName)
@@ -330,7 +330,8 @@ class ZiplineCache private constructor(
     nowEpochMs: Long,
     isManifest: Boolean,
     manifestFreshAtMs: Long? = null,
-  ): Files {
+  ): Files? {
+    if (closed) return null
     val manifestForApplicationName = if (isManifest) {
       applicationName
     } else {
@@ -381,6 +382,7 @@ class ZiplineCache private constructor(
     fileSizeBytes: Long,
     nowEpochMs: Long,
   ) {
+    if (closed) return
     database.transaction {
       // Go from DIRTY to READY.
       require(getOrNull(metadata.id)?.file_state == FileState.DIRTY) {
@@ -485,7 +487,7 @@ class ZiplineCache private constructor(
         content = loadedManifest.manifestBytes,
         putFreshAtMs = freshAtMs,
         nowEpochMs = nowEpochMs,
-      )
+      ) ?: return
       database.filesQueries.updateFresh(
         id = manifestMetadata.id,
         fresh_at_epoch_ms = freshAtMs,

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheTest.kt
@@ -339,6 +339,89 @@ class ZiplineCacheTest {
   }
 
   @Test
+  fun readReturnsNullAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileContents = "abc123".encodeUtf8()
+      val fileSha = fileContents.sha256()
+
+      cache.getOrPut("app1", fileSha, nowMillis) { fileContents }
+      assertEquals(fileContents, cache.read(fileSha))
+
+      cache.close()
+      assertNull(cache.read(fileSha))
+    }
+  }
+
+  @Test
+  fun getOrPutFallsBackToDownloadAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileContents = "abc123".encodeUtf8()
+      val fileSha = fileContents.sha256()
+
+      cache.getOrPut("app1", fileSha, nowMillis) { fileContents }
+
+      cache.close()
+      var downloadCalled = false
+      val result = cache.getOrPut("app1", fileSha, nowMillis) {
+        downloadCalled = true
+        fileContents
+      }
+      assertTrue(downloadCalled)
+      assertEquals(fileContents, result)
+    }
+  }
+
+  @Test
+  fun unpinIsNoOpAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileContents = "abc123".encodeUtf8()
+      val fileSha = fileContents.sha256()
+
+      cache.getOrPut("app1", fileSha, nowMillis) { fileContents }
+
+      cache.close()
+      cache.unpin("app1", fileSha) // Should be a no-op, not a crash.
+    }
+  }
+
+  @Test
+  fun getPinnedManifestReturnsNullAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileApple = testFixtures.createZiplineFile(createJs("apple"), "apple.js")
+      cache.getOrPut("red", fileApple.sha256(), nowMillis) { fileApple }
+      val manifestApple = createRelativeManifest("apple", fileApple.sha256())
+      cache.pinManifest("red", manifestApple, nowMillis)
+      assertNotNull(cache.getPinnedManifest("red", nowMillis))
+
+      cache.close()
+      assertNull(cache.getPinnedManifest("red", nowMillis))
+    }
+  }
+
+  @Test
+  fun pinManifestIsNoOpAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileApple = testFixtures.createZiplineFile(createJs("apple"), "apple.js")
+      cache.getOrPut("red", fileApple.sha256(), nowMillis) { fileApple }
+      val manifestApple = createRelativeManifest("apple", fileApple.sha256())
+
+      cache.close()
+      cache.pinManifest("red", manifestApple, nowMillis) // Should be a no-op, not a crash.
+    }
+  }
+
+  @Test
+  fun updateManifestFreshAtIsNoOpAfterClose(): Unit = runBlocking {
+    withCache { cache ->
+      val fileContents = testFixtures.manifestByteString
+      cache.pinManifest("red", LoadedManifest(fileContents, 5), nowMillis)
+
+      cache.close()
+      cache.updateManifestFreshAt("red", LoadedManifest(fileContents, 10), nowMillis)
+    }
+  }
+
+  @Test
   fun manifestFreshAtMs(): Unit = runBlocking {
     val fileContents = testFixtures.manifestByteString
 


### PR DESCRIPTION
## Summary

- Adds a `@Volatile` `closed` flag to `ZiplineCache` (as a class body property, not a constructor parameter) that is set **before** the SQLite driver is closed, ensuring visibility to concurrent threads
- Guards all database-accessing methods to bail out gracefully when the cache is closed:
  - `getOrPut` — falls back to `download()`
  - `read` — returns `null`
  - `unpin` — no-op
  - `getPinnedManifest` — returns `null`
  - `pinManifest` — no-op
  - `unpinManifest` — no-op
  - `updateManifestFreshAt` — no-op
  - `prune` — no-op
  - `countFiles` — returns `0`
  - `countPins` — returns `0`
- Prevents `sqlite3_reset` from being called on a destroyed connection when concurrent coroutines race against cache closure (root cause of iOS use-after-free crashes)

The pattern follows the existing `hasWriteFailures` guard — methods that already checked `hasWriteFailures` now also check `closed`, and methods without existing guards get standalone `if (closed)` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)