### PR TITLE
Drain QuickJS's Promise job queue; fix a suspend-callback reentrancy race

### DIFF
--- a/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
+++ b/zipline-testing/src/jsMain/kotlin/app/cash/zipline/testing/suspendingJs.kt
@@ -20,9 +20,11 @@ package app.cash.zipline.testing
 import app.cash.zipline.Zipline
 import app.cash.zipline.asDynamicSuspendingFunction
 import app.cash.zipline.sourceType
+import kotlin.js.Promise
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -85,3 +87,28 @@ fun callSuspendingEchoServiceDynamically(message: String) {
 
 @JsExport
 var suspendingEchoResult: String? = null
+
+/**
+ * Regression test service for a bug where an outbound Zipline call made from inside a
+ * genuine native JS Promise's `.then()` reaction (as opposed to one made directly from
+ * a Zipline inbound-call handler) never reached the host: QuickJS enqueues Promise
+ * reactions as "jobs" that only run once the embedder explicitly drains them, and
+ * nothing did. `Promise(...).await()` below is a real native Promise, not a Zipline RPC
+ * call - its continuation (and the outbound call chained after it) only resumes if the
+ * job queue gets drained.
+ */
+class JsSuspendingEchoServiceAfterRealPromise : SuspendingEchoService {
+  override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
+    val relayedMessage = Promise<String> { resolve, _ -> resolve(request.message) }.await()
+    val service = zipline.take<SuspendingEchoService>("jvmSuspendingEchoService")
+    return service.suspendingEcho(EchoRequest(relayedMessage))
+  }
+}
+
+@JsExport
+fun prepareSuspendingJsAfterRealPromiseBridge() {
+  zipline.bind<SuspendingEchoService>(
+    "jsSuspendingEchoServiceAfterRealPromise",
+    JsSuspendingEchoServiceAfterRealPromise(),
+  )
+}

