### PR TITLE
Run Dokka in pull request checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,6 +140,7 @@ jobs:
       - run: >
           ./gradlew
           check
+          :dokkaHtmlMultiModule
           -x allTests
           -x iosSimulatorArm64Test
           -x iosX64Test


### PR DESCRIPTION
Fixes #1763

## Summary

- Run the full multi-module Dokka task in the existing pull-request check job.
- Catch documentation failures under the same configured JDK before tagged releases.

## Validation

- `ANDROID_HOME=/Users/arpitagarwal/Library/Android/sdk ./gradlew :dokkaHtmlMultiModule`
- Parsed the workflow YAML and verified the check job includes `:dokkaHtmlMultiModule`
- `git diff --check`
