### PR TITLE
Fix manifest loads from network after using cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Nothing yet!
+* Fix: Listen for manifest url changes after local (cached/embedded) manifest loaded.
 
 ## [1.27.0] - 2026-04-02
 [1.27.0]: https://github.com/cashapp/zipline/releases/tag/1.27.0

--- a/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
+++ b/zipline-loader/src/commonMain/kotlin/app/cash/zipline/loader/ZiplineLoader.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.joinAll
@@ -252,13 +253,15 @@ class ZiplineLoader internal constructor(
         initializer,
       )
 
-      // If we successfully loaded local code, don't collect the remote code. We're done!
       if (localManifest != null) {
         previousManifest = localManifest
-        return@channelFlow
       }
 
-      manifestUrlFlow.collect { manifestUrl ->
+      manifestUrlFlow
+        // If we successfully loaded a local copy we can skip a network load, but we still want to react to changes in
+        // the target url.
+        .drop(if (localManifest != null) 1 else 0)
+        .collect { manifestUrl ->
         val loadedFromNetwork = loadFromNetwork(
           previousManifest,
           nowEpochMs(),

--- a/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
+++ b/zipline-loader/src/commonTest/kotlin/app/cash/zipline/loader/ZiplineLoaderTest.kt
@@ -37,6 +37,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -436,6 +437,50 @@ class ZiplineLoaderTest {
       zipline.getLog(),
     )
     zipline.close()
+  }
+
+  @Test
+  fun loadsManifestFromCacheAndThenFromUrlWhenUrlChanged() = runBlocking {
+    tester.seedEmbedded("test", "test", freshAtEpochMs = 100L)
+
+    val urlFlow = MutableSharedFlow<String>(replay = 1).apply { emit(MANIFEST_URL) }
+
+    loader.load(
+      applicationName = "test",
+      freshnessChecker = FakeFreshnessCheckerFresh,
+      manifestUrlFlow = urlFlow,
+    ).test {
+      val cachedZipline = (awaitItem() as LoadResult.Success).zipline
+      assertEquals(
+        cachedZipline.getLog(),
+        """
+        |test loaded
+        |
+        """.trimMargin(),
+      )
+      cachedZipline.close()
+
+      httpClient.filePathToByteString = mapOf(
+        MANIFEST_URL to testFixtures.manifestNoBaseUrlByteString,
+        ALPHA_URL to testFixtures.alphaByteString,
+        BRAVO_URL to testFixtures.bravoByteString,
+      )
+
+      // Re-emit URL to trigger a new load
+      urlFlow.emit(MANIFEST_URL)
+
+      val networkZipline = (awaitItem() as LoadResult.Success).zipline
+      assertEquals(
+        networkZipline.getLog(),
+        """
+        |alpha loaded
+        |bravo loaded
+        |
+        """.trimMargin(),
+      )
+
+      networkZipline.close()
+    }
   }
 
   @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") // Access :zipline-loader internals.


### PR DESCRIPTION
Once a local copy of an app is loaded, all changes to the `manifestUrlFlow` are dropped. This made it impossible to trigger a re-load of the app in response to a url change. This changes the behaviour to skip a network load if a local copy was loaded, but to continue listening for changes to the url flow.