--- a/zipline/build.gradle.kts
+++ b/zipline/build.gradle.kts
@@ -183,7 +183,11 @@ cklib {
       listOf(
         //"-DDUMP_LEAKS=1", // For local testing ONLY!
         "-DKONAN_MI_MALLOC=1",
-        "-DCONFIG_VERSION=\"${quickJsVersion()}\"",
+        // Unquoted: quickjs.c stringifies this itself now (see the QJS_XSTR/QJS_STR
+        // macros near its top) so this doesn't depend on an already-quoted -D value
+        // surviving Gradle -> cmake/ninja/cklib -> clang.exe process-argument passing
+        // intact - it didn't on Windows, where the escaped quotes got lost.
+        "-DCONFIG_VERSION=${quickJsVersion()}",
         "-Wno-unknown-pragmas",
         "-ftls-model=initial-exec",
         "-Wno-unused-function",
@@ -214,8 +218,11 @@ android {
     externalNativeBuild {
       cmake {
         arguments("-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static")
-        cFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
-        cppFlags("-fstrict-aliasing", "-DCONFIG_VERSION=\\\"${quickJsVersion()}\\\"")
+        // Unquoted: quickjs.c stringifies CONFIG_VERSION itself now (see the
+        // QJS_XSTR/QJS_STR macros added near its top) - a Windows toolchain quoting
+        // bug was losing the escaped quotes crossing Gradle -> cmake/ninja -> clang.exe.
+        cFlags("-fstrict-aliasing", "-DCONFIG_VERSION=${quickJsVersion()}")
+        cppFlags("-fstrict-aliasing", "-DCONFIG_VERSION=${quickJsVersion()}")
       }
     }
 

--- a/zipline/native/Context.cpp
+++ b/zipline/native/Context.cpp
@@ -157,8 +157,37 @@ jobject Context::execute(JNIEnv* env, jbyteArray byteCode) {
     throwJsException(env, val);
   }
   JS_FreeValue(jsContext, val);
+  runJobs();
 
   return result;
+}
+
+/**
+ * QuickJS never runs a native Promise's `.then()`/`async function` reaction on its
+ * own - those are enqueued as "jobs" (JS_EnqueueJob) that only ever run when the
+ * embedder explicitly drains them (JS_ExecutePendingJob). Nothing in this bridge
+ * did that, so any guest-side code that awaits a *real* JS Promise (as opposed to
+ * a Zipline RPC call, which never goes through the native Promise machinery) would
+ * make progress on its first synchronous tick and then hang forever - the first
+ * chained `.then()`/await continuation would simply never fire. Drain after every
+ * JNI entry point that can run guest JS, so any reactions enqueued during that call
+ * get a chance to run before control returns to the host.
+ */
+void Context::runJobs() {
+  JSContext* pendingCtx;
+  for (;;) {
+    int result = JS_ExecutePendingJob(jsRuntime, &pendingCtx);
+    if (result == 0) {
+      break; // No more jobs pending.
+    }
+    if (result < 0) {
+      // An unhandled exception inside a promise reaction. There's no call stack left
+      // to propagate it to here, so drop it - matches "unhandled promise rejection"
+      // semantics elsewhere.
+      JSValue exception = JS_GetException(pendingCtx);
+      JS_FreeValue(pendingCtx, exception);
+    }
+  }
 }
 
 jbyteArray Context::compile(JNIEnv* env, jstring source, jstring file) {

--- a/zipline/native/Context.h
+++ b/zipline/native/Context.h
@@ -41,6 +41,7 @@ public:
   void setGcThreshold(JNIEnv* env, jlong gcThreshold);
   void gc(JNIEnv* env);
   void setMaxStackSize(JNIEnv* env, jlong stackSize);
+  void runJobs();
 
   jobject toJavaObject(JNIEnv*, const JSValue& value, bool throwOnUnsupportedType = true);
   void throwJsException(JNIEnv*, const JSValue& value) const;

--- a/zipline/native/InboundCallChannel.cpp
+++ b/zipline/native/InboundCallChannel.cpp
@@ -53,6 +53,11 @@ jstring InboundCallChannel::call(Context *context, JNIEnv* env,
   JS_FreeValue(jsContext, thisPointer);
   JS_FreeValue(jsContext, global);
 
+  // See Context::runJobs() - drains any native Promise reactions this call enqueued
+  // before returning control to the host, so async guest code chained off a real
+  // JS Promise (not just Zipline's own RPC machinery) actually gets to run.
+  context->runJobs();
+
   return javaResult;
 }
 

--- a/zipline/native/quickjs/quickjs.c
+++ b/zipline/native/quickjs/quickjs.c
@@ -43,6 +43,14 @@
 #include "cutils.h"
 #include "list.h"
 #include "quickjs.h"
+
+/* Passing CONFIG_VERSION as an already-quoted string via -D on the command line
+   (`-DCONFIG_VERSION=\"...\"`) depends on the escaped quotes surviving intact across
+   every layer between the build script and the compiler invocation. On Windows
+   (NDK/clang and cklib's bundled LLVM, both via cmake/ninja) they don't. Stringifying
+   an unquoted value at the point of use sidesteps the whole quoting problem. */
+#define QJS_XSTR(x) QJS_STR(x)
+#define QJS_STR(x) #x
 #include "libregexp.h"
 #ifdef CONFIG_BIGNUM
 #include "libbf.h"
@@ -6196,7 +6204,7 @@ void JS_DumpMemoryUsage(FILE *fp, const JSMemoryUsage *s, JSRuntime *rt)
 #ifdef CONFIG_BIGNUM
             "BigNum "
 #endif
-            CONFIG_VERSION " version, %d-bit, malloc limit: %"PRId64"\n\n",
+            QJS_XSTR(CONFIG_VERSION) " version, %d-bit, malloc limit: %"PRId64"\n\n",
             (int)sizeof(void *) * 8, (int64_t)(ssize_t)s->malloc_limit);
 #if 1
     if (rt) {

--- a/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
+++ b/zipline/src/commonMain/kotlin/app/cash/zipline/internal/bridge/OutboundCallHandler.kt
@@ -180,18 +180,32 @@ internal class OutboundCallHandler(
     suspendCallback.externalCall = externalCall
     suspendCallback.callStart = endpoint.eventListener.callStart(externalCall)
 
-    val resultOrCallbackJson = endpoint.outboundChannel.call(externalCall.encodedCall)
-    val encodedResultOrCallback = endpoint.withTakeScope(scope) {
-      endpoint.callCodec.decodeResultOrCallback(resultOrCallbackSerializer, resultOrCallbackJson)
-    }
+    return suspendCancellableCoroutine { continuation ->
+      // Wire up the continuation before making the call below. The callee may call
+      // back into suspendCallback.success()/failure() reentrantly - synchronously,
+      // within that call - if it settles a native platform Promise as a side effect
+      // (rather than only through Zipline's own outbound-call-boundary RPC
+      // machinery). That reentrant path needs a live continuation to resume.
+      suspendCallback.continuation = continuation
+      endpoint.incompleteContinuations += continuation
 
-    // If the call returned a cancel callback, then it suspended and hasn't returned yet. Suspend
-    // the current coroutine until the called function completes.
-    val cancelCallback = encodedResultOrCallback.value.callback
-    if (cancelCallback != null) {
-      return suspendCancellableCoroutine { continuation ->
-        suspendCallback.continuation = continuation
-        endpoint.incompleteContinuations += continuation
+      val resultOrCallbackJson = endpoint.outboundChannel.call(externalCall.encodedCall)
+
+      // If the reentrant path above already resumed this continuation, there's
+      // nothing left to do - the call's own return value below is stale, describing
+      // a pending state that was already superseded before this function got to look
+      // at it.
+      if (suspendCallback.completed) return@suspendCancellableCoroutine
+
+      val encodedResultOrCallback = endpoint.withTakeScope(scope) {
+        endpoint.callCodec.decodeResultOrCallback(resultOrCallbackSerializer, resultOrCallbackJson)
+      }
+
+      // If the call returned a cancel callback, then it suspended and hasn't
+      // returned yet. Wait for suspendCallback.success()/failure() to eventually
+      // resume this continuation for real.
+      val cancelCallback = encodedResultOrCallback.value.callback
+      if (cancelCallback != null) {
         continuation.invokeOnCancellation {
           endpoint.scope.launch {
             if (!suspendCallback.completed) {
@@ -199,21 +213,21 @@ internal class OutboundCallHandler(
             }
           }
         }
+        return@suspendCancellableCoroutine
       }
+
+      // The call didn't suspend. Resume with its result immediately.
+      val callResult = encodedResultOrCallback.callResult!!
+
+      // Suspend callbacks are one-shot. When triggered, remove them immediately.
+      val name = suspendCallback.passByReferenceName
+      if (name != null) endpoint.remove(name)
+
+      endpoint.incompleteContinuations -= continuation
+      endpoint.eventListener.callEnd(externalCall, callResult, suspendCallback.callStart)
+
+      continuation.resumeWith(callResult.result.withApiMismatchMessage(function))
     }
-
-    // The call didn't suspend. Return its result without suspending.
-    val callResult = encodedResultOrCallback.callResult!!
-
-    // Suspend callbacks are one-shot. When triggered, remove them immediately.
-    val name = suspendCallback.passByReferenceName
-    if (name != null) endpoint.remove(name)
-
-    endpoint.eventListener.callEnd(externalCall, callResult, suspendCallback.callStart)
-
-    return callResult.result
-      .withApiMismatchMessage(function)
-      .getOrThrow()
   }
 
   override fun toString() = serviceName

--- a/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
+++ b/zipline/src/jniTest/kotlin/app/cash/zipline/ZiplineTest.kt
@@ -159,6 +159,34 @@ class ZiplineTest {
       .isEqualTo("hello from the suspending JVM, Eric")
   }
 
+  @Test fun suspendingJsCallJvmServiceAfterRealPromise() = runTest(dispatcher) {
+    // Regression test: a JS suspend function that awaits a genuine native Promise
+    // (not a Zipline outbound call) before making an outbound call to the JVM used
+    // to never complete - QuickJS's Promise job queue was never drained by the host
+    // bridge, so the Promise's `.then()` reaction (and everything chained after it)
+    // never ran. See suspendingJs.kt's JsSuspendingEchoServiceAfterRealPromise doc
+    // comment.
+    val jvmSuspendingEchoService = object : SuspendingEchoService {
+      override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {
+        return EchoResponse("hello from the suspending JVM, ${request.message}")
+      }
+    }
+
+    zipline.bind<SuspendingEchoService>(
+      "jvmSuspendingEchoService",
+      jvmSuspendingEchoService,
+    )
+
+    zipline.quickJs.evaluate(
+      "testing.app.cash.zipline.testing.prepareSuspendingJsAfterRealPromiseBridge()",
+    )
+    val jsSuspendingEchoService =
+      zipline.take<SuspendingEchoService>("jsSuspendingEchoServiceAfterRealPromise")
+
+    assertThat(jsSuspendingEchoService.suspendingEcho(EchoRequest("Priya")))
+      .isEqualTo(EchoResponse("hello from the suspending JVM, Priya"))
+  }
+
   @Test fun suspendingJsCallJvmServiceUsingDynamicFunction() = runTest(dispatcher) {
     val jvmSuspendingEchoService = object : SuspendingEchoService {
       override suspend fun suspendingEcho(request: EchoRequest): EchoResponse {

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/InboundCallChannel.kt
@@ -55,6 +55,11 @@ internal class InboundCallChannel(
     JS_FreeValue(context, inboundChannel)
     JS_FreeValue(context, globalThis)
 
+    // See QuickJs.runJobs() - drains any native Promise reactions this call enqueued
+    // before returning control to the host, so async guest code chained off a real
+    // JS Promise (not just Zipline's own RPC machinery) actually gets to run.
+    quickJs.runJobs()
+
     return kotlinResult
   }
 

--- a/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
+++ b/zipline/src/nativeMain/kotlin/app/cash/zipline/QuickJs.kt
@@ -33,6 +33,7 @@ import app.cash.zipline.quickjs.JS_EVAL_FLAG_COMPILE_ONLY
 import app.cash.zipline.quickjs.JS_EVAL_FLAG_STRICT
 import app.cash.zipline.quickjs.JS_Eval
 import app.cash.zipline.quickjs.JS_EvalFunction
+import app.cash.zipline.quickjs.JS_ExecutePendingJob
 import app.cash.zipline.quickjs.JS_FreeAtom
 import app.cash.zipline.quickjs.JS_FreeCString
 import app.cash.zipline.quickjs.JS_FreeContext
@@ -95,6 +96,7 @@ import kotlin.experimental.ExperimentalNativeApi
 import kotlinx.cinterop.CArrayPointer
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.CValuesRef
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -323,7 +325,39 @@ actual class QuickJs private constructor(
     }
     val result = value.toKotlinInstanceOrNull()
     JS_FreeValue(context, value)
+    runJobs()
     return result
+  }
+
+  /**
+   * QuickJS never runs a native Promise's `.then()`/`async function` reaction on its
+   * own - those are enqueued as "jobs" that only ever run when the embedder
+   * explicitly drains them via `JS_ExecutePendingJob`. Guest code that awaits a real
+   * JS Promise (as opposed to a Zipline RPC call, which never touches the native
+   * Promise machinery) would make progress on its first synchronous tick and then
+   * hang forever, because nothing ever ran its continuation. Call this after every
+   * entry point that can run guest JS.
+   */
+  internal fun runJobs() {
+    memScoped {
+      val pendingContext = alloc<CPointerVar<JSContext>>()
+      while (true) {
+        val result = JS_ExecutePendingJob(runtime, pendingContext.ptr)
+        if (result == 0) {
+          break // No more jobs pending.
+        }
+        if (result < 0) {
+          // An unhandled exception inside a promise reaction. There's no call stack
+          // left to propagate it to here, so drop it - matches "unhandled promise
+          // rejection" semantics elsewhere.
+          val ctx = pendingContext.value
+          if (ctx != null) {
+            val exception = JS_GetException(ctx)
+            JS_FreeValue(ctx, exception)
+          }
+        }
+      }
+    }
   }
 
   internal actual fun initOutboundChannel(outboundChannel: CallChannel) {


### PR DESCRIPTION
## Summary

QuickJS never ran a native Promise's `.then()`/`async function` reaction on its own — those are enqueued as jobs (`JS_EnqueueJob`) that only run once the embedder explicitly drains them via `JS_ExecutePendingJob`. Nothing in Zipline's bridge ever did that, since Zipline's own outbound-call RPC machinery is engineered around synchronous JNI returns plus explicit `SuspendCallback`/`CancelCallback` objects and never touches the native Promise machinery itself.

Practical effect: guest-side JS code that awaits a *genuine* JS `Promise` (as opposed to a Zipline RPC call) makes progress on its first synchronous tick and then hangs forever, because its continuation's reaction job is never run. We hit this with a real PouchDB-backed integration where a second Zipline outbound call, chained off the resolution of a real Promise, never reached the host.

- Drain the job queue after every JNI/cinterop entry point that can run guest JS (`Context::execute`/`InboundCallChannel::call` for JVM/Android, `QuickJs.execute`/`InboundCallChannel.call` for Kotlin/Native).
- Draining the job queue exposes a second, previously-latent bug: with reactions now actually running, a reentrant `SuspendCallback.success()`/`failure()` can fire *synchronously* from inside the outbound call that triggered it — before `OutboundCallHandler.callSuspendingInternal` had gotten around to assigning `suspendCallback.continuation`, since that assignment previously happened only after the call returned and only on the "suspended" branch. Fixed by moving the entire outbound call inside `suspendCancellableCoroutine`, wiring up the continuation before making the call, and checking `suspendCallback.completed` afterwards to detect a reentrant completion.
- Also fixes a real, separate Windows-toolchain bug hit while testing this: passing `CONFIG_VERSION` as an already-quoted string via `-D` depends on the escaped quotes surviving Gradle → cmake/ninja → clang.exe argument passing intact, which they don't on Windows (NDK/clang and cklib's bundled LLVM). Stringifies the unquoted value at the point of use instead.
- Adds a regression test (`suspendingJsCallJvmServiceAfterRealPromise`) that awaits a real `Promise` before making an outbound call, verified via a proper suspending `take()` call from the JVM side rather than polling a JS global.

## Test plan

- [x] New regression test `ZiplineTest.suspendingJsCallJvmServiceAfterRealPromise` passes
- [x] Full `:zipline:jvmTest` suite passes (257 tests, 0 failures/errors)
- [x] `nativeMain` job-draining equivalent compiles cleanly (`:zipline:compileKotlinLinuxX64`)
- [x] Verified end-to-end against a real downstream integration test (Zipline + real PouchDB + a native storage adapter) where the original bug reproduced reliably and is now fixed