### PR TITLE
Fix StackOverflowError for services that return their own type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Fix: Listen for manifest url changes after local (cached/embedded) manifest loaded.
+* Fix: Don't crash the Kotlin compiler plugin with a `StackOverflowError` when a `ZiplineService`
+  function returns its own service type, or when two services return each other.
 * Upgrade [Kotlin 2.4.20-Beta2](https://github.com/JetBrains/kotlin/releases/tag/v2.4.20-Beta2)
 
 ## [1.27.0] - 2026-04-02

--- a/zipline-kotlin-plugin-tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
+++ b/zipline-kotlin-plugin-tests/src/test/kotlin/app/cash/zipline/kotlin/ZiplineKotlinPluginTest.kt
@@ -416,6 +416,53 @@ class ZiplineKotlinPluginTest {
     )
     assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
   }
+
+  @Test
+  fun `service function returns its own type`() {
+    val result = compile(
+      sourceFile = SourceFile.kotlin(
+        "main.kt",
+        """
+        package app.cash.zipline.testing
+
+        import app.cash.zipline.ZiplineService
+
+        interface RecursiveService : ZiplineService {
+          fun next(name: String): RecursiveService
+          suspend fun suspendingNext(name: String): RecursiveService
+        }
+
+        interface GenericRecursiveService<T> : ZiplineService {
+          fun next(value: T): GenericRecursiveService<T>
+        }
+        """,
+      ),
+    )
+    assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+  }
+
+  @Test
+  fun `services return each other`() {
+    val result = compile(
+      sourceFile = SourceFile.kotlin(
+        "main.kt",
+        """
+        package app.cash.zipline.testing
+
+        import app.cash.zipline.ZiplineService
+
+        interface PingService : ZiplineService {
+          fun ping(): PongService
+        }
+
+        interface PongService : ZiplineService {
+          fun pong(): PingService
+        }
+        """,
+      ),
+    )
+    assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+  }
 }
 
 @ExperimentalCompilerApi

--- a/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
+++ b/zipline-kotlin-plugin/src/main/kotlin/app/cash/zipline/kotlin/AdapterGenerator.kt
@@ -287,6 +287,11 @@ internal class AdapterGenerator(
       }
     }
 
+    // Register the adapter before generating its members. A function that returns this service
+    // type (directly, or through another service) looks this adapter up again while its
+    // serializers are generated, and that lookup must not start building a second adapter.
+    companion.declarations += adapterClass
+
     val serialNameProperty = irSerialNameProperty(adapterClass, constructor)
     adapterClass.declarations += serialNameProperty
 
@@ -335,7 +340,6 @@ internal class AdapterGenerator(
       ),
     )
 
-    companion.declarations += adapterClass
     companion.patchDeclarationParents(original)
     return adapterClass
   }

--- a/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
+++ b/zipline/src/hostTest/kotlin/app/cash/zipline/ZiplineServiceTest.kt
@@ -150,12 +150,33 @@ internal class ZiplineServiceTest {
     factoryClient.create(null)
   }
 
+  @Test
+  fun serviceReturnsItsOwnType() = runBlocking(Unconfined) {
+    val (endpointA, endpointB) = newEndpointPair(this)
+
+    endpointA.bind<PathService>("root", RealPathService("root"))
+    val rootClient = endpointB.take<PathService>("root")
+
+    val childClient = rootClient.child("a").child("b")
+    assertEquals("root/a/b", childClient.path())
+  }
+
   interface ContextualNullableParameter : ZiplineService {
     fun create(string: @Contextual String?)
   }
 
   class RealContextualNullableParameter : ContextualNullableParameter {
     override fun create(string: String?) = Unit
+  }
+
+  interface PathService : ZiplineService {
+    fun child(name: String): PathService
+    fun path(): String
+  }
+
+  class RealPathService(private val path: String) : PathService {
+    override fun child(name: String): PathService = RealPathService("$path/$name")
+    override fun path(): String = path
   }
 
   interface EchoServiceFactory : ZiplineService {


### PR DESCRIPTION
Closes #1838.

`getOrCreateAdapterClass` only added the generated `Adapter` to the companion after all of its members were built. Building `ziplineFunctions` resolves a serializer for each return type, and a `ZiplineService` return type goes back through `AdapterGenerator` for the same class. The adapter wasn't registered yet, so it started building another one, and so on until the stack ran out.

This registers the adapter right after its constructor is created, so the re-entrant lookup finds it. Services that return each other (`PingService` returns `PongService` and vice versa) hit the same path and are covered too.

Tests:
- plugin: a service returning itself (regular, `suspend`, and generic), and two services returning each other
- runtime: `ZiplineServiceTest.serviceReturnsItsOwnType` calls through a returned service

On trunk both plugin tests fail with the `StackOverflowError`, and `ZiplineServiceTest` doesn't compile (same crash, since zipline's own tests run through the plugin). With the fix, `:zipline-kotlin-plugin-tests:test` and `:zipline:jvmTest` pass locally.
