### PR TITLE
Fix EXC_BAD_ACCESS when ZiplineCache is closed during an in-flight query

### DIFF
--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt
@@ -23,6 +23,9 @@ import app.cash.zipline.loader.internal.cache.SqlDriverFactory
 import app.cash.zipline.loader.internal.cache.createDatabase
 import app.cash.zipline.loader.internal.fetcher.LoadedManifest
 import kotlin.concurrent.Volatile
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.SynchronizedObject
+import kotlinx.coroutines.internal.synchronized
 import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import okio.Closeable
@@ -42,8 +45,13 @@ import okio.Path
  * the cache and behavior is undefined.
  *
  * If multiple threads in a single process operate on a cache instance simultaneously, downloads may
- * be repeated but no thread will be blocked.
+ * be repeated but they won't block each other on the database. [close] is also safe to call
+ * concurrently with an in-flight operation: it acquires [lock], so it waits for any operation
+ * already touching the database to finish before it closes the [driver]. This prevents a
+ * use-after-free crash where the native SQLite driver is torn down while another thread is mid-query
+ * (for example, when the cache is closed during sign-out while a code load is still in flight).
  */
+@OptIn(InternalCoroutinesApi::class)
 class ZiplineCache private constructor(
   private val driver: SqlDriver,
   private val database: Database,
@@ -55,6 +63,13 @@ class ZiplineCache private constructor(
 ) : Closeable {
 
   @Volatile private var closed: Boolean = false
+
+  /**
+   * Guards all access to [driver] and [database], including [close]. This ensures the driver is
+   * never closed while another thread is executing a query against it. It is reentrant, so an
+   * operation that calls into another guarded operation won't deadlock.
+   */
+  private val lock = SynchronizedObject()
 
   /*
    * Files are named by their SHA-256 hashes. We use a SQLite database for file metadata: which
@@ -80,8 +95,10 @@ class ZiplineCache private constructor(
    */
 
   override fun close() {
-    closed = true
-    driver.close()
+    synchronized(lock) {
+      closed = true
+      driver.close()
+    }
   }
 
   private fun write(
@@ -92,15 +109,17 @@ class ZiplineCache private constructor(
     isManifest: Boolean = false,
     manifestFreshAtMs: Long? = null,
   ): Files? {
-    val metadata = openForWrite(
-      applicationName = applicationName,
-      sha256 = sha256,
-      nowEpochMs = nowEpochMs,
-      isManifest = isManifest,
-      manifestFreshAtMs = manifestFreshAtMs,
-    ) ?: return null
-    write(metadata, content, nowEpochMs)
-    return metadata
+    return synchronized(lock) {
+      val metadata = openForWrite(
+        applicationName = applicationName,
+        sha256 = sha256,
+        nowEpochMs = nowEpochMs,
+        isManifest = isManifest,
+        manifestFreshAtMs = manifestFreshAtMs,
+      ) ?: return null
+      write(metadata, content, nowEpochMs)
+      metadata
+    }
   }
 
   private fun write(metadata: Files, content: ByteString, nowEpochMs: Long) {
@@ -173,9 +192,11 @@ class ZiplineCache private constructor(
     sha256: ByteString,
     nowEpochMs: Long,
   ): ByteString? {
-    if (closed) return null
-    val metadata = database.filesQueries.get(sha256.hex()).executeAsOneOrNull() ?: return null
-    return read(metadata, nowEpochMs)
+    return synchronized(lock) {
+      if (closed) return null
+      val metadata = database.filesQueries.get(sha256.hex()).executeAsOneOrNull() ?: return null
+      read(metadata, nowEpochMs)
+    }
   }
 
   private fun read(
@@ -214,25 +235,29 @@ class ZiplineCache private constructor(
   }
 
   internal fun unpin(applicationName: String, sha256: ByteString) {
-    if (closed) return
-    val fileId = database.filesQueries.get(sha256.hex()).executeAsOneOrNull()?.id ?: return
-    database.pinsQueries.delete_pin(applicationName, fileId)
+    synchronized(lock) {
+      if (closed) return
+      val fileId = database.filesQueries.get(sha256.hex()).executeAsOneOrNull()?.id ?: return
+      database.pinsQueries.delete_pin(applicationName, fileId)
+    }
   }
 
   /** Returns null if there is no pinned manifest. */
   internal fun getPinnedManifest(applicationName: String, nowEpochMs: Long): LoadedManifest? {
-    if (hasWriteFailures || closed) return null // This cache is broken.
+    return synchronized(lock) {
+      if (hasWriteFailures || closed) return null // This cache is broken.
 
-    try {
-      val manifestFile = database.filesQueries
-        .selectPinnedManifest(applicationName)
-        .executeAsOneOrNull() ?: return null
-      val manifestBytes = read(manifestFile, nowEpochMs) ?: return null
-      return LoadedManifest(manifestBytes, manifestFile.fresh_at_epoch_ms!!)
-    } catch (e: Exception) {
-      hasWriteFailures = true // Mark this cache as broken.
-      loaderEventListener.cacheStorageFailed(applicationName, e)
-      return null
+      try {
+        val manifestFile = database.filesQueries
+          .selectPinnedManifest(applicationName)
+          .executeAsOneOrNull() ?: return null
+        val manifestBytes = read(manifestFile, nowEpochMs) ?: return null
+        LoadedManifest(manifestBytes, manifestFile.fresh_at_epoch_ms!!)
+      } catch (e: Exception) {
+        hasWriteFailures = true // Mark this cache as broken.
+        loaderEventListener.cacheStorageFailed(applicationName, e)
+        null
+      }
     }
   }
 
@@ -242,33 +267,35 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures || closed) return // This cache is broken.
+    synchronized(lock) {
+      if (hasWriteFailures || closed) return // This cache is broken.
 
-    try {
-      val manifestBytes = loadedManifest.manifestBytes
-      val manifestMetadata = getOrPutManifest(
-        applicationName = applicationName,
-        content = manifestBytes,
-        putFreshAtMs = loadedManifest.freshAtEpochMs,
-        nowEpochMs = nowEpochMs,
-      ) ?: return
+      try {
+        val manifestBytes = loadedManifest.manifestBytes
+        val manifestMetadata = getOrPutManifest(
+          applicationName = applicationName,
+          content = manifestBytes,
+          putFreshAtMs = loadedManifest.freshAtEpochMs,
+          nowEpochMs = nowEpochMs,
+        ) ?: return
 
-      database.transaction {
-        database.pinsQueries.delete_application_pins(applicationName)
+        database.transaction {
+          database.pinsQueries.delete_application_pins(applicationName)
 
-        // Pin all modules in this manifest.
-        loadedManifest.manifest.modules.forEach { (_, module) ->
-          database.filesQueries.get(module.sha256.hex()).executeAsOneOrNull()?.let { metadata ->
-            createPinIfNotExists(applicationName, metadata.id)
+          // Pin all modules in this manifest.
+          loadedManifest.manifest.modules.forEach { (_, module) ->
+            database.filesQueries.get(module.sha256.hex()).executeAsOneOrNull()?.let { metadata ->
+              createPinIfNotExists(applicationName, metadata.id)
+            }
           }
-        }
 
-        // Pin the manifest.
-        createPinIfNotExists(applicationName, manifestMetadata.id)
+          // Pin the manifest.
+          createPinIfNotExists(applicationName, manifestMetadata.id)
+        }
+      } catch (e: Exception) {
+        hasWriteFailures = true // Mark this cache as broken.
+        loaderEventListener.cacheStorageFailed(applicationName, e)
       }
-    } catch (e: Exception) {
-      hasWriteFailures = true // Mark this cache as broken.
-      loaderEventListener.cacheStorageFailed(applicationName, e)
     }
   }
 
@@ -281,42 +308,44 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures || closed) return // This cache is broken.
+    synchronized(lock) {
+      if (hasWriteFailures || closed) return // This cache is broken.
 
-    try {
-      val unpinManifestBytes = loadedManifest.manifestBytes
-      val unpinManifestFile = database.filesQueries
-        .get(unpinManifestBytes.sha256().hex())
-        .executeAsOneOrNull()
-
-      // Get fallback manifest metadata.
-      val fallbackManifestFile: Files? = unpinManifestFile?.let {
-        database.filesQueries
-          .selectPinnedManifestNotFileId(applicationName, it.id)
+      try {
+        val unpinManifestBytes = loadedManifest.manifestBytes
+        val unpinManifestFile = database.filesQueries
+          .get(unpinManifestBytes.sha256().hex())
           .executeAsOneOrNull()
-      } ?: database.filesQueries
-        .selectPinnedManifest(applicationName)
-        .executeAsOneOrNull()
 
-      // There is no fallback manifest, delete all pins and return.
-      if (fallbackManifestFile == null) {
-        database.pinsQueries.delete_application_pins(applicationName)
-        return
-      }
+        // Get fallback manifest metadata.
+        val fallbackManifestFile: Files? = unpinManifestFile?.let {
+          database.filesQueries
+            .selectPinnedManifestNotFileId(applicationName, it.id)
+            .executeAsOneOrNull()
+        } ?: database.filesQueries
+          .selectPinnedManifest(applicationName)
+          .executeAsOneOrNull()
 
-      // Pin the fallback manifest, which removes all pins prior to pinning.
-      val fallbackManifestBytes = read(fallbackManifestFile, nowEpochMs)
-        ?: throw FileNotFoundException(
-          "No manifest file on disk with [fileName=${fallbackManifestFile.sha256_hex}]",
+        // There is no fallback manifest, delete all pins and return.
+        if (fallbackManifestFile == null) {
+          database.pinsQueries.delete_application_pins(applicationName)
+          return
+        }
+
+        // Pin the fallback manifest, which removes all pins prior to pinning.
+        val fallbackManifestBytes = read(fallbackManifestFile, nowEpochMs)
+          ?: throw FileNotFoundException(
+            "No manifest file on disk with [fileName=${fallbackManifestFile.sha256_hex}]",
+          )
+        val fallbackManifest = LoadedManifest(
+          fallbackManifestBytes,
+          fallbackManifestFile.fresh_at_epoch_ms!!,
         )
-      val fallbackManifest = LoadedManifest(
-        fallbackManifestBytes,
-        fallbackManifestFile.fresh_at_epoch_ms!!,
-      )
-      pinManifest(applicationName, fallbackManifest, nowEpochMs)
-    } catch (e: Exception) {
-      hasWriteFailures = true // Mark this cache as broken.
-      loaderEventListener.cacheStorageFailed(applicationName, e)
+        pinManifest(applicationName, fallbackManifest, nowEpochMs)
+      } catch (e: Exception) {
+        hasWriteFailures = true // Mark this cache as broken.
+        loaderEventListener.cacheStorageFailed(applicationName, e)
+      }
     }
   }
 
@@ -417,12 +446,14 @@ class ZiplineCache private constructor(
    * It will also delete dirty files that were open when the previous run completed.
    */
   private fun initialize() {
-    try {
-      deleteDirtyFiles()
-      prune()
-    } catch (e: Exception) {
-      hasWriteFailures = true // Mark this cache as broken.
-      loaderEventListener.cacheStorageFailed(null, e)
+    synchronized(lock) {
+      try {
+        deleteDirtyFiles()
+        prune()
+      } catch (e: Exception) {
+        hasWriteFailures = true // Mark this cache as broken.
+        loaderEventListener.cacheStorageFailed(null, e)
+      }
     }
   }
 
@@ -444,28 +475,34 @@ class ZiplineCache private constructor(
    * have opened them.
    */
   internal fun prune(maxSizeInBytes: Long = this.maxSizeInBytes) {
-    if (closed) return
-    while (true) {
-      val currentSize = database.filesQueries.selectCacheSumBytes().executeAsOne().SUM ?: 0L
-      if (currentSize <= maxSizeInBytes) return
+    synchronized(lock) {
+      if (closed) return
+      while (true) {
+        val currentSize = database.filesQueries.selectCacheSumBytes().executeAsOne().SUM ?: 0L
+        if (currentSize <= maxSizeInBytes) return
 
-      val toDelete = database.filesQueries.selectOldestReady().executeAsOneOrNull() ?: return
+        val toDelete = database.filesQueries.selectOldestReady().executeAsOneOrNull() ?: return
 
-      fileSystem.delete(path(toDelete))
-      database.filesQueries.delete(toDelete.id)
+        fileSystem.delete(path(toDelete))
+        database.filesQueries.delete(toDelete.id)
+      }
     }
   }
 
   /** Returns the number of files in the cache DB. */
   internal fun countFiles(): Int {
-    if (closed) return 0
-    return database.filesQueries.count().executeAsOne().toInt()
+    return synchronized(lock) {
+      if (closed) return 0
+      database.filesQueries.count().executeAsOne().toInt()
+    }
   }
 
   /** Returns the number of pins in the cache DB. */
   internal fun countPins(): Int {
-    if (closed) return 0
-    return database.pinsQueries.count().executeAsOne().toInt()
+    return synchronized(lock) {
+      if (closed) return 0
+      database.pinsQueries.count().executeAsOne().toInt()
+    }
   }
 
   private fun path(metadata: Files): Path = directory / "entry-${metadata.id}.bin"
@@ -478,23 +515,25 @@ class ZiplineCache private constructor(
     loadedManifest: LoadedManifest,
     nowEpochMs: Long,
   ) {
-    if (hasWriteFailures || closed) return // This cache is broken.
+    synchronized(lock) {
+      if (hasWriteFailures || closed) return // This cache is broken.
 
-    try {
-      val freshAtMs = loadedManifest.freshAtEpochMs
-      val manifestMetadata = getOrPutManifest(
-        applicationName = applicationName,
-        content = loadedManifest.manifestBytes,
-        putFreshAtMs = freshAtMs,
-        nowEpochMs = nowEpochMs,
-      ) ?: return
-      database.filesQueries.updateFresh(
-        id = manifestMetadata.id,
-        fresh_at_epoch_ms = freshAtMs,
-      )
-    } catch (e: Exception) {
-      hasWriteFailures = true // Mark this cache as broken.
-      loaderEventListener.cacheStorageFailed(applicationName, e)
+      try {
+        val freshAtMs = loadedManifest.freshAtEpochMs
+        val manifestMetadata = getOrPutManifest(
+          applicationName = applicationName,
+          content = loadedManifest.manifestBytes,
+          putFreshAtMs = freshAtMs,
+          nowEpochMs = nowEpochMs,
+        ) ?: return
+        database.filesQueries.updateFresh(
+          id = manifestMetadata.id,
+          fresh_at_epoch_ms = freshAtMs,
+        )
+      } catch (e: Exception) {
+        hasWriteFailures = true // Mark this cache as broken.
+        loaderEventListener.cacheStorageFailed(applicationName, e)
+      }
     }
   }
 

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheConcurrencyTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheConcurrencyTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2024 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.zipline.loader.internal.cache
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.zipline.loader.LoaderEventListener
+import app.cash.zipline.loader.ZiplineCache
+import app.cash.zipline.loader.randomToken
+import app.cash.zipline.loader.testSqlDriverFactory
+import app.cash.zipline.testing.systemFileSystem
+import kotlin.concurrent.Volatile
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okio.ByteString.Companion.encodeUtf8
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Regression test for a use-after-free crash (EXC_BAD_ACCESS in `sqlite3_reset`) that happened when
+ * [ZiplineCache.close] tore down the SQLite driver while another thread was still executing a query
+ * against it. On iOS this raced during sign-out: the Treehouse/Zipline cache was closed while a code
+ * load was still reading from the cache on a background worker thread.
+ *
+ * [ZiplineCache.close] must acquire the same lock as the database operations, so it waits for any
+ * in-flight operation to finish before closing the driver.
+ */
+class ZiplineCacheConcurrencyTest {
+  private val fileSystem = systemFileSystem
+  private val directory = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "okio-${randomToken().hex()}"
+
+  @Test
+  fun closeWaitsForInFlightDatabaseOperation(): Unit = runBlocking {
+    fileSystem.createDirectories(directory)
+
+    val instrumentedDriver = InstrumentedDriver(
+      testSqlDriverFactory().create(
+        path = directory / "zipline.db",
+        schema = Database.Schema,
+      ),
+    )
+    val cache = ZiplineCache(
+      sqlDriverFactory = object : SqlDriverFactory {
+        override fun create(path: Path, schema: SqlSchema<QueryResult.Value<Unit>>) =
+          instrumentedDriver
+      },
+      fileSystem = fileSystem,
+      directory = directory,
+      maxSizeInBytes = 1024L,
+      loaderEventListener = LoaderEventListener.None,
+    )
+
+    // Seed the cache with a readable entry. Instrumentation is off for this.
+    val fileContents = "abc123".encodeUtf8()
+    val fileSha = fileContents.sha256()
+    cache.getOrPut("app1", fileSha, 1_000L) { fileContents }
+
+    // Arm the instrumentation so the next query holds the database "in flight" long enough for a
+    // concurrent close() to race with it.
+    instrumentedDriver.blockNextQuery = true
+
+    // Run a read on a background thread; it will enter the driver and stay there for ~2s.
+    val readJob = launch(Dispatchers.Default) {
+      cache.read(fileSha, 1_000L)
+    }
+
+    // Wait until the read is actually executing inside the driver.
+    val spinUntil = TimeSource.Monotonic.markNow()
+    while (!instrumentedDriver.queryInFlight && spinUntil.elapsedNow() < 10.seconds) {
+      // Busy-wait for the background read to reach the driver.
+    }
+    assertTrue(instrumentedDriver.queryInFlight, "the background read never reached the driver")
+
+    // Close the cache while the read is still in flight. With the fix this blocks until the read
+    // completes; without it, the driver is closed from under the in-flight query.
+    cache.close()
+
+    assertFalse(
+      instrumentedDriver.closedWhileQueryInFlight,
+      "driver was closed while a query was still executing (use-after-free)",
+    )
+
+    readJob.join()
+  }
+
+  /**
+   * Delegates to a real [SqlDriver] but can hold a single query "in flight" and records whether
+   * [close] was ever called while a query was executing.
+   */
+  private class InstrumentedDriver(
+    private val delegate: SqlDriver,
+  ) : SqlDriver by delegate {
+    @Volatile var blockNextQuery = false
+    @Volatile var queryInFlight = false
+    @Volatile var closedWhileQueryInFlight = false
+
+    override fun <R> executeQuery(
+      identifier: Int?,
+      sql: String,
+      mapper: (SqlCursor) -> QueryResult<R>,
+      parameters: Int,
+      binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> {
+      if (!blockNextQuery) {
+        return delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+      }
+      blockNextQuery = false
+      queryInFlight = true
+      try {
+        val start = TimeSource.Monotonic.markNow()
+        while (start.elapsedNow() < 2.seconds) {
+          // Keep the query "executing" to widen the race window.
+        }
+        return delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+      } finally {
+        queryInFlight = false
+      }
+    }
+
+    override fun close() {
+      if (queryInFlight) closedWhileQueryInFlight = true
+      delegate.close()
+    }
+  }
+}


### PR DESCRIPTION
## Crash Info
| Field | Value |
|-------|-------|
| Error Class | `EXC_BAD_ACCESS` |
| Message | Attempted to dereference garbage pointer 0x400000000. |
| Platform | ios |
| Severity | error |

> Fixing the crash at its source. The crash was observed in the Cash iOS app,
> but every frame is in the Zipline library, so the fix belongs here in
> `cashapp/zipline`.

## Root Cause
`ZiplineCache.close()` closed the SQLite `SqlDriver` without any synchronization
against in-flight database operations. All cache database access is serialized on a
single-threaded cache dispatcher, but `close()` is invoked directly from the host
thread and bypasses that serialization. On iOS this raced during **sign-out**: the
Treehouse/Zipline cache was closed while a code load was still executing a query on a
background worker thread (`FsCachingFetcher.fetch` → `ZiplineCache.getOrPut` →
`read` → `FilesQueries.GetQuery.execute`). `driver.close()` finalized/freed the native
SQLite prepared statements while another thread was mid-query, so `sqlite3_reset`
dereferenced freed memory → `EXC_BAD_ACCESS`. The `@Volatile closed` flag did not
prevent this: it is a time-of-check/time-of-use race — a thread can pass the
`if (closed) …` guard and enter `executeAsOneOrNull()` just before `close()` sets the
flag and tears down the driver.

## Fix
Added a single reentrant lock (`kotlinx.coroutines.internal.SynchronizedObject`) that
guards **all** access to `driver`/`database`, including `close()`. Because `close()`
now acquires the same lock as every database operation, it waits for any in-flight
operation to finish before closing the driver, so the native SQLite objects are never
freed from under an executing query. The lock is reentrant, so operations that call
into other guarded operations (e.g. `pinManifest` → `write`, `getPinnedManifest` →
`read`) don't deadlock. The suspending `getOrPut` still runs its `download()` outside
the lock (only its discrete `read`/`write` database steps are guarded), so downloads
are not serialized and no coroutine blocks across a suspension point.

### Files Changed
- `zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineCache.kt` — guard `close()` and every database-touching method with a reentrant `lock`.
- `zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/internal/cache/ZiplineCacheConcurrencyTest.kt` — regression test: `close()` must wait for an in-flight query instead of tearing down the driver under it.

## Stacktrace (from crash reports)
```
_sqlite3_reset (/usr/lib/libsqlite3.dylib)
co.touchlab.sqliter.interop.ActualSqliteStatement#resetStatement
app.cash.sqldelight.driver.native.NativeSqliteDriver#accessConnection
app.cash.sqldelight.driver.native.ConnectionWrapper#executeQuery
app.cash.zipline.loader.internal.cache.FilesQueries.GetQuery.execute
app.cash.sqldelight.ExecutableQuery#executeAsOneOrNull
app.cash.zipline.loader.ZiplineCache.$getOrPutCOROUTINE$0.invokeSuspend
app.cash.zipline.loader.internal.fetcher.FsCachingFetcher.FsCachingFetcher$fetch$2 …
kotlinx.coroutines.MultiWorkerDispatcher$workerRunLoop$1 …  (background worker thread)
```
Breadcrumbs immediately before the crash show a sign-out/cleanup sequence
(`EntitySyncer … clearData`, `SyncEntity Sync Wipe reason:"LOGOUT"`,
`… became invalidated as part of sign out cleanup`), consistent with the cache being
closed on the host thread while a load was still in flight.

## Testing
- [ ] Added `ZiplineCacheConcurrencyTest.closeWaitsForInFlightDatabaseOperation`: a background thread holds a query "in flight" inside an instrumented `SqlDriver` while the main thread calls `close()`. It asserts the driver is never closed while a query is executing. This fails before the fix (close tears the driver down mid-query) and passes after. **Could not be executed in the fix environment** (no Gradle distribution download / no Android SDK), so it was verified by construction and code review, not a live run.
- [ ] No public API change (private field + unchanged method signatures), so `binary-compatibility-validator` `.api` files are unaffected.

## Review Guidance
- Key invariant: `driver.close()` must never run concurrently with any `database.*`
  access. Verify every method that touches `driver`/`database` acquires `lock`
  (`close`, `read`, `write`, `unpin`, `getPinnedManifest`, `pinManifest`,
  `unpinManifest`, `updateManifestFreshAt`, `prune`, `countFiles`, `countPins`,
  `initialize`); the private helpers (`read(metadata)`, `openForWrite`, `setReady`,
  `getOrNull`, `getOrPutManifest`, `createPinIfNotExists`, `deleteDirtyFiles`) are only
  ever reached from a guarded caller.
- `getOrPut` intentionally is not wrapped as a whole — only its `read`/`write` steps
  are guarded — so the network `download()` doesn't hold the lock.
- Regression signal: any new `driver`/`database` access added outside `synchronized(lock)`
  reopens the race.
- Uses `kotlinx.coroutines.internal.SynchronizedObject` (already an `api` dependency via
  `kotlinx-coroutines-core`) behind `@OptIn(InternalCoroutinesApi::class)`; it is
  reentrant on both JVM and native. If you'd prefer to avoid the internal coroutines API,
  swap in an `atomicfu` `reentrantLock()` — the guarding structure is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